### PR TITLE
Added support for creating and retrieving user-provided service instances.

### DIFF
--- a/cloudfoundry-client-lib/src/main/java/org/cloudfoundry/client/lib/CloudFoundryClient.java
+++ b/cloudfoundry-client-lib/src/main/java/org/cloudfoundry/client/lib/CloudFoundryClient.java
@@ -182,6 +182,10 @@ public class CloudFoundryClient implements CloudFoundryOperations {
 		cc.createService(service);
 	}
 
+	public void createUserProvidedService(CloudService service, Map<String, Object> credentials) {
+		cc.createUserProvidedService(service, credentials);
+	}
+
 	public void uploadApplication(String appName, String file) throws IOException {
 		cc.uploadApplication(appName, new File(file), null);
 	}

--- a/cloudfoundry-client-lib/src/main/java/org/cloudfoundry/client/lib/CloudFoundryOperations.java
+++ b/cloudfoundry-client-lib/src/main/java/org/cloudfoundry/client/lib/CloudFoundryOperations.java
@@ -176,6 +176,14 @@ public interface CloudFoundryOperations {
 	void createService(CloudService service);
 
 	/**
+	 * Create a user-provided service.
+	 *
+	 * @param service cloud service info
+	 * @param credentials the user-provided service credentials
+	 */
+	void createUserProvidedService(CloudService service, Map<String, Object> credentials);
+
+	/**
 	 * Upload an application.
 	 *
 	 * @param appName application name

--- a/cloudfoundry-client-lib/src/main/java/org/cloudfoundry/client/lib/domain/CloudService.java
+++ b/cloudfoundry-client-lib/src/main/java/org/cloudfoundry/client/lib/domain/CloudService.java
@@ -20,7 +20,7 @@ package org.cloudfoundry.client.lib.domain;
 /**
  * Class representing an instance of a service created for a space.
  *
- * @author: Thomas Risberg
+ * @author Thomas Risberg
  */
 public class CloudService extends CloudEntity {
 
@@ -38,6 +38,9 @@ public class CloudService extends CloudEntity {
 		super(meta, name);
 	}
 
+	public boolean isUserProvided() {
+		return plan == null && provider == null && version == null;
+	}
 
 	public String getVersion() {
 		return version;

--- a/cloudfoundry-client-lib/src/main/java/org/cloudfoundry/client/lib/rest/CloudControllerClient.java
+++ b/cloudfoundry-client-lib/src/main/java/org/cloudfoundry/client/lib/rest/CloudControllerClient.java
@@ -81,6 +81,8 @@ public interface CloudControllerClient {
 
 	void createService(CloudService service);
 
+	void createUserProvidedService(CloudService service, Map<String, Object> credentials);
+
 	CloudService getService(String service);
 
 	void deleteService(String service);

--- a/cloudfoundry-client-lib/src/main/java/org/cloudfoundry/client/lib/util/CloudEntityResourceMapper.java
+++ b/cloudfoundry-client-lib/src/main/java/org/cloudfoundry/client/lib/util/CloudEntityResourceMapper.java
@@ -160,18 +160,16 @@ public class CloudEntityResourceMapper {
 				getMeta(resource),
 				getNameOfResource(resource));
 		Map<String, Object> servicePlanResource = getEmbeddedResource(resource, "service_plan");
-		Map<String, Object> serviceResource = null;
-		if (servicePlanResource != null) {
-			serviceResource = getEmbeddedResource(servicePlanResource, "service");
-		}
-		if (servicePlanResource != null && serviceResource != null) {
-			//TODO: assuming vendor corresponds to the service.provider and not service_instance.vendor_data
-			cloudService.setLabel(getEntityAttribute(serviceResource, "label", String.class));
-			cloudService.setProvider(getEntityAttribute(serviceResource, "provider", String.class));
-			cloudService.setVersion(getEntityAttribute(serviceResource, "version", String.class));
-		}
 		if (servicePlanResource != null) {
 			cloudService.setPlan(getEntityAttribute(servicePlanResource, "name", String.class));
+
+			Map<String, Object> serviceResource = getEmbeddedResource(servicePlanResource, "service");
+			if (serviceResource != null) {
+				//TODO: assuming vendor corresponds to the service.provider and not service_instance.vendor_data
+				cloudService.setLabel(getEntityAttribute(serviceResource, "label", String.class));
+				cloudService.setProvider(getEntityAttribute(serviceResource, "provider", String.class));
+				cloudService.setVersion(getEntityAttribute(serviceResource, "version", String.class));
+			}
 		}
 		return cloudService;
 	}


### PR DESCRIPTION
@ramnivas The "pragmatic" approach ended up being easier than we discussed. Credentials for user-provided service instances should not be part of the object model, since credentials for system-provisioned services are not returned in the object model. So user-provided credentials are provided only to the `createUserProvidedService()` method. Just some changes to the REST response mapping code and a small helper in the model. 
