### PR TITLE
Quick fix regression: HTTP proxy config missing in OAuth 

### DIFF
--- a/cloudfoundry-client-lib/src/main/java/org/cloudfoundry/client/lib/oauth2/OauthClient.java
+++ b/cloudfoundry-client-lib/src/main/java/org/cloudfoundry/client/lib/oauth2/OauthClient.java
@@ -60,9 +60,10 @@ public class OauthClient {
 	public OAuth2AccessToken getToken(String username, String password) {
 		OAuth2ProtectedResourceDetails resource = getResourceDetails(username, password);
 		AccessTokenRequest request = createAccessTokenRequest(username, password);
-		
-		ResourceOwnerPasswordAccessTokenProvider provider = new ResourceOwnerPasswordAccessTokenProvider();
-		OAuth2AccessToken token = null;
+
+        ResourceOwnerPasswordAccessTokenProvider provider = createResourceOwnerPasswordAccessTokenProvider();
+        provider.setRequestFactory(restTemplate.getRequestFactory()); //copy the http proxy along
+        OAuth2AccessToken token = null;
 		try {
 			token = provider.obtainAccessToken(resource, request);
 		}
@@ -74,14 +75,18 @@ public class OauthClient {
 		}
 		return token;
 	}
-	
-	public OAuth2AccessToken refreshToken(OAuth2AccessToken currentToken, String username, String password) {
+
+    protected ResourceOwnerPasswordAccessTokenProvider createResourceOwnerPasswordAccessTokenProvider() {
+        return new ResourceOwnerPasswordAccessTokenProvider();
+    }
+
+    public OAuth2AccessToken refreshToken(OAuth2AccessToken currentToken, String username, String password) {
 		OAuth2ProtectedResourceDetails resource = getResourceDetails(username, password);
 		AccessTokenRequest request = createAccessTokenRequest(username, password);
 
-		ResourceOwnerPasswordAccessTokenProvider provider = new ResourceOwnerPasswordAccessTokenProvider();
-		
-		return provider.refreshAccessToken(resource, currentToken.getRefreshToken(), request);
+        ResourceOwnerPasswordAccessTokenProvider provider = createResourceOwnerPasswordAccessTokenProvider();
+
+        return provider.refreshAccessToken(resource, currentToken.getRefreshToken(), request);
 	}
 
 	@SuppressWarnings({ "rawtypes", "unchecked" })

--- a/cloudfoundry-client-lib/src/test/java/org/cloudfoundry/client/lib/oauth2/OauthClientTest.java
+++ b/cloudfoundry-client-lib/src/test/java/org/cloudfoundry/client/lib/oauth2/OauthClientTest.java
@@ -1,0 +1,48 @@
+package org.cloudfoundry.client.lib.oauth2;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.springframework.http.client.ClientHttpRequestFactory;
+import org.springframework.security.oauth2.client.token.grant.password.ResourceOwnerPasswordAccessTokenProvider;
+import org.springframework.security.oauth2.common.OAuth2AccessToken;
+import org.springframework.web.client.RestTemplate;
+import java.net.URL;
+
+
+@RunWith(org.mockito.runners.MockitoJUnitRunner.class)
+public class OauthClientTest {
+
+    @Mock
+    RestTemplate restTemplate;
+
+    @Mock
+    ResourceOwnerPasswordAccessTokenProvider provider;
+
+    @Mock
+    ClientHttpRequestFactory requestFactory;
+
+    /**
+     * Verify proxies in original rest template are propagated into ResourceOwnerPasswordAccessTokenProvider as well.
+     * @throws Exception
+     */
+    @Test
+    public void testGetTokenPreservesProxies() throws Exception {
+        //given
+        OauthClient oauthClient = new OauthClient(new URL("http://api.run.pivotal.io"), restTemplate) {
+            @Override
+            protected ResourceOwnerPasswordAccessTokenProvider createResourceOwnerPasswordAccessTokenProvider() {
+                return provider;
+            }
+        };
+
+        Mockito.when(restTemplate.getRequestFactory()).thenReturn(requestFactory);
+
+        //when
+        OAuth2AccessToken token = oauthClient.getToken("login", "password");
+
+        //then
+        Mockito.verify(provider).setRequestFactory(requestFactory);
+    }
+}


### PR DESCRIPTION
Fixed regression introduced in edcb7a8 with does not propagate the HTTP proxy config to OAuth anymore

As a first step this is tested with a unit test that focuses on this specific aspect, after a small refactoring to OAuth class. An integration test for covering all interactions is being worked on in https://github.com/cloudfoundry/vcap-java-client/pull/69
