### PR TITLE
It would be nice if push and update didn't force the execution of "package"

### DIFF
--- a/cloudfoundry-maven-plugin/src/main/java/org/cloudfoundry/maven/Push.java
+++ b/cloudfoundry-maven-plugin/src/main/java/org/cloudfoundry/maven/Push.java
@@ -47,8 +47,6 @@ import org.springframework.http.HttpStatus;
  *
  * @goal push
  *
- * @execute phase="package"
- *
  */
 public class Push extends AbstractApplicationAwareCloudFoundryMojo {
 

--- a/cloudfoundry-maven-plugin/src/main/java/org/cloudfoundry/maven/Update.java
+++ b/cloudfoundry-maven-plugin/src/main/java/org/cloudfoundry/maven/Update.java
@@ -32,7 +32,6 @@ import org.cloudfoundry.maven.common.CommonUtils;
  * @since 1.0.0
  *
  * @goal update
- * @execute phase="package"
  */
 public class Update extends AbstractApplicationAwareCloudFoundryMojo {
 


### PR DESCRIPTION
I like to execute this plugin standalone and we also sometimes employ a custom maven lifecycle for some of our builds.  I would prefer it if when I executed push or update on this plugin it didn't assume I wanted to also execute "package" on the default lifecycle.

If always executing "package" is a must for these goals then another option is to provide alternative goals that don't execute "package".  I could submit a PR that does that instead if requested.
