### PR TITLE
Moved TokensFile from Maven plugin to cloudfoundry-client-lib.

### DIFF
--- a/cloudfoundry-client-lib/pom.xml
+++ b/cloudfoundry-client-lib/pom.xml
@@ -18,7 +18,7 @@
 	</licenses>
 
 	<properties>
-		<spring.framework.version>3.0.7.RELEASE</spring.framework.version>
+		<spring.framework.version>3.2.2.RELEASE</spring.framework.version>
 		<spring.security.oauth.version>1.0.0.RELEASE</spring.security.oauth.version>
 	</properties>
 
@@ -87,6 +87,12 @@
 		</dependency>
 
 		<dependency>
+			<groupId>com.esotericsoftware.yamlbeans</groupId>
+			<artifactId>yamlbeans</artifactId>
+			<version>1.06</version>
+		</dependency>
+
+		<dependency>
 			<groupId>org.codehaus.jackson</groupId>
 			<artifactId>jackson-core-asl</artifactId>
 			<version>1.6.2</version>
@@ -132,6 +138,7 @@
 			<artifactId>commons-io</artifactId>
 			<version>2.1</version>
 		</dependency>
+
 		<dependency>
 			<groupId>org.cloudfoundry.test</groupId>
 			<artifactId>non-ascii-file-name</artifactId>

--- a/cloudfoundry-client-lib/src/main/java/org/cloudfoundry/client/lib/tokens/TargetInfos.java
+++ b/cloudfoundry-client-lib/src/main/java/org/cloudfoundry/client/lib/tokens/TargetInfos.java
@@ -1,4 +1,4 @@
-package org.cloudfoundry.maven.common;
+package org.cloudfoundry.client.lib.tokens;
 
 import org.springframework.security.oauth2.common.DefaultOAuth2AccessToken;
 import org.springframework.security.oauth2.common.DefaultOAuth2RefreshToken;

--- a/cloudfoundry-maven-plugin/pom.xml
+++ b/cloudfoundry-maven-plugin/pom.xml
@@ -176,12 +176,6 @@
 		</dependency>
 
 		<dependency>
-			<groupId>com.esotericsoftware.yamlbeans</groupId>
-			<artifactId>yamlbeans</artifactId>
-			<version>1.06</version>
-		</dependency>
-
-		<dependency>
 			<groupId>junit</groupId>
 			<artifactId>junit</artifactId>
 			<version>4.10</version>

--- a/cloudfoundry-maven-plugin/src/main/java/org/cloudfoundry/maven/AbstractCloudFoundryMojo.java
+++ b/cloudfoundry-maven-plugin/src/main/java/org/cloudfoundry/maven/AbstractCloudFoundryMojo.java
@@ -31,8 +31,8 @@ import org.apache.maven.wagon.authentication.AuthenticationInfo;
 import org.cloudfoundry.client.lib.CloudCredentials;
 import org.cloudfoundry.client.lib.CloudFoundryClient;
 import org.cloudfoundry.client.lib.CloudFoundryException;
+import org.cloudfoundry.client.lib.tokens.TokensFile;
 import org.cloudfoundry.maven.common.Assert;
-import org.cloudfoundry.maven.common.AuthTokens;
 import org.cloudfoundry.maven.common.DefaultConstants;
 import org.cloudfoundry.maven.common.SystemProperties;
 import org.springframework.http.HttpStatus;
@@ -57,7 +57,7 @@ public abstract class AbstractCloudFoundryMojo extends AbstractMojo {
 	private String artifactId;
 
 	protected CloudFoundryClient client;
-	protected AuthTokens authTokens = new AuthTokens();
+	protected TokensFile tokensFile = new TokensFile();
 
 	/**
 	 * @parameter expression="${cf.password}"
@@ -110,8 +110,8 @@ public abstract class AbstractCloudFoundryMojo extends AbstractMojo {
 		super();
 	}
 
-	public AbstractCloudFoundryMojo(AuthTokens authTokens) {
-		this.authTokens = authTokens;
+	public AbstractCloudFoundryMojo(TokensFile tokensFile) {
+		this.tokensFile = tokensFile;
 	}
 
 	/**
@@ -122,12 +122,11 @@ public abstract class AbstractCloudFoundryMojo extends AbstractMojo {
 	 * @throws ParserConfigurationException
 	 */
 	protected OAuth2AccessToken retrieveToken() throws MojoExecutionException {
-		final OAuth2AccessToken token = authTokens.retrieveToken(getTarget());
+		final OAuth2AccessToken token = tokensFile.retrieveToken(getTarget());
 
 		if (token == null) {
-			throw new MojoExecutionException(String.format("Access token could not be read from '%s' for target '%s'. " +
-					"Configure a username and password, or use the login goal.",
-					authTokens.getTokensFilePath(), getTarget().toString()));
+			throw new MojoExecutionException(String.format("Can not authenticate to target '%s'. " +
+					"Configure a username and password, or use the login goal.", getTarget().toString()));
 		}
 
 		return token;

--- a/cloudfoundry-maven-plugin/src/main/java/org/cloudfoundry/maven/Login.java
+++ b/cloudfoundry-maven-plugin/src/main/java/org/cloudfoundry/maven/Login.java
@@ -23,7 +23,7 @@ import org.apache.maven.plugin.MojoFailureException;
 import org.cloudfoundry.client.lib.domain.CloudInfo;
 import org.cloudfoundry.client.lib.domain.CloudSpace;
 import org.cloudfoundry.maven.common.Assert;
-import org.cloudfoundry.maven.common.AuthTokens;
+import org.cloudfoundry.client.lib.tokens.TokensFile;
 import org.cloudfoundry.maven.common.SystemProperties;
 
 import org.springframework.security.oauth2.common.OAuth2AccessToken;
@@ -44,8 +44,8 @@ public class Login extends AbstractCloudFoundryMojo {
 	public Login() {
 	}
 
-	public Login(AuthTokens authTokens) {
-		this.authTokens = authTokens;
+	public Login(TokensFile tokensFile) {
+		this.tokensFile = tokensFile;
 	}
 
 	@Override
@@ -63,7 +63,7 @@ public class Login extends AbstractCloudFoundryMojo {
 		final CloudInfo cloudInfo = getClient().getCloudInfo();
 		final CloudSpace space = getCurrentSpace();
 
-		authTokens.saveToken(getTarget(), token, cloudInfo, space);
+		tokensFile.saveToken(getTarget(), token, cloudInfo, space);
 
 		getLog().info("Authentication successful");
 	}

--- a/cloudfoundry-maven-plugin/src/main/java/org/cloudfoundry/maven/Logout.java
+++ b/cloudfoundry-maven-plugin/src/main/java/org/cloudfoundry/maven/Logout.java
@@ -19,7 +19,7 @@ package org.cloudfoundry.maven;
 
 import org.apache.maven.plugin.MojoExecutionException;
 import org.apache.maven.plugin.MojoFailureException;
-import org.cloudfoundry.maven.common.AuthTokens;
+import org.cloudfoundry.client.lib.tokens.TokensFile;
 
 /**
  * Performs logout and removes the target info from ~/.cf/tokens.yml.
@@ -35,8 +35,8 @@ public class Logout extends AbstractCloudFoundryMojo {
 	public Logout() {
 	}
 
-	public Logout(AuthTokens authTokens) {
-		super(authTokens);
+	public Logout(TokensFile tokensFile) {
+		super(tokensFile);
 	}
 
 	@Override
@@ -49,6 +49,6 @@ public class Logout extends AbstractCloudFoundryMojo {
 
 	@Override
 	protected void doExecute() throws MojoExecutionException {
-		authTokens.removeToken(getTarget());
+		tokensFile.removeToken(getTarget());
 	}
 }

--- a/cloudfoundry-maven-plugin/src/test/java/org/cloudfoundry/maven/LoginAndLogoutTest.java
+++ b/cloudfoundry-maven-plugin/src/test/java/org/cloudfoundry/maven/LoginAndLogoutTest.java
@@ -33,7 +33,7 @@ import org.cloudfoundry.client.lib.domain.CloudEntity;
 import org.cloudfoundry.client.lib.domain.CloudInfo;
 import org.cloudfoundry.client.lib.domain.CloudOrganization;
 import org.cloudfoundry.client.lib.domain.CloudSpace;
-import org.cloudfoundry.maven.common.AuthTokens;
+import org.cloudfoundry.client.lib.tokens.TokensFile;
 import org.junit.Before;
 import org.junit.ClassRule;
 import org.junit.Ignore;
@@ -70,7 +70,7 @@ public class LoginAndLogoutTest {
 	public void setup() throws Exception {
 		initMocks(this);
 
-		TestableAuthTokens authTokens = new TestableAuthTokens();
+		TestableTokensFile authTokens = new TestableTokensFile();
 
 		cloudFoundryMojo = new TestableCloudFoundryMojo(authTokens);
 
@@ -105,13 +105,13 @@ public class LoginAndLogoutTest {
 			cloudFoundryMojo.retrieveToken();
 			fail();
 		} catch (MojoExecutionException e) {
-			assertTrue(e.getMessage().contains("Access token could not be read"));
+			assertTrue(e.getMessage().contains("Can not authenticate to target"));
 		}
 	}
 }
 
 @Ignore
-class TestableAuthTokens extends AuthTokens {
+class TestableTokensFile extends TokensFile {
 	@Override
 	public String getTokensFilePath() {
 		try {
@@ -125,8 +125,8 @@ class TestableAuthTokens extends AuthTokens {
 @Ignore
 class TestableLogin extends Login {
 
-	public TestableLogin(CloudFoundryClient client, AuthTokens authTokens) {
-		super(authTokens);
+	public TestableLogin(CloudFoundryClient client, TokensFile tokensFile) {
+		super(tokensFile);
 		this.client = client;
 	}
 
@@ -148,8 +148,8 @@ class TestableLogin extends Login {
 @Ignore
 class TestableLogout extends Logout {
 
-	public TestableLogout(AuthTokens authTokens) {
-		super(authTokens);
+	public TestableLogout(TokensFile tokensFile) {
+		super(tokensFile);
 	}
 
 	@Override
@@ -165,8 +165,8 @@ class TestableLogout extends Logout {
 @Ignore
 class TestableCloudFoundryMojo extends AbstractCloudFoundryMojo {
 
-	public TestableCloudFoundryMojo(AuthTokens authTokens) {
-		this.authTokens = authTokens;
+	public TestableCloudFoundryMojo(TokensFile tokensFile) {
+		this.tokensFile = tokensFile;
 	}
 
 	@Override


### PR DESCRIPTION
This commit adds functionality to cloudfoundry-client-lib to read and write access and refresh tokens from `~/.cf/tokens.yml` in a way that is compatible with the `cf` CLI tool. 

This functionality was initially added to the Maven plugin, but moved to cloudfoundry-client-lib to make it available to other clients. 
