### PR TITLE
Adding buildpack support + ability to run test from an HTTP proxy

### DIFF
--- a/cloudfoundry-client-lib/src/main/java/org/cloudfoundry/client/lib/CloudFoundryClient.java
+++ b/cloudfoundry-client-lib/src/main/java/org/cloudfoundry/client/lib/CloudFoundryClient.java
@@ -169,14 +169,23 @@ public class CloudFoundryClient implements CloudFoundryOperations {
 		cc.createApplication(appName, staging, memory, uris, serviceNames, checkExists);
 	}
 
-	public void createApplication(String appName, Staging staging, int memory, List<String> uris,
-								  List<String> serviceNames, String applicationPlan) {
-		cc.createApplication(appName, staging, memory, uris, serviceNames, applicationPlan, false);
+    public void createApplication(String appName, Staging staging, int memory, List<String> uris,
+                                  List<String> serviceNames, String applicationPlan) {
+        cc.createApplication(appName, staging, memory, uris, serviceNames, applicationPlan, false, null);
+    }
+
+    public void createApplication(String appName, Staging staging, int memory, List<String> uris,
+                                  List<String> serviceNames, String applicationPlan, String buildpackUrl) {
+		cc.createApplication(appName, staging, memory, uris, serviceNames, applicationPlan, false, buildpackUrl);
 	}
 
 	public void createApplication(String appName, Staging staging, int memory, List<String> uris,
-								  List<String> serviceNames, String applicationPlan, boolean checkExists) {
-		cc.createApplication(appName, staging, memory, uris, serviceNames, applicationPlan, checkExists);
+                                  List<String> serviceNames, String applicationPlan, boolean checkExists) {
+		cc.createApplication(appName, staging, memory, uris, serviceNames, applicationPlan, checkExists, null);
+	}
+	public void createApplication(String appName, Staging staging, int memory, List<String> uris,
+                                  List<String> serviceNames, String applicationPlan, boolean checkExists, String buildpackUrl) {
+		cc.createApplication(appName, staging, memory, uris, serviceNames, applicationPlan, checkExists, buildpackUrl);
 	}
 
 	public void createApplication(String appName, String framework, int memory, List<String> uris,

--- a/cloudfoundry-client-lib/src/main/java/org/cloudfoundry/client/lib/CloudFoundryOperations.java
+++ b/cloudfoundry-client-lib/src/main/java/org/cloudfoundry/client/lib/CloudFoundryOperations.java
@@ -168,9 +168,23 @@ public interface CloudFoundryOperations {
 	 * @param uris list of URIs for the app
 	 * @param serviceNames list of service names to bind to app
 	 * @param applicationPlan the application plan for the deployed app
+     * @param buildpackUrl a custom buildpack url (e.g. https://github.com/cloudfoundry/java-buildpack.git) or null to use the default one
 	 */
 	void createApplication(String appName, Staging staging, int memory, List<String> uris,
-						   List<String> serviceNames, String applicationPlan);
+                           List<String> serviceNames, String applicationPlan, String buildpackUrl);
+
+	/**
+	 * Create application.
+	 *
+	 * @param appName application name
+	 * @param staging staging info
+	 * @param memory memory to use in MB
+	 * @param uris list of URIs for the app
+	 * @param serviceNames list of service names to bind to app
+	 * @param applicationPlan the application plan for the deployed app
+	 */
+	void createApplication(String appName, Staging staging, int memory, List<String> uris,
+                           List<String> serviceNames, String applicationPlan);
 
 	/**
 	 * Create application.
@@ -210,6 +224,21 @@ public interface CloudFoundryOperations {
 	 */
 	void createApplication(String appName, Staging staging, int memory, List<String> uris,
 						   List<String> serviceNames, String applicationPlan, boolean checkExists);
+
+	/**
+	 * Create application.
+	 *
+	 * @param appName application name
+	 * @param staging staging info
+	 * @param memory memory to use in MB
+	 * @param uris list of URIs for the app
+	 * @param serviceNames list of service names to bind to app
+	 * @param applicationPlan the application plan for the deployed app
+	 * @param checkExists check if app exists before creating it
+     * @param buildpackUrl a custom buildpack url (e.g. "https://github.com/cloudfoundry/java-buildpack.git") or null to use the default one
+	 */
+	void createApplication(String appName, Staging staging, int memory, List<String> uris,
+                           List<String> serviceNames, String applicationPlan, boolean checkExists, String buildpackUrl);
 
 	/**
 	 * Create application.
@@ -287,9 +316,9 @@ public interface CloudFoundryOperations {
 	void uploadApplication(String appName, ApplicationArchive archive, UploadStatusCallback callback) throws IOException;
 
 	/**
-	 * Start application. May return starting info if the response obtained after the start request contains headers. 
+	 * Start application. May return starting info if the response obtained after the start request contains headers.
 	 * If the response does not contain headers, null is returned instead.
-	 * 
+	 *
 	 * @param appName
 	 *            name of application
 	 * @return Starting info containing response headers, if headers are present in the response. If there are no headers, return null.

--- a/cloudfoundry-client-lib/src/main/java/org/cloudfoundry/client/lib/domain/CloudApplication.java
+++ b/cloudfoundry-client-lib/src/main/java/org/cloudfoundry/client/lib/domain/CloudApplication.java
@@ -52,8 +52,9 @@ public class CloudApplication extends CloudEntity {
 	private Map<String, Integer> resources = new HashMap<String, Integer>();
 	private int runningInstances;
 	private List<String> env = new ArrayList<String>();
+    private String buildpackUrl;
 
-	// Constructor for V2 entities
+    // Constructor for V2 entities
 	public CloudApplication(Meta meta, String name) {
 		super(meta, name);
 	}
@@ -115,6 +116,14 @@ public class CloudApplication extends CloudEntity {
 				setCommand((String) metaValue.get(COMMAND_KEY));
 			}
 		}
+	}
+
+    public String getBuildpackUrl() {
+        return buildpackUrl;
+    }
+
+    public void setBuildpackUrl(String buildpackUrl) {
+        this.buildpackUrl = buildpackUrl;
 	}
 
 	public enum AppState {

--- a/cloudfoundry-client-lib/src/main/java/org/cloudfoundry/client/lib/rest/CloudControllerClient.java
+++ b/cloudfoundry-client-lib/src/main/java/org/cloudfoundry/client/lib/rest/CloudControllerClient.java
@@ -101,7 +101,7 @@ public interface CloudControllerClient {
 									  List<String> serviceNames, boolean checkExists);
 
 	void createApplication(String appName, Staging staging, int memory, List<String> uris,
-									  List<String> serviceNames, String applicationPlan, boolean checkExists);
+                           List<String> serviceNames, String applicationPlan, boolean checkExists, String buildpackUrl);
 
 	void uploadApplication(String appName, File file, UploadStatusCallback callback) throws IOException;
 

--- a/cloudfoundry-client-lib/src/main/java/org/cloudfoundry/client/lib/rest/CloudControllerClientV1.java
+++ b/cloudfoundry-client-lib/src/main/java/org/cloudfoundry/client/lib/rest/CloudControllerClientV1.java
@@ -263,11 +263,12 @@ public class CloudControllerClientV1 extends AbstractCloudControllerClient {
 
 	public void createApplication(String appName, Staging staging, int memory, List<String> uris,
 								  List<String> serviceNames, boolean checkExists) {
-		createApplication(appName, staging, memory, uris, serviceNames, null, checkExists);
+        String buildpackUrl = null; //V1 clients use the default buildpack to preserve api compatibility
+        createApplication(appName, staging, memory, uris, serviceNames, null, checkExists, buildpackUrl);
 	}
 
 	public void createApplication(String appName, Staging staging, int memory, List<String> uris,
-								  List<String> serviceNames, String applicationPlan, boolean checkExists) {
+                                  List<String> serviceNames, String applicationPlan, boolean checkExists, String buildpackUrl) {
 		if (checkExists) {
 			try {
 				getApplication(appName);

--- a/cloudfoundry-client-lib/src/main/java/org/cloudfoundry/client/lib/rest/CloudControllerClientV2.java
+++ b/cloudfoundry-client-lib/src/main/java/org/cloudfoundry/client/lib/rest/CloudControllerClientV2.java
@@ -359,11 +359,11 @@ public class CloudControllerClientV2 extends AbstractCloudControllerClient {
 
 	public void createApplication(String appName, Staging staging, int memory, List<String> uris,
 								  List<String> serviceNames, boolean checkExists) {
-		createApplication(appName, staging, memory, uris, serviceNames, null, checkExists);
+		createApplication(appName, staging, memory, uris, serviceNames, null, checkExists, null);
 	}
 
 	public void createApplication(String appName, Staging staging, int memory, List<String> uris,
-								  List<String> serviceNames, String applicationPlan, boolean checkExists) {
+                                  List<String> serviceNames, String applicationPlan, boolean checkExists, String buildpackUrl) {
 		if (checkExists) {
 			try {
 				getAppId(appName);
@@ -379,6 +379,9 @@ public class CloudControllerClientV2 extends AbstractCloudControllerClient {
 		appRequest.put("space_guid", sessionSpace.getMeta().getGuid());
 		appRequest.put("name", appName);
 		appRequest.put("memory", memory);
+        if (buildpackUrl != null) {
+		    appRequest.put("buildpack", buildpackUrl);
+        }
 		appRequest.put("instances", 1);
 		if (staging.getCommand() != null) {
 			appRequest.put("command", staging.getCommand());
@@ -637,9 +640,9 @@ public class CloudControllerClientV2 extends AbstractCloudControllerClient {
 			ResponseEntity<String> entity = getRestTemplate().exchange(
 					getUrl("/v2/apps/{guid}?stage_async=true"), HttpMethod.PUT, requestEntity,
 					String.class, app.getMeta().getGuid());
-		
+
 			HttpHeaders headers = entity.getHeaders();
-			
+
 			// Return a starting info, even with a null staging log value, as a non-null starting info
 			// indicates that the response entity did have headers. The API contract is to return starting info
 			// if there are headers in the response, null otherwise.
@@ -1163,24 +1166,24 @@ public class CloudControllerClientV2 extends AbstractCloudControllerClient {
 			return;
 		}
 		Map<String, Object> entity = (Map<String, Object>) resource.get("entity");
-		
-		
+
+
 		String headKey = resourcePath[0];
 		String[] tailPath = Arrays.copyOfRange(resourcePath, 1, resourcePath.length);
-		
+
 		if (!entity.containsKey(headKey)) {
 			String pathUrl = entity.get(headKey + "_url").toString();
 			Object response = getRestTemplate().getForObject(getUrl(pathUrl), Object.class);
 			if (resource instanceof Map) {
 				Map responseMap = (Map)response;
 				if (responseMap.containsKey("resources")) {
-					response = responseMap.get("resources"); 
+					response = responseMap.get("resources");
 				}
 			}
 			entity.put(headKey, response);
 		}
 		Object embeddedResource = entity.get(headKey);
-		
+
 		if (embeddedResource instanceof Map) {
 			Map<String, Object> embeddedResourceMap = (Map<String, Object>) embeddedResource;
 			//entity = (Map<String, Object>) embeddedResourceMap.get("entity");

--- a/cloudfoundry-client-lib/src/main/java/org/cloudfoundry/client/lib/util/CloudEntityResourceMapper.java
+++ b/cloudfoundry-client-lib/src/main/java/org/cloudfoundry/client/lib/util/CloudEntityResourceMapper.java
@@ -138,6 +138,10 @@ public class CloudEntityResourceMapper {
 		} else {
 			app.setPlan("free");
 		}
+        String buildpack = getEntityAttribute(resource, "buildpack", String.class);
+        if (buildpack != null) {
+            app.setBuildpackUrl(buildpack);
+        }
 		app.setDebug(null);
 		String runtime = null;
 		Map<String, Object> runtimeResource = getEmbeddedResource(resource, "runtime");


### PR DESCRIPTION
See https://github.com/cloudfoundry/vcap-java-client/issues/42

Preserving compatibility with existing clients by adding new methods in CloudFoundryClient and CloudFoundryOperations.
Added accessor for buildpack in application.
