### PR TITLE
Add support for self-signed SSL certificates in API and plugins.

### DIFF
--- a/cloudfoundry-client-lib/src/main/java/org/cloudfoundry/client/lib/CloudFoundryClient.java
+++ b/cloudfoundry-client-lib/src/main/java/org/cloudfoundry/client/lib/CloudFoundryClient.java
@@ -63,47 +63,96 @@ public class CloudFoundryClient implements CloudFoundryOperations {
 	/**
 	 * Construct client for anonymous user. Useful only to get to the '/info' endpoint.
 	 */
+
 	public CloudFoundryClient(URL cloudControllerUrl) {
-		this(null, cloudControllerUrl);
+		this(null, cloudControllerUrl, null, (HttpProxyConfiguration) null, false);
 	}
 
-	public CloudFoundryClient(CloudCredentials credentials, URL cloudControllerUrl) {
-		this(credentials, cloudControllerUrl, (CloudSpace)null);
+	public CloudFoundryClient(URL cloudControllerUrl, boolean trustSelfSignedCerts) {
+		this(null, cloudControllerUrl, null, (HttpProxyConfiguration) null, trustSelfSignedCerts);
 	}
 
-	public CloudFoundryClient(CloudCredentials credentials, URL cloudControllerUrl, CloudSpace sessionSpace) {
-		this(credentials, cloudControllerUrl, sessionSpace, null);
-    }
+	public CloudFoundryClient(URL cloudControllerUrl, HttpProxyConfiguration httpProxyConfiguration) {
+		this(null, cloudControllerUrl, null, httpProxyConfiguration, false);
+	}
 
-	public CloudFoundryClient(CloudCredentials credentials, URL cloudControllerUrl, String orgName, String spaceName) {
-		this(credentials, cloudControllerUrl, orgName, spaceName, null);
-    }
+	public CloudFoundryClient(URL cloudControllerUrl, HttpProxyConfiguration httpProxyConfiguration,
+	                          boolean trustSelfSignedCerts) {
+		this(null, cloudControllerUrl, null, httpProxyConfiguration, trustSelfSignedCerts);
+	}
 
 	/**
-	 * Constructors to use with an http proxy configuration.
+	 * Construct client without a default org and space.
 	 */
-	public CloudFoundryClient(URL cloudControllerUrl, HttpProxyConfiguration httpProxyConfiguration) {
-		this(null, cloudControllerUrl, httpProxyConfiguration);
+
+	public CloudFoundryClient(CloudCredentials credentials, URL cloudControllerUrl) {
+		this(credentials, cloudControllerUrl, null, (HttpProxyConfiguration) null, false);
 	}
 
 	public CloudFoundryClient(CloudCredentials credentials, URL cloudControllerUrl,
-							  HttpProxyConfiguration httpProxyConfiguration) {
-		this(credentials, cloudControllerUrl, null, httpProxyConfiguration);
+	                          boolean trustSelfSignedCerts) {
+		this(credentials, cloudControllerUrl, null, (HttpProxyConfiguration) null, trustSelfSignedCerts);
 	}
 
 	public CloudFoundryClient(CloudCredentials credentials, URL cloudControllerUrl,
-							  CloudSpace sessionSpace, HttpProxyConfiguration httpProxyConfiguration) {
-		Assert.notNull(cloudControllerUrl, "URL for cloud controller cannot be null");
-		CloudControllerClientFactory cloudControllerClientFactory =
-				new CloudControllerClientFactory(new RestUtil(), httpProxyConfiguration);
-		this.cc = cloudControllerClientFactory.newCloudController(cloudControllerUrl, credentials, sessionSpace);
+	                          HttpProxyConfiguration httpProxyConfiguration) {
+		this(credentials, cloudControllerUrl, null, httpProxyConfiguration, false);
+	}
+
+	public CloudFoundryClient(CloudCredentials credentials, URL cloudControllerUrl,
+	                          HttpProxyConfiguration httpProxyConfiguration, boolean trustSelfSignedCerts) {
+		this(credentials, cloudControllerUrl, null, httpProxyConfiguration, trustSelfSignedCerts);
+	}
+
+	/**
+	 * Construct a client with a default CloudSpace.
+	 */
+
+	public CloudFoundryClient(CloudCredentials credentials, URL cloudControllerUrl, CloudSpace sessionSpace) {
+		this(credentials, cloudControllerUrl, sessionSpace, null, false);
     }
 
-	public CloudFoundryClient(CloudCredentials credentials, URL cloudControllerUrl,
-							  String orgName, String spaceName, HttpProxyConfiguration httpProxyConfiguration) {
+	public CloudFoundryClient(CloudCredentials credentials, URL cloudControllerUrl, CloudSpace sessionSpace,
+	                          boolean trustSelfSignedCerts) {
+		this(credentials, cloudControllerUrl, sessionSpace, null, trustSelfSignedCerts);
+	}
+
+	public CloudFoundryClient(CloudCredentials credentials, URL cloudControllerUrl, CloudSpace sessionSpace,
+	                          HttpProxyConfiguration httpProxyConfiguration) {
+		this(credentials, cloudControllerUrl, sessionSpace, httpProxyConfiguration, false);
+	}
+
+	public CloudFoundryClient(CloudCredentials credentials, URL cloudControllerUrl, CloudSpace sessionSpace,
+	                          HttpProxyConfiguration httpProxyConfiguration, boolean trustSelfSignedCerts) {
 		Assert.notNull(cloudControllerUrl, "URL for cloud controller cannot be null");
 		CloudControllerClientFactory cloudControllerClientFactory =
-				new CloudControllerClientFactory(new RestUtil(), httpProxyConfiguration);
+				new CloudControllerClientFactory(httpProxyConfiguration, trustSelfSignedCerts);
+		this.cc = cloudControllerClientFactory.newCloudController(cloudControllerUrl, credentials, sessionSpace);
+	}
+
+	/**
+	 * Construct a client with a default space name and org name.
+	 */
+
+	public CloudFoundryClient(CloudCredentials credentials, URL cloudControllerUrl, String orgName, String spaceName) {
+		this(credentials, cloudControllerUrl, orgName, spaceName, null, false);
+	}
+
+	public CloudFoundryClient(CloudCredentials credentials, URL cloudControllerUrl, String orgName, String spaceName,
+	                          boolean trustSelfSignedCerts) {
+		this(credentials, cloudControllerUrl, orgName, spaceName, null, trustSelfSignedCerts);
+	}
+
+	public CloudFoundryClient(CloudCredentials credentials, URL cloudControllerUrl, String orgName, String spaceName,
+							  HttpProxyConfiguration httpProxyConfiguration) {
+		this(credentials, cloudControllerUrl, orgName, spaceName, httpProxyConfiguration, false);
+	}
+
+	public CloudFoundryClient(CloudCredentials credentials, URL cloudControllerUrl, String orgName, String spaceName,
+	                          HttpProxyConfiguration httpProxyConfiguration, boolean trustSelfSignedCerts) {
+		Assert.notNull(cloudControllerUrl, "URL for cloud controller cannot be null");
+		CloudControllerClientFactory cloudControllerClientFactory =
+				new CloudControllerClientFactory(httpProxyConfiguration, trustSelfSignedCerts);
 		this.cc = cloudControllerClientFactory.newCloudController(cloudControllerUrl, credentials, orgName, spaceName);
 	}
 
@@ -392,10 +441,6 @@ public class CloudFoundryClient implements CloudFoundryOperations {
 
 	public void deleteRoute(String host, String domainName) {
 		cc.deleteRoute(host, domainName);
-	}
-
-	public void updateHttpProxyConfiguration(HttpProxyConfiguration httpProxyConfiguration) {
-		cc.updateHttpProxyConfiguration(httpProxyConfiguration);
 	}
 
 	public void registerRestLogListener(RestLogCallback callBack) {

--- a/cloudfoundry-client-lib/src/main/java/org/cloudfoundry/client/lib/CloudFoundryOperations.java
+++ b/cloudfoundry-client-lib/src/main/java/org/cloudfoundry/client/lib/CloudFoundryOperations.java
@@ -595,13 +595,6 @@ public interface CloudFoundryOperations {
 	void deleteRoute(String host, String domainName);
 
 	/**
-	 * Update http proxy configuration settings.
-	 *
-	 * @param httpProxyConfiguration the new configuration settings
-	 */
-	void updateHttpProxyConfiguration(HttpProxyConfiguration httpProxyConfiguration);
-
-	/**
 	 * Register a new RestLogCallback
 	 *
 	 * @param callBack the callback to be registered

--- a/cloudfoundry-client-lib/src/main/java/org/cloudfoundry/client/lib/rest/CloudControllerClient.java
+++ b/cloudfoundry-client-lib/src/main/java/org/cloudfoundry/client/lib/rest/CloudControllerClient.java
@@ -188,8 +188,6 @@ public interface CloudControllerClient {
 
 	// Misc. utility methods
 
-	void updateHttpProxyConfiguration(HttpProxyConfiguration httpProxyConfiguration);
-
 	void registerRestLogListener(RestLogCallback callBack);
 
 	void unRegisterRestLogListener(RestLogCallback callBack);

--- a/cloudfoundry-client-lib/src/main/java/org/cloudfoundry/client/lib/util/JsonUtil.java
+++ b/cloudfoundry-client-lib/src/main/java/org/cloudfoundry/client/lib/util/JsonUtil.java
@@ -22,8 +22,10 @@ import org.apache.commons.logging.LogFactory;
 import org.cloudfoundry.client.lib.domain.CloudResource;
 import org.codehaus.jackson.map.ObjectMapper;
 import org.codehaus.jackson.type.TypeReference;
+import org.springframework.http.MediaType;
 
 import java.io.IOException;
+import java.nio.charset.Charset;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
@@ -40,6 +42,11 @@ public class JsonUtil {
 	protected static final Log logger = LogFactory.getLog(JsonUtil.class);
 
 	private final static ObjectMapper mapper = new ObjectMapper();
+
+	public static final MediaType JSON_MEDIA_TYPE = new MediaType(
+			MediaType.APPLICATION_JSON.getType(),
+			MediaType.APPLICATION_JSON.getSubtype(),
+			Charset.forName("UTF-8"));
 
 	public static Map<String, Object> convertJsonToMap(String json) {
 		Map<String, Object> retMap = new HashMap<String, Object>();

--- a/cloudfoundry-client-lib/src/main/java/org/cloudfoundry/client/lib/util/RestUtil.java
+++ b/cloudfoundry-client-lib/src/main/java/org/cloudfoundry/client/lib/util/RestUtil.java
@@ -1,15 +1,33 @@
 package org.cloudfoundry.client.lib.util;
 
+import static org.apache.http.conn.ssl.SSLSocketFactory.STRICT_HOSTNAME_VERIFIER;
+
 import org.apache.http.HttpHost;
+import org.apache.http.client.HttpClient;
 import org.apache.http.conn.params.ConnRoutePNames;
+import org.apache.http.conn.scheme.Scheme;
+import org.apache.http.conn.ssl.SSLSocketFactory;
+import org.apache.http.conn.ssl.TrustSelfSignedStrategy;
 import org.cloudfoundry.client.lib.HttpProxyConfiguration;
 import org.cloudfoundry.client.lib.oauth2.OauthClient;
+import org.cloudfoundry.client.lib.rest.CloudControllerClientImpl;
+import org.cloudfoundry.client.lib.rest.CloudControllerResponseErrorHandler;
 import org.cloudfoundry.client.lib.rest.LoggingRestTemplate;
 import org.springframework.http.client.ClientHttpRequestFactory;
 import org.springframework.http.client.HttpComponentsClientHttpRequestFactory;
+import org.springframework.http.converter.ByteArrayHttpMessageConverter;
+import org.springframework.http.converter.FormHttpMessageConverter;
+import org.springframework.http.converter.HttpMessageConverter;
+import org.springframework.http.converter.ResourceHttpMessageConverter;
+import org.springframework.http.converter.StringHttpMessageConverter;
+import org.springframework.http.converter.json.MappingJacksonHttpMessageConverter;
 import org.springframework.web.client.RestTemplate;
 
 import java.net.URL;
+import java.security.GeneralSecurityException;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
 
 /**
  * Some helper utilities for creating classes used for the REST support.
@@ -18,22 +36,69 @@ import java.net.URL;
  */
 public class RestUtil {
 
-	public RestTemplate createRestTemplate(HttpProxyConfiguration httpProxyConfiguration) {
+	public RestTemplate createRestTemplate(HttpProxyConfiguration httpProxyConfiguration, boolean trustSelfSignedCerts) {
 		RestTemplate restTemplate = new LoggingRestTemplate();
-		restTemplate.setRequestFactory(createRequestFactory(httpProxyConfiguration));
+		restTemplate.setRequestFactory(createRequestFactory(httpProxyConfiguration, trustSelfSignedCerts));
+		restTemplate.setErrorHandler(new CloudControllerResponseErrorHandler());
+		restTemplate.setMessageConverters(getHttpMessageConverters());
+
 		return restTemplate;
 	}
 
-	public ClientHttpRequestFactory createRequestFactory(HttpProxyConfiguration httpProxyConfiguration) {
+	public ClientHttpRequestFactory createRequestFactory(HttpProxyConfiguration httpProxyConfiguration, boolean trustSelfSignedCerts) {
 		HttpComponentsClientHttpRequestFactory requestFactory = new HttpComponentsClientHttpRequestFactory();
+		HttpClient httpClient = requestFactory.getHttpClient();
+
+		if (trustSelfSignedCerts) {
+			registerSslSocketFactory(httpClient);
+		}
+
 		if (httpProxyConfiguration != null) {
 			HttpHost proxy = new HttpHost(httpProxyConfiguration.getProxyHost(), httpProxyConfiguration.getProxyPort());
-			requestFactory.getHttpClient().getParams().setParameter(ConnRoutePNames.DEFAULT_PROXY, proxy);
+			httpClient.getParams().setParameter(ConnRoutePNames.DEFAULT_PROXY, proxy);
 		}
+
 		return requestFactory;
 	}
 
-	public OauthClient createOauthClient(URL authorizationUrl, HttpProxyConfiguration httpProxyConfiguration) {
-		return new OauthClient(authorizationUrl, createRestTemplate(httpProxyConfiguration));
+	public OauthClient createOauthClient(URL authorizationUrl, HttpProxyConfiguration httpProxyConfiguration, boolean trustSelfSignedCerts) {
+		return new OauthClient(authorizationUrl, createRestTemplate(httpProxyConfiguration, trustSelfSignedCerts));
+	}
+
+	private void registerSslSocketFactory(HttpClient httpClient)  {
+		try {
+			SSLSocketFactory socketFactory = new SSLSocketFactory(new TrustSelfSignedStrategy(), STRICT_HOSTNAME_VERIFIER);
+			httpClient.getConnectionManager().getSchemeRegistry().register(new Scheme("https", 443, socketFactory));
+		} catch (GeneralSecurityException gse) {
+			throw new RuntimeException("An error occurred setting up the SSLSocketFactory", gse);
+		}
+	}
+
+	private List<HttpMessageConverter<?>> getHttpMessageConverters() {
+		List<HttpMessageConverter<?>> messageConverters = new ArrayList<HttpMessageConverter<?>>();
+		messageConverters.add(new ByteArrayHttpMessageConverter());
+		messageConverters.add(new StringHttpMessageConverter());
+		messageConverters.add(new ResourceHttpMessageConverter());
+		messageConverters.add(new UploadApplicationPayloadHttpMessageConverter());
+		messageConverters.add(getFormHttpMessageConverter());
+		messageConverters.add(new MappingJacksonHttpMessageConverter());
+		return messageConverters;
+	}
+
+	private FormHttpMessageConverter getFormHttpMessageConverter() {
+		FormHttpMessageConverter formPartsMessageConverter = new CloudControllerClientImpl.CloudFoundryFormHttpMessageConverter();
+		formPartsMessageConverter.setPartConverters(getFormPartsMessageConverters());
+		return formPartsMessageConverter;
+	}
+
+	private List<HttpMessageConverter<?>> getFormPartsMessageConverters() {
+		List<HttpMessageConverter<?>> partConverters = new ArrayList<HttpMessageConverter<?>>();
+		StringHttpMessageConverter stringConverter = new StringHttpMessageConverter();
+		stringConverter.setSupportedMediaTypes(Collections.singletonList(JsonUtil.JSON_MEDIA_TYPE));
+		stringConverter.setWriteAcceptCharset(false);
+		partConverters.add(stringConverter);
+		partConverters.add(new ResourceHttpMessageConverter());
+		partConverters.add(new UploadApplicationPayloadHttpMessageConverter());
+		return partConverters;
 	}
 }

--- a/cloudfoundry-gradle-plugin/src/main/groovy/org/cloudfoundry/gradle/CloudFoundryExtension.groovy
+++ b/cloudfoundry-gradle-plugin/src/main/groovy/org/cloudfoundry/gradle/CloudFoundryExtension.groovy
@@ -55,6 +55,7 @@ class CloudFoundryExtension {
     Integer appStartupTimeout
 
     boolean useSystemProxy = true
+    boolean trustSelfSignedCerts = false;
 
     CloudFoundryExtension(Project project) {
         application = project.name

--- a/cloudfoundry-gradle-plugin/src/main/groovy/org/cloudfoundry/gradle/tasks/AbstractCloudFoundryTask.groovy
+++ b/cloudfoundry-gradle-plugin/src/main/groovy/org/cloudfoundry/gradle/tasks/AbstractCloudFoundryTask.groovy
@@ -133,7 +133,7 @@ abstract class AbstractCloudFoundryTask extends DefaultTask {
     private CloudFoundryClient createClient(CloudCredentials credentials) {
         HttpProxyConfiguration proxyConfiguration = getHttpProxyConfiguration()
         URL targetUrl = target.toURL()
-        new CloudFoundryClient(credentials, targetUrl, organization, space, proxyConfiguration)
+        new CloudFoundryClient(credentials, targetUrl, organization, space, proxyConfiguration, trustSelfSignedCerts)
     }
 
     private HttpProxyConfiguration getHttpProxyConfiguration() {
@@ -326,6 +326,10 @@ abstract class AbstractCloudFoundryTask extends DefaultTask {
 
     boolean getUseSystemProxy() {
         propertyOrExtension('useSystemProxy')
+    }
+
+    boolean getTrustSelfSignedCerts() {
+        propertyOrExtension('trustSelfSignedCerts')
     }
 
     def getServiceInfos() {

--- a/cloudfoundry-maven-plugin/src/main/java/org/cloudfoundry/maven/Target.java
+++ b/cloudfoundry-maven-plugin/src/main/java/org/cloudfoundry/maven/Target.java
@@ -44,37 +44,9 @@ import org.cloudfoundry.maven.common.UiUtils;
  */
 public class Target extends AbstractCloudFoundryMojo {
 
-	/**
-	 * 	@FIXME Not sure whether one should be able to overwrite execute()
-	 *
-	 */
-	@Override
-	public void execute() throws MojoExecutionException, MojoFailureException {
-		final URI target = getTarget();
-		Assert.configurationNotNull(target, "target", SystemProperties.TARGET);
-
-		try {
-			client = new CloudFoundryClient(getTarget().toURL());
-			doExecute();
-		} catch (MalformedURLException e) {
-			throw new MojoExecutionException(
-					String.format("Incorrect Cloud Foundry target url, are you sure '%s' is correct? Make sure the url contains a scheme, e.g. http://... ", target), e);
-		}
-	}
-
 	@Override
 	protected void doExecute() throws MojoExecutionException {
-
-		CloudFoundryClient newClient;
-
-		if (getUsername() != null && getPassword() != null) {
-			newClient = createCloudFoundryClient(getUsername(), getPassword(), getTarget(), getOrg(), getSpace());
-		} else {
-			newClient = createCloudFoundryClient(retrieveToken(), getTarget(), getOrg(), getSpace());
-		}
-
-		final CloudInfo cloudInfo = newClient.getCloudInfo();
-
+		final CloudInfo cloudInfo = getClient().getCloudInfo();
 		getLog().info(UiUtils.renderCloudInfoFormattedAsString(cloudInfo, getTarget().toString(), getOrg(), getSpace()));
 	}
 }


### PR DESCRIPTION
Adds the ability for users of the Java API specify that self-signed SSL certificates issued by the same domain as the Cloud Controller endpoint should be accepted. 

This includes some refactoring to isolate the responsibility of setting up the `RestTemplate` and `OauthClient` used by the API to one class, as well as determining the authorization endpoint. These responsibilities were spread across multiple classes. 

The `updateHttpProxyConfiguration` method was removed, as it was complicating the responsibility of setting up RestTemplate and it should not be necessary to change the basic characteristics of the connection once it is established. 

Configuration parameters named `trustSelfSignedCerts` were added to the Maven and Gradle plugins to enable this feature in the plugins. 
