### PR TITLE
Modify two input value for function "parse".

### DIFF
--- a/cloudfoundry-client-lib/src/main/java/org/cloudfoundry/client/lib/domain/InstanceStats.java
+++ b/cloudfoundry-client-lib/src/main/java/org/cloudfoundry/client/lib/domain/InstanceStats.java
@@ -38,7 +38,7 @@ public class InstanceStats {
 			this.time = parseDate(parse(String.class, attributes.get("time")));
 			this.cpu = parse(Double.class, attributes.get("cpu"));
 			this.disk = parse(Integer.class, attributes.get("disk"));
-			this.mem = parse(Double.class, attributes.get("mem"));
+			this.mem = parse(Integer.class, attributes.get("mem"));
 		}
 
 		public double getCpu() {
@@ -94,7 +94,7 @@ public class InstanceStats {
 			}
 			this.fdsQuota = parse(Integer.class, stats.get("fds_quota"));
 			this.host = parse(String.class, stats.get("host"));
-			this.uptime = parse(Double.class, stats.get("uptime"));
+			this.uptime = parse(Integer.class, stats.get("uptime"));
 		}
 	}
 


### PR DESCRIPTION
Hi, our project tends to write a cf monitoring to get some attributes by calling vcap Java API. We find a bug that when using function "parse" to get "mem" value, the result is empty if the attribute type is Double.class. The reason is that "mem"'s type is Integer, so I fixed this point to from "Double.class" to "Integer.class". The same bug also occurs for "uptime". Please check and review. 
