### PR TITLE
Adding support for fetching staging logs

### DIFF
--- a/cloudfoundry-client-lib/src/main/java/org/cloudfoundry/client/lib/CloudFoundryClient.java
+++ b/cloudfoundry-client-lib/src/main/java/org/cloudfoundry/client/lib/CloudFoundryClient.java
@@ -398,4 +398,8 @@ public class CloudFoundryClient implements CloudFoundryOperations {
 		cc.unRegisterRestLogListener(callBack);
 	}
 
+    public List<String> getStagingLogs(StartingInfo startingInfo) {
+        return cc.getStagingLogs(startingInfo);
+    }
+
 }

--- a/cloudfoundry-client-lib/src/main/java/org/cloudfoundry/client/lib/CloudFoundryOperations.java
+++ b/cloudfoundry-client-lib/src/main/java/org/cloudfoundry/client/lib/CloudFoundryOperations.java
@@ -644,4 +644,12 @@ public interface CloudFoundryOperations {
 	 * @param callBack the callback to be un-registered
 	 */
 	void unRegisterRestLogListener(RestLogCallback callBack);
+
+    /**
+     * Provides staging logs. At times, this method may take times (up to minutes) to return as staging logs are
+     * streamed as they arrive from CC
+     * @param startingInfo The pointer to logs returned by {@link #startApplication(String)}
+     * @return a possibly empty list of logs containing staging logs
+     */
+    List<String> getStagingLogs(StartingInfo startingInfo);
 }

--- a/cloudfoundry-client-lib/src/main/java/org/cloudfoundry/client/lib/rest/CloudControllerClient.java
+++ b/cloudfoundry-client-lib/src/main/java/org/cloudfoundry/client/lib/rest/CloudControllerClient.java
@@ -176,4 +176,6 @@ public interface CloudControllerClient {
 	void registerRestLogListener(RestLogCallback callBack);
 
 	void unRegisterRestLogListener(RestLogCallback callBack);
+
+    List<String> getStagingLogs(StartingInfo startingInfo);
 }

--- a/cloudfoundry-client-lib/src/test/java/org/cloudfoundry/client/lib/AbstractCloudFoundryClientTest.java
+++ b/cloudfoundry-client-lib/src/test/java/org/cloudfoundry/client/lib/AbstractCloudFoundryClientTest.java
@@ -30,7 +30,6 @@ import java.io.IOException;
 import java.net.MalformedURLException;
 import java.net.URL;
 import java.util.ArrayList;
-import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -870,7 +869,25 @@ public abstract class AbstractCloudFoundryClientTest {
 		}
 	}
 
-	@Test
+    @Test
+    public void getStagingLogs() throws Exception {
+        String appName = createSpringTravelApp("stagingLogs", null, "https://github.com/cloudfoundry/java-buildpack.git");
+
+        File file = SampleProjects.springTravel();
+        getConnectedClient().uploadApplication(appName, file.getCanonicalPath());
+
+        StartingInfo startingInfo = getConnectedClient().startApplication(appName);
+
+        List<String> logs = getConnectedClient().getStagingLogs(startingInfo);
+
+        assertNotNull(logs);
+        assertTrue(logs.size() > 0);
+        for (int i=0; i< logs.size(); i++) {
+            assertNotNull(" log #" + i, logs.get(i));
+        }
+    }
+
+    @Test
 	@Ignore("Ignore until the Java buildpack detects app crashes upon OOM correctly")
 	public void getCrashLogs() throws Exception {
 		String appName = namespacedAppName("simple_crashlogs");


### PR DESCRIPTION
Adding ability to fetch staging logs which is especially important when using a custom buildpack.

Details on the changes:
Since CC streams them using keep-alive, and some logs may time long time to be obtained, to avoid socket read timeouts, the read timeout is increased to 5 mins for staging logs.
Attempts are made to follow the offset if ever staging logs would be large and chunked by CC. Might create parasite 404 warn traces.
