### PR TITLE
Changes to start application method to support response headers

### DIFF
--- a/cloudfoundry-client-lib/src/main/java/org/cloudfoundry/client/lib/CloudFoundryClient.java
+++ b/cloudfoundry-client-lib/src/main/java/org/cloudfoundry/client/lib/CloudFoundryClient.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2009-2012 the original author or authors.
+ * Copyright 2009-2013 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -215,8 +215,8 @@ public class CloudFoundryClient implements CloudFoundryOperations {
     }
 
 
-	public void startApplication(String appName) {
-		cc.startApplication(appName);
+	public StartingInfo startApplication(String appName) {
+		return cc.startApplication(appName);
 	}
 
 	public void debugApplication(String appName, DebugMode mode) {

--- a/cloudfoundry-client-lib/src/main/java/org/cloudfoundry/client/lib/CloudFoundryOperations.java
+++ b/cloudfoundry-client-lib/src/main/java/org/cloudfoundry/client/lib/CloudFoundryOperations.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2009-2012 the original author or authors.
+ * Copyright 2009-2013 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -287,11 +287,14 @@ public interface CloudFoundryOperations {
 	void uploadApplication(String appName, ApplicationArchive archive, UploadStatusCallback callback) throws IOException;
 
 	/**
-	 * Start appplication.
-	 *
-	 * @param appName name of application
+	 * Start application. May return starting info if the response obtained after the start request contains headers. 
+	 * If the response does not contain headers, null is returned instead.
+	 * 
+	 * @param appName
+	 *            name of application
+	 * @return Starting info containing response headers, if headers are present in the response. If there are no headers, return null.
 	 */
-	void startApplication(String appName);
+	StartingInfo startApplication(String appName);
 
 	/**
 	 * Debug application.
@@ -302,7 +305,7 @@ public interface CloudFoundryOperations {
 	void debugApplication(String appName, CloudApplication.DebugMode mode);
 
 	/**
-	 * Stop applicataion.
+	 * Stop application.
 	 *
 	 * @param appName name of application
 	 */

--- a/cloudfoundry-client-lib/src/main/java/org/cloudfoundry/client/lib/StartingInfo.java
+++ b/cloudfoundry-client-lib/src/main/java/org/cloudfoundry/client/lib/StartingInfo.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2013 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.cloudfoundry.client.lib;
+
+/**
+ * Starting info contains values from response headers when an application is
+ * first started. One of the possible header values may be the location of the
+ * staging log when starting an application.
+ * 
+ * @author Nieraj Singh.
+ * 
+ */
+public class StartingInfo {
+
+	private final String stagingFile;
+
+	public StartingInfo(String stagingFile) {
+		this.stagingFile = stagingFile;
+	}
+
+	/**
+	 * 
+	 * @return URL value of the file location for the staging log, or null if not available.
+	 */
+	public String getStagingFile() {
+		return stagingFile;
+	}
+
+}

--- a/cloudfoundry-client-lib/src/main/java/org/cloudfoundry/client/lib/rest/CloudControllerClient.java
+++ b/cloudfoundry-client-lib/src/main/java/org/cloudfoundry/client/lib/rest/CloudControllerClient.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2009-2012 the original author or authors.
+ * Copyright 2009-2013 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -19,6 +19,7 @@ package org.cloudfoundry.client.lib.rest;
 import org.cloudfoundry.client.lib.CloudCredentials;
 import org.cloudfoundry.client.lib.HttpProxyConfiguration;
 import org.cloudfoundry.client.lib.RestLogCallback;
+import org.cloudfoundry.client.lib.StartingInfo;
 import org.cloudfoundry.client.lib.UploadStatusCallback;
 import org.cloudfoundry.client.lib.archive.ApplicationArchive;
 import org.cloudfoundry.client.lib.domain.ApplicationStats;
@@ -106,7 +107,7 @@ public interface CloudControllerClient {
 
 	void uploadApplication(String appName, ApplicationArchive archive, UploadStatusCallback callback) throws IOException;
 
-	void startApplication(String appName);
+	StartingInfo startApplication(String appName);
 
 	void debugApplication(String appName, CloudApplication.DebugMode mode);
 

--- a/cloudfoundry-client-lib/src/main/java/org/cloudfoundry/client/lib/rest/CloudControllerClientV1.java
+++ b/cloudfoundry-client-lib/src/main/java/org/cloudfoundry/client/lib/rest/CloudControllerClientV1.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2009-2012 the original author or authors.
+ * Copyright 2009-2013 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -38,6 +38,7 @@ import org.cloudfoundry.client.lib.domain.InstancesInfo;
 import org.cloudfoundry.client.lib.domain.ServiceConfiguration;
 import org.cloudfoundry.client.lib.domain.Staging;
 import org.cloudfoundry.client.lib.domain.UploadApplicationPayload;
+import org.cloudfoundry.client.lib.StartingInfo;
 import org.codehaus.jackson.map.ObjectMapper;
 import org.springframework.http.HttpEntity;
 import org.springframework.http.HttpHeaders;
@@ -335,11 +336,12 @@ public class CloudControllerClientV1 extends AbstractCloudControllerClient {
 		}
 	}
 
-	public void startApplication(String appName) {
+	public StartingInfo startApplication(String appName) {
 		CloudApplication app = getApplication(appName);
 		app.setState(CloudApplication.AppState.STARTED);
 		app.setDebug(null);
 		doUpdateApplication(app);
+		return null;
 	}
 
 	public void debugApplication(String appName, CloudApplication.DebugMode mode) {

--- a/cloudfoundry-client-lib/src/test/java/org/cloudfoundry/client/lib/AbstractCloudFoundryClientTest.java
+++ b/cloudfoundry-client-lib/src/test/java/org/cloudfoundry/client/lib/AbstractCloudFoundryClientTest.java
@@ -1024,16 +1024,16 @@ public abstract class AbstractCloudFoundryClientTest {
 	}
 
 	//
-	// Private helper methods
+	// helper methods
 	//
 
-	private String createSpringTravelApp(String suffix, List<String> serviceNames) {
+	protected String createSpringTravelApp(String suffix, List<String> serviceNames) {
 		String appName = namespacedAppName("travel_test-" + suffix);
 		createSpringApplication(appName, serviceNames);
 		return appName;
 	}
 
-	private CloudApplication uploadSpringTravelApp(String appName) throws IOException {
+	protected CloudApplication uploadSpringTravelApp(String appName) throws IOException {
 		File file = SampleProjects.springTravel();
 		getConnectedClient().uploadApplication(appName, file.getCanonicalPath());
 		return getConnectedClient().getApplication(appName);

--- a/cloudfoundry-client-lib/src/test/java/org/cloudfoundry/client/lib/CloudFoundryClientV2Test.java
+++ b/cloudfoundry-client-lib/src/test/java/org/cloudfoundry/client/lib/CloudFoundryClientV2Test.java
@@ -121,6 +121,17 @@ public class CloudFoundryClientV2Test extends AbstractCloudFoundryClientTest {
 		List<CloudSpace> spaces = authenticatedClient.getSpaces();
 		assertNotNull(spaces);
 		assertTrue(spaces.size() > 0);
+	}	
+	
+	@Test
+	public void startApplicationWithInfo() throws IOException {
+		String appName = createSpringTravelApp("start", null);
+		uploadSpringTravelApp(appName);
+		StartingInfo info = getConnectedClient().startApplication(appName);
+		CloudApplication app = getConnectedClient().getApplication(appName);
+		assertEquals(CloudApplication.AppState.STARTED, app.getState());
+		assertNotNull(info);
+		assertNotNull(info.getStagingFile());
 	}
 
 	@Test


### PR DESCRIPTION
request is made. The data from the response headers are then returned in
a StartingInfo object. Among the data that is retrieved from the
response headers is the location of the staging log file. Added unit
test case to test the start application that returns a starting
information with the location of the staging log file.
