### PR TITLE
Make org optional when connecting since it can be derived from the space.

### DIFF
--- a/cloudfoundry-client-lib/src/main/java/org/cloudfoundry/client/lib/rest/CloudControllerClientImpl.java
+++ b/cloudfoundry-client-lib/src/main/java/org/cloudfoundry/client/lib/rest/CloudControllerClientImpl.java
@@ -154,9 +154,11 @@ public class CloudControllerClientImpl implements CloudControllerClient {
 		initialize(cloudControllerUrl, restUtil, cloudCredentials, authorizationEndpoint, null, httpProxyConfiguration);
 		List<CloudSpace> spaces = tempClient.getSpaces();
 		for (CloudSpace space : spaces) {
-			CloudOrganization org = space.getOrganization();
-			if (org.getName().equals(orgName) && space.getName().equals(spaceName)) {
-				sessionSpace = space;
+			if (space.getName().equals(spaceName)) {
+				CloudOrganization org = space.getOrganization();
+				if (orgName == null || org.getName().equals(orgName)) {
+					sessionSpace = space;
+				}
 			}
 		}
 		if (sessionSpace == null) {

--- a/cloudfoundry-client-lib/src/test/java/org/cloudfoundry/client/lib/CloudFoundryClientTest.java
+++ b/cloudfoundry-client-lib/src/test/java/org/cloudfoundry/client/lib/CloudFoundryClientTest.java
@@ -116,7 +116,7 @@ public class CloudFoundryClientTest {
         }
         connectedClient = new CloudFoundryClient(new CloudCredentials(CCNG_USER_EMAIL, CCNG_USER_PASS), 
 												    new URL(CCNG_API_URL), CCNG_USER_ORG, CCNG_USER_SPACE, httpProxyConfiguration);
-        	connectedClient.login();
+		connectedClient.login();
 		connectedClient.deleteAllApplications();
 		connectedClient.deleteAllServices();
 		clearTestDomainAndRoutes();


### PR DESCRIPTION
It should be possible to pass just the space name when connecting, or the space and the org together. 
