### PR TITLE
[CF-129] Make the java client act like VMC when uploading apps, and so be more broadly compatible.

### DIFF
--- a/cloudfoundry-client-lib/src/main/java/org/cloudfoundry/client/lib/rest/CloudControllerClientV1.java
+++ b/cloudfoundry-client-lib/src/main/java/org/cloudfoundry/client/lib/rest/CloudControllerClientV1.java
@@ -309,9 +309,8 @@ public class CloudControllerClientV1 extends AbstractCloudControllerClient {
 		try {
 			getRestTemplate().postForLocation(url, entity, appName);
 		} catch (HttpServerErrorException hsee) {
-			if (HttpStatus.INTERNAL_SERVER_ERROR.equals(hsee.getStatusCode()) || HttpStatus.UNSUPPORTED_MEDIA_TYPE.equals(hsee.getStatusCode())) {
+			if (HttpStatus.INTERNAL_SERVER_ERROR.equals(hsee.getStatusCode())) {
 				// this is for supporting legacy Micro Cloud Foundry 1.1 and older
-        System.out.println("Hmm... Appfog?  Retrying with the legacy version!");
 				uploadAppUsingLegacyApi(url, entity, appName);
 			} else {
 				throw hsee;


### PR DESCRIPTION
Accept headers to be compatible with varnish and other things that appear to have been put in front of the appfog controller, otherwise a HTTP 415 is issued.

Use the POST/ _method=put  mechanism that vmc uses to be compatible with that tool.
Appfog appear to have given up on native PUT support and totally disabled it (now getting a 405)

With these updates, can deploy to appfogs CF, along with micro cf and cloudfoundry.com
