### PR TITLE
Fixed bug in URI parsing when multiple subdomains are registered (from gberche-orange)

### DIFF
--- a/cloudfoundry-client-lib/src/test/java/org/cloudfoundry/client/lib/rest/CloudControllerClientImplTest.java
+++ b/cloudfoundry-client-lib/src/test/java/org/cloudfoundry/client/lib/rest/CloudControllerClientImplTest.java
@@ -1,0 +1,80 @@
+package org.cloudfoundry.client.lib.rest;
+
+import org.cloudfoundry.client.lib.CloudCredentials;
+import org.cloudfoundry.client.lib.HttpProxyConfiguration;
+import org.cloudfoundry.client.lib.oauth2.OauthClient;
+import org.cloudfoundry.client.lib.util.RestUtil;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.springframework.http.client.ClientHttpRequestFactory;
+import org.springframework.web.client.RestTemplate;
+
+import java.net.URI;
+import java.net.URL;
+import java.util.*;
+
+import static java.util.Arrays.asList;
+import static org.mockito.Matchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+@RunWith(org.mockito.runners.MockitoJUnitRunner.class)
+public class CloudControllerClientImplTest {
+
+    private static final String CCNG_API_URL = System.getProperty("ccng.target", "http://api.run.pivotal.io");
+    private static final String CCNG_USER_EMAIL = System.getProperty("ccng.email", "java-authenticatedClient-test-user@vmware.com");
+    private static final String CCNG_USER_PASS = System.getProperty("ccng.passwd");
+    private static final String CCNG_USER_ORG = System.getProperty("ccng.org", "gopivotal.com");
+    private static final String CCNG_USER_SPACE = System.getProperty("ccng.space", "test");
+
+    @Mock
+    private RestUtil restUtil;
+    @Mock
+    private RestTemplate restTemplate;
+    @Mock
+    private ClientHttpRequestFactory clientHttpRequestFactory;
+    @Mock
+    private OauthClient oauthClient;
+
+    private CloudControllerClientImpl controllerClient;
+
+    /**
+     * Failed attempt to instanciate CloudControllerClientImpl with existing constructors. Just here to illustrate the
+     * need to move the initialize() method out of the constructor.
+     */
+    public void setUpWithNonEmptyConstructorWithoutLuck() throws Exception {
+        restUtil = mock(RestUtil.class);
+        when(restUtil.createRestTemplate(any(HttpProxyConfiguration.class))).thenReturn(restTemplate);
+        when(restUtil.createOauthClient(any(URL.class), any(HttpProxyConfiguration.class))).thenReturn(oauthClient);
+        when(restTemplate.getRequestFactory()).thenReturn(clientHttpRequestFactory);
+
+        controllerClient = new CloudControllerClientImpl(new URL("http://api.dummyendpoint.com/login"), restUtil, new CloudCredentials(CCNG_USER_EMAIL, CCNG_USER_PASS),
+                new URL(CCNG_API_URL), CCNG_USER_ORG, CCNG_USER_SPACE, null);
+    }
+
+    @Before
+    public void setUpWithEmptyConstructor() throws Exception {
+        controllerClient = new CloudControllerClientImpl();
+    }
+
+    @Test
+    public void extractUriInfo_selects_most_specific_subdomain() throws Exception {
+        //given
+        String uri = "myhost.sub1.sub2.domain.com";
+        Map<String, UUID> domains = new LinkedHashMap<String, UUID>(); //Since impl iterates key, need to control iteration order with a LinkedHashMap
+        domains.put("domain.com", UUID.randomUUID());
+        domains.put("sub1.sub2.domain.com", UUID.randomUUID());
+        Map<String, String> uriInfo = new HashMap<String, String>(2);
+
+        //when
+        controllerClient.extractUriInfo(domains, uri, uriInfo);
+
+        //then
+        Assert.assertEquals(domains.get("sub1.sub2.domain.com"), domains.get(uriInfo.get("domainName")));
+        Assert.assertEquals("myhost", uriInfo.get("host"));
+    }
+
+}


### PR DESCRIPTION
In case multiple subdomains are registered, CloudControllerClientImpl.extractUriInfo() was picking the first one in the order returned by the provided map's iterator (Map<String, UUID> domains). Now selects the most specific one (the domain with the longuest size).
Added associated unit test. Since it was impossible to properly inject mocks, I had to create a new protected constructor. Would be useful to move the initialize() call out of the constructor in future to each such tests
