### PR TITLE
Add skip support to the plugin

### DIFF
--- a/cloudfoundry-maven-plugin/src/main/java/org/cloudfoundry/maven/AbstractCloudFoundryMojo.java
+++ b/cloudfoundry-maven-plugin/src/main/java/org/cloudfoundry/maven/AbstractCloudFoundryMojo.java
@@ -95,6 +95,12 @@ public abstract class AbstractCloudFoundryMojo extends AbstractMojo {
 	private String space;
 
 	/**
+	 * Skip any and all execution of this plugin.
+	 * @parameter expression="${cf.skip}" default="false"
+	 */
+	private boolean skip;
+	
+	/**
 	 * The Maven Wagon manager to use when obtaining server authentication details.
 	 *
 	 * @component role="org.apache.maven.artifact.manager.WagonManager"
@@ -226,6 +232,10 @@ public abstract class AbstractCloudFoundryMojo extends AbstractMojo {
 	 * Delegates to doExecute() for the actual business logic.
 	 */
 	public void execute() throws MojoExecutionException, MojoFailureException {
+		if(skip) {
+			getLog().info("Skipping execution of CloudFoundry Maven Plugin");
+			return;
+		}
 		Assert.configurationNotNull(target, "target", SystemProperties.TARGET);
 
 		try {

--- a/cloudfoundry-maven-plugin/src/test/java/org/cloudfoundry/maven/AbstractCloudFoundryMojoTest.java
+++ b/cloudfoundry-maven-plugin/src/test/java/org/cloudfoundry/maven/AbstractCloudFoundryMojoTest.java
@@ -40,6 +40,20 @@ public class AbstractCloudFoundryMojoTest extends AbstractMojoTestCase {
 	protected void setUp() throws Exception {
 		super.setUp();
 	}
+	
+	/**
+	 * @throws Exception
+	 */
+	public void testSkip() throws Exception {
+
+		File testPom = new File(getBasedir(), "src/test/resources/test-pom.xml");
+
+		Push mojo = (Push) lookupMojo("push", testPom);
+
+		setVariableValueToObject(mojo, "skip", true);
+		
+		mojo.execute();
+	}
 
 	/**
 	 * @throws Exception


### PR DESCRIPTION
It is a common practice for maven plugins to add a "skip" property that allows for control of the execution of the plugin based on the value of a property.  Without it the only way to limit execution of the plugin is the use of profiles which is not always the best solution to a problem.

This PR adds the skip property (cf.skip) to the AbstractCloudFoundryMojo and should not error out even if no configuration is specified.
