### PR TITLE
Fixed bug where null service name is added to app services

### DIFF
--- a/cloudfoundry-client-lib/src/main/java/org/cloudfoundry/client/lib/util/CloudEntityResourceMapper.java
+++ b/cloudfoundry-client-lib/src/main/java/org/cloudfoundry/client/lib/util/CloudEntityResourceMapper.java
@@ -152,7 +152,10 @@ public class CloudEntityResourceMapper {
 		List<String> serviceList = new ArrayList<String>();
 		for (Map<String, Object> binding : serviceBindings) {
 			Map<String, Object> service = getEntityAttribute(binding, "service_instance", Map.class);
-			serviceList.add(getNameOfResource(service));
+			String serviceName = getNameOfResource(service);
+			if (serviceName != null) {
+				serviceList.add(serviceName);
+			}
 		}
 		app.setServices(serviceList);
 		return app;


### PR DESCRIPTION
Fixed bug where null service name is added to an application's list of bound services, when the service has had no bound services. Added three test cases to test this scenario, in particular using the update Services client API.
