### PR TITLE
Support not sending memory so that Cloud Controller default can be used.

### DIFF
--- a/cloudfoundry-client-lib/src/main/java/org/cloudfoundry/client/lib/CloudFoundryClient.java
+++ b/cloudfoundry-client-lib/src/main/java/org/cloudfoundry/client/lib/CloudFoundryClient.java
@@ -173,7 +173,7 @@ public class CloudFoundryClient implements CloudFoundryOperations {
 		return cc.getApplicationMemoryChoices();
 	}
 
-	public void createApplication(String appName, Staging staging, int memory, List<String> uris,
+	public void createApplication(String appName, Staging staging, Integer memory, List<String> uris,
 								  List<String> serviceNames) {
 		cc.createApplication(appName, staging, memory, uris, serviceNames);
 	}

--- a/cloudfoundry-client-lib/src/main/java/org/cloudfoundry/client/lib/CloudFoundryOperations.java
+++ b/cloudfoundry-client-lib/src/main/java/org/cloudfoundry/client/lib/CloudFoundryOperations.java
@@ -164,7 +164,7 @@ public interface CloudFoundryOperations {
 	 * @param uris list of URIs for the app
 	 * @param serviceNames list of service names to bind to app
 	 */
-	void createApplication(String appName, Staging staging, int memory, List<String> uris,
+	void createApplication(String appName, Staging staging, Integer memory, List<String> uris,
                            List<String> serviceNames);
 
 

--- a/cloudfoundry-client-lib/src/main/java/org/cloudfoundry/client/lib/rest/CloudControllerClient.java
+++ b/cloudfoundry-client-lib/src/main/java/org/cloudfoundry/client/lib/rest/CloudControllerClient.java
@@ -103,7 +103,7 @@ public interface CloudControllerClient {
 
 	int[] getApplicationMemoryChoices();
 
-	void createApplication(String appName, Staging staging, int memory, List<String> uris,
+	void createApplication(String appName, Staging staging, Integer memory, List<String> uris,
                            List<String> serviceNames);
 
 	void uploadApplication(String appName, File file, UploadStatusCallback callback) throws IOException;

--- a/cloudfoundry-client-lib/src/main/java/org/cloudfoundry/client/lib/rest/CloudControllerClientImpl.java
+++ b/cloudfoundry-client-lib/src/main/java/org/cloudfoundry/client/lib/rest/CloudControllerClientImpl.java
@@ -860,7 +860,7 @@ public class CloudControllerClientImpl implements CloudControllerClient {
 		return JsonUtil.convertJsonToMap(resp);
 	}
 
-	public void createApplication(String appName, Staging staging, int memory, List<String> uris,
+	public void createApplication(String appName, Staging staging, Integer memory, List<String> uris,
 	                              List<String> serviceNames) {
 		HashMap<String, Object> appRequest = new HashMap<String, Object>();
 		appRequest.put("space_guid", sessionSpace.getMeta().getGuid());

--- a/cloudfoundry-maven-plugin/README.md
+++ b/cloudfoundry-maven-plugin/README.md
@@ -240,7 +240,7 @@ Additional certain configuration parameter will fall back to using default value
 + **appname**: If no app name is specified, the Maven artifact id is being used
 + **instances**: Defaults to *1*
 + **no-start**: Defaults to *false*
-+ **memory**: Defaults to *512* (MB)
++ **memory**: Defaults to Cloud Controller value
 + **path**: Defaults to *${project.build.directory}/${project.build.finalName}.war*
 + **server**: Special parameter to tell **Maven** which server element in `settings.xml`
   holds the credentials for Cloud Foundry. Defaults to *cloud-foundry-credentials*

--- a/cloudfoundry-maven-plugin/src/main/java/org/cloudfoundry/maven/AbstractApplicationAwareCloudFoundryMojo.java
+++ b/cloudfoundry-maven-plugin/src/main/java/org/cloudfoundry/maven/AbstractApplicationAwareCloudFoundryMojo.java
@@ -297,7 +297,8 @@ abstract class AbstractApplicationAwareCloudFoundryMojo extends AbstractCloudFou
 	 * that value is used). If not the pom.xml configuration parameter is used,
 	 * if available.
 	 *
-	 * If the value is not defined, 512 (MB) is returned as default.
+	 * If the value is not defined, null is returned.  Triggering an empty value
+	 * to be sent to the Cloud Controller where its default will be used.
 	 *
 	 * @return Returns the configured memory choice
 	 */
@@ -309,12 +310,7 @@ abstract class AbstractApplicationAwareCloudFoundryMojo extends AbstractCloudFou
 			return Integer.valueOf(urlProperty);
 		}
 
-		if (this.memory == null) {
-			return DefaultConstants.MEMORY;
-		} else {
-			return this.memory;
-		}
-
+		return this.memory;
 	}
 
 	/**

--- a/cloudfoundry-maven-plugin/src/main/java/org/cloudfoundry/maven/AbstractPush.java
+++ b/cloudfoundry-maven-plugin/src/main/java/org/cloudfoundry/maven/AbstractPush.java
@@ -58,7 +58,9 @@ public class AbstractPush extends AbstractApplicationAwareCloudFoundryMojo {
 		final List<String> uris = getAllUris();
 		final List<String> serviceNames = getServiceNames();
 
-		validateMemoryChoice(getClient(), memory);
+		if(memory != null) {
+			validateMemoryChoice(getClient(), memory);
+		}
 		validatePath(path);
 
 		addDomains();
@@ -148,7 +150,9 @@ public class AbstractPush extends AbstractApplicationAwareCloudFoundryMojo {
 			} else {
 				client.stopApplication(appname);
 				client.updateApplicationStaging(appname, staging);
-				client.updateApplicationMemory(appname, memory);
+				if(memory != null) {
+					client.updateApplicationMemory(appname, memory);
+				}
 				client.updateApplicationUris(appname, uris);
 				client.updateApplicationServices(appname, serviceNames);
 			}

--- a/cloudfoundry-maven-plugin/src/main/java/org/cloudfoundry/maven/common/DefaultConstants.java
+++ b/cloudfoundry-maven-plugin/src/main/java/org/cloudfoundry/maven/common/DefaultConstants.java
@@ -32,7 +32,6 @@ package org.cloudfoundry.maven.common;
 public final class DefaultConstants {
 
 	public static final String MAVEN_DEFAULT_SERVER = "cloud-foundry-credentials";
-	public static final Integer MEMORY = 512;
 	public static final Boolean NO_START = Boolean.FALSE;
 	public static final Integer DEFAULT_INSTANCE = 1;
 

--- a/cloudfoundry-maven-plugin/src/test/java/org/cloudfoundry/maven/CheckDefaultParametersMojosTest.java
+++ b/cloudfoundry-maven-plugin/src/test/java/org/cloudfoundry/maven/CheckDefaultParametersMojosTest.java
@@ -60,7 +60,7 @@ public class CheckDefaultParametersMojosTest extends AbstractMojoTestCase {
 		doReturn(null).when(mojo).getCommandlineProperty(any(SystemProperties.class));
 
 		assertEquals("cf-maven-tests", mojo.getAppname());
-		assertEquals(Integer.valueOf(512), mojo.getMemory());
+		assertNull(mojo.getMemory());
 		assertNull("Password by default is null.", mojo.getPassword());
 		assertEquals("cloud-foundry-credentials", mojo.getServer());
 		assertTrue(mojo.getServices().isEmpty());


### PR DESCRIPTION
Also this PR won't change current memory setting for application previously
scaled to a different value.

This PR fixes https://github.com/cloudfoundry/cf-java-client/issues/117.

I didn't patch the Gradle plugin because of lack of experience in that space.  But the Client changes should work for both and be backwards compatible.
