### PR TITLE
Support domain only routes without having to prefix the url with a .

### DIFF
--- a/cloudfoundry-client-lib/src/main/java/org/cloudfoundry/client/lib/rest/CloudControllerClientImpl.java
+++ b/cloudfoundry-client-lib/src/main/java/org/cloudfoundry/client/lib/rest/CloudControllerClientImpl.java
@@ -951,7 +951,9 @@ public class CloudControllerClientImpl implements CloudControllerClient {
                     uriInfo.put("domainName", domain);
                     if (domain.length() < authority.length()) {
                         uriInfo.put("host", authority.substring(0, authority.indexOf(domain) - 1));
-                    }
+                    } else if (domain.length() == authority.length()) {
+                        uriInfo.put("host", "");
+                    } 
                 }
 			}
 		}
@@ -1254,8 +1256,8 @@ public class CloudControllerClientImpl implements CloudControllerClient {
 		newUris.removeAll(app.getUris());
 		List<String> removeUris = app.getUris();
 		removeUris.removeAll(uris);
-		addUris(newUris, app.getMeta().getGuid());
 		removeUris(removeUris, app.getMeta().getGuid());
+		addUris(newUris, app.getMeta().getGuid());
 	}
 
 	public void updateApplicationEnv(String appName, Map<String, String> env) {


### PR DESCRIPTION
Also reversed remove/add route order since it is possible for `.joe.com`
to be the same route as `joe.com` but different urls.  By removing
before adding we don't run into a case where the application
accidentally has no routes because equal routes don't have the same
url.

Mike
