### PR TITLE
Fixed building of app URIs with a domain only.

### DIFF
--- a/cloudfoundry-client-lib/src/main/java/org/cloudfoundry/client/lib/rest/CloudControllerClientImpl.java
+++ b/cloudfoundry-client-lib/src/main/java/org/cloudfoundry/client/lib/rest/CloudControllerClientImpl.java
@@ -1651,16 +1651,19 @@ public class CloudControllerClientImpl implements CloudControllerClient {
 	}
 
 	private List<String> findApplicationUris(UUID appGuid) {
-		Map<String, Object> urlVars = new HashMap<String, Object>();
 		String urlPath = "/v2/apps/{app}/routes?inline-relations-depth=1";
+		Map<String, Object> urlVars = new HashMap<String, Object>();
 		urlVars.put("app", appGuid);
 		List<Map<String, Object>> resourceList = getAllResources(urlPath, urlVars);
 		List<String> uris =  new ArrayList<String>();
 		for (Map<String, Object> resource : resourceList) {
 			Map<String, Object> domainResource = CloudEntityResourceMapper.getEmbeddedResource(resource, "domain");
-			String uri = CloudEntityResourceMapper.getEntityAttribute(resource, "host", String.class) + "." +
-					CloudEntityResourceMapper.getEntityAttribute(domainResource, "name", String.class);
-			uris.add(uri);
+			String host = CloudEntityResourceMapper.getEntityAttribute(resource, "host", String.class);
+			String domain = CloudEntityResourceMapper.getEntityAttribute(domainResource, "name", String.class);
+			if (host != null && host.length() > 0)
+				uris.add(host + "." + domain);
+			else
+				uris.add(domain);
 		}
 		return uris;
 	}

--- a/cloudfoundry-client-lib/src/test/java/org/cloudfoundry/client/lib/CloudFoundryClientTest.java
+++ b/cloudfoundry-client-lib/src/test/java/org/cloudfoundry/client/lib/CloudFoundryClientTest.java
@@ -352,9 +352,8 @@ public class CloudFoundryClientTest {
 
 	@Test
 	public void createApplication() {
-		List<String> uris = new ArrayList<String>();
 		String appName = namespacedAppName("travel_test-0");
-		uris.add(computeAppUrl(appName));
+		List<String> uris = Arrays.asList(computeAppUrl(appName));
 		Staging staging =  new Staging();
 		connectedClient.createApplication(appName, staging, DEFAULT_MEMORY, uris, null);
 		CloudApplication app = connectedClient.getApplication(appName);
@@ -406,6 +405,24 @@ public class CloudFoundryClientTest {
 		assertEquals(CloudApplication.AppState.STOPPED, app.getState());
 
 		assertEquals(2, app.getStaging().getHealthCheckTimeout().intValue());
+	}
+
+	@Test
+	public void createApplicationWithDomainOnly() {
+		String appName = namespacedAppName("travel_test-tld");
+
+		connectedClient.addDomain(TEST_DOMAIN);
+		List<String> uris = Arrays.asList(TEST_DOMAIN);
+
+		Staging staging =  new Staging();
+		connectedClient.createApplication(appName, staging, DEFAULT_MEMORY, uris, null);
+		CloudApplication app = connectedClient.getApplication(appName);
+		assertNotNull(app);
+		assertEquals(appName, app.getName());
+
+		List<String> actualUris = app.getUris();
+		assertTrue(actualUris.size() == 1);
+		assertEquals(TEST_DOMAIN, actualUris.get(0));
 	}
 
 	@Test


### PR DESCRIPTION
This is a follow-up to the merged PR that allows a route to be set for an app that contains only the domain part, without a host. Building of URIs on getApplication(s) was adding a "." to the front of the domain when a host was not included. Also added a test to verify the correct behavior.
