### PR TITLE
Replaced usage of deprecated commons-httpclient with org.apache.httpcomponents.

### DIFF
--- a/cloudfoundry-client-lib/pom.xml
+++ b/cloudfoundry-client-lib/pom.xml
@@ -81,9 +81,9 @@
 		</dependency>
 
 		<dependency>
-			<groupId>commons-httpclient</groupId>
-			<artifactId>commons-httpclient</artifactId>
-			<version>3.1</version>
+			<groupId>org.apache.httpcomponents</groupId>
+			<artifactId>httpclient</artifactId>
+			<version>4.2.5</version>
 		</dependency>
 
 		<dependency>

--- a/cloudfoundry-client-lib/src/main/java/org/cloudfoundry/client/lib/util/RestUtil.java
+++ b/cloudfoundry-client-lib/src/main/java/org/cloudfoundry/client/lib/util/RestUtil.java
@@ -1,10 +1,12 @@
 package org.cloudfoundry.client.lib.util;
 
+import org.apache.http.HttpHost;
+import org.apache.http.conn.params.ConnRoutePNames;
 import org.cloudfoundry.client.lib.HttpProxyConfiguration;
 import org.cloudfoundry.client.lib.oauth2.OauthClient;
 import org.cloudfoundry.client.lib.rest.LoggingRestTemplate;
 import org.springframework.http.client.ClientHttpRequestFactory;
-import org.springframework.http.client.CommonsClientHttpRequestFactory;
+import org.springframework.http.client.HttpComponentsClientHttpRequestFactory;
 import org.springframework.web.client.RestTemplate;
 
 import java.net.URL;
@@ -12,7 +14,7 @@ import java.net.URL;
 /**
  * Some helper utilities for creating classes used for the REST support.
  *
- * @author: Thomas Risberg
+ * @author Thomas Risberg
  */
 public class RestUtil {
 
@@ -23,10 +25,10 @@ public class RestUtil {
 	}
 
 	public ClientHttpRequestFactory createRequestFactory(HttpProxyConfiguration httpProxyConfiguration) {
-		CommonsClientHttpRequestFactory requestFactory = new CommonsClientHttpRequestFactory();
+		HttpComponentsClientHttpRequestFactory requestFactory = new HttpComponentsClientHttpRequestFactory();
 		if (httpProxyConfiguration != null) {
-			requestFactory.getHttpClient().getHostConfiguration().setProxy(httpProxyConfiguration.getProxyHost(),
-					httpProxyConfiguration.getProxyPort());
+			HttpHost proxy = new HttpHost(httpProxyConfiguration.getProxyHost(), httpProxyConfiguration.getProxyPort());
+			requestFactory.getHttpClient().getParams().setParameter(ConnRoutePNames.DEFAULT_PROXY, proxy);
 		}
 		return requestFactory;
 	}


### PR DESCRIPTION
Replaced the usage of the deprecated `org.springframework.http.client.CommonsClientHttpRequestFactory` with the current `org.springframework.http.client.HttpComponentsClientHttpRequestFactory` when creating the HTTP client for `RestTemplate`. This makes cloudfoundry-client-lib compatible with Spring 4.x. 

Patch courtesy of @mstine. 
