### PR TITLE
fixing a typo in maven plugin

### DIFF
--- a/cloudfoundry-maven-plugin/src/main/java/org/cloudfoundry/maven/AbstractCloudFoundryMojo.java
+++ b/cloudfoundry-maven-plugin/src/main/java/org/cloudfoundry/maven/AbstractCloudFoundryMojo.java
@@ -417,7 +417,7 @@ public abstract class AbstractCloudFoundryMojo extends AbstractMojo {
 				return authenticationInfo.getPassword();
 			} else {
 				getLog().debug(String.format(
-						"In settings.xml no passwword was found for server element '%s'. Does the element exist?", this.getServer()));
+						"In settings.xml no password was found for server element '%s'. Does the element exist?", this.getServer()));
 				return null;
 			}
 


### PR DESCRIPTION
I have fixed a typo in the maven plugin's warning message in case the password setting is missing.
