### PR TITLE
Moved dependencies and plugins into integration-test profile.

### DIFF
--- a/cloudfoundry-client-lib/pom.xml
+++ b/cloudfoundry-client-lib/pom.xml
@@ -39,6 +39,7 @@
 				<maven.test.skip>true</maven.test.skip>
 			</properties>
 		</profile>
+
 		<profile>
 			<id>integration-test</id>
 			<build>
@@ -52,8 +53,88 @@
 							</includes>
 						</configuration>
 					</plugin>
+
+					<!-- Used to syntactically verify our byteman rules that detect unexpected direct sockets not going through proxy -->
+					<plugin>
+						<groupId>org.jboss.byteman</groupId>
+						<artifactId>byteman-rulecheck-maven-plugin</artifactId>
+						<version>2.1.3</version>
+						<executions>
+							<execution>
+								<id>rulecheck-test</id>
+								<goals>
+									<goal>rulecheck</goal>
+								</goals>
+								<configuration>
+									<packages>
+										<package>org.cloudfoundry</package>
+									</packages>
+									<includes>
+										<include>**/*.btm</include>
+									</includes>
+									<verbose>true</verbose>
+								</configuration>
+							</execution>
+						</executions>
+					</plugin>
+					<plugin>
+						<groupId>org.apache.maven.plugins</groupId>
+						<artifactId>maven-dependency-plugin</artifactId>
+						<executions>
+							<execution>
+								<id>copy-test-app</id>
+								<goals>
+									<goal>copy</goal>
+								</goals>
+								<phase>generate-test-resources</phase>
+								<configuration>
+									<artifactItems>
+										<artifactItem>
+											<groupId>org.cloudfoundry.test</groupId>
+											<artifactId>non-ascii-file-name</artifactId>
+											<version>0.1.0.BUILD-SNAPSHOT</version>
+											<type>war</type>
+											<outputDirectory>${project.build.directory}/generated-test-resources</outputDirectory>
+										</artifactItem>
+										<artifactItem>
+											<groupId>org.cloudfoundry.test</groupId>
+											<artifactId>simple-spring-app</artifactId>
+											<version>0.1.0.BUILD-SNAPSHOT</version>
+											<type>war</type>
+											<outputDirectory>${project.build.directory}/generated-test-resources</outputDirectory>
+										</artifactItem>
+									</artifactItems>
+									<stripVersion>true</stripVersion>
+								</configuration>
+							</execution>
+						</executions>
+					</plugin>
 				</plugins>
 			</build>
+
+			<dependencies>
+				<dependency>
+					<groupId>com.sun</groupId>
+					<artifactId>tools</artifactId>
+					<version>1.6</version>
+					<scope>system</scope>
+					<systemPath>${tools.jar}</systemPath>
+				</dependency>
+				<dependency>
+					<groupId>org.cloudfoundry.test</groupId>
+					<artifactId>non-ascii-file-name</artifactId>
+					<version>0.1.0.BUILD-SNAPSHOT</version>
+					<type>war</type>
+					<scope>provided</scope>
+				</dependency>
+				<dependency>
+					<groupId>org.cloudfoundry.test</groupId>
+					<artifactId>simple-spring-app</artifactId>
+					<version>0.1.0.BUILD-SNAPSHOT</version>
+					<type>war</type>
+					<scope>provided</scope>
+				</dependency>
+			</dependencies>
 		</profile>
 
 		<!-- tools classes are needed by byteman, and their path is system-dependent,
@@ -136,6 +217,11 @@
 			<artifactId>httpclient</artifactId>
 			<version>4.2.5</version>
 		</dependency>
+		<dependency>
+			<groupId>commons-io</groupId>
+			<artifactId>commons-io</artifactId>
+			<version>2.1</version>
+		</dependency>
 
 		<dependency>
 			<groupId>com.esotericsoftware.yamlbeans</groupId>
@@ -197,43 +283,16 @@
 			<scope>test</scope>
 		</dependency>
 		<dependency>
-			<groupId>org.jboss.byteman</groupId>
-			<artifactId>byteman-bmunit</artifactId>
-			<version>${byteman.version}</version>
-			<scope>test</scope>
-		</dependency>
-		<dependency>
-			<groupId>com.sun</groupId>
-			<artifactId>tools</artifactId>
-			<version>1.6</version>
-			<scope>system</scope>
-			<systemPath>${tools.jar}</systemPath>
-		</dependency>
-		<dependency>
 			<groupId>log4j</groupId>
 			<artifactId>log4j</artifactId>
 			<version>1.2.14</version>
 			<scope>test</scope>
 		</dependency>
 		<dependency>
-			<groupId>commons-io</groupId>
-			<artifactId>commons-io</artifactId>
-			<version>2.1</version>
-		</dependency>
-
-		<dependency>
-			<groupId>org.cloudfoundry.test</groupId>
-			<artifactId>non-ascii-file-name</artifactId>
-			<version>0.1.0.BUILD-SNAPSHOT</version>
-			<type>war</type>
-			<scope>provided</scope>
-		</dependency>
-		<dependency>
-			<groupId>org.cloudfoundry.test</groupId>
-			<artifactId>simple-spring-app</artifactId>
-			<version>0.1.0.BUILD-SNAPSHOT</version>
-			<type>war</type>
-			<scope>provided</scope>
+			<groupId>org.jboss.byteman</groupId>
+			<artifactId>byteman-bmunit</artifactId>
+			<version>${byteman.version}</version>
+			<scope>test</scope>
 		</dependency>
 	</dependencies>
 
@@ -307,63 +366,6 @@
 					</execution>
 				</executions>
 			</plugin>
-			<plugin>
-				<groupId>org.apache.maven.plugins</groupId>
-				<artifactId>maven-dependency-plugin</artifactId>
-				<executions>
-					<execution>
-						<id>copy-test-app</id>
-						<goals>
-							<goal>copy</goal>
-						</goals>
-						<phase>generate-test-resources</phase>
-						<configuration>
-							<artifactItems>
-								<artifactItem>
-									<groupId>org.cloudfoundry.test</groupId>
-									<artifactId>non-ascii-file-name</artifactId>
-									<version>0.1.0.BUILD-SNAPSHOT</version>
-									<type>war</type>
-									<outputDirectory>${project.build.directory}/generated-test-resources</outputDirectory>
-								</artifactItem>
-								<artifactItem>
-									<groupId>org.cloudfoundry.test</groupId>
-									<artifactId>simple-spring-app</artifactId>
-									<version>0.1.0.BUILD-SNAPSHOT</version>
-									<type>war</type>
-									<outputDirectory>${project.build.directory}/generated-test-resources</outputDirectory>
-								</artifactItem>
-							</artifactItems>
-							<stripVersion>true</stripVersion>
-						</configuration>
-					</execution>
-				</executions>
-			</plugin>
-
-			<!-- Used to syntaxically verify our byteman rules that detect unexpected direct sockets not going through proxy -->
-			<plugin>
-				<groupId>org.jboss.byteman</groupId>
-				<artifactId>byteman-rulecheck-maven-plugin</artifactId>
-				<version>2.1.3</version>
-				<executions>
-					<execution>
-						<id>rulecheck-test</id>
-						<goals>
-							<goal>rulecheck</goal>
-						</goals>
-						<configuration>
-							<packages>
-								<package>org.cloudfoundry</package>
-							</packages>
-							<includes>
-								<include>**/*.btm</include>
-							</includes>
-							<verbose>true</verbose>
-						</configuration>
-					</execution>
-				</executions>
-			</plugin>
-
 		</plugins>
 		<testResources>
 			<testResource>


### PR DESCRIPTION
Moved dependencies and plugins into integration-test profile to clean up the released pom and speed up non-integration-test builds.

The released pom for cf-client-lib included the following dependency: 

```
    <dependency>
      <groupId>com.sun</groupId>
      <artifactId>tools</artifactId>
      <version>1.6</version>
      <scope>system</scope>
      <systemPath>/System/Library/Java/JavaVirtualMachines/1.6.0.jdk/Contents/Home/../Classes/classes.jar</systemPath>
    </dependency>
```

Some maven builds complain about the relative path, and this path is specific to OSX machines (since the release was built on a Mac). 

Moving the `classes.jar` dependency into the `integration-test` profile will prevent this dependency from being included in the released pom.xml in the future. 

The test app dependencies were also moved into the `integration-test` profile for general hygiene. 
