### PR TITLE
Fixed bug in determining authorization endpoint introduced in a prior refactoring.

### DIFF
--- a/cloudfoundry-client-lib/src/main/java/org/cloudfoundry/client/lib/rest/CloudControllerClientFactory.java
+++ b/cloudfoundry-client-lib/src/main/java/org/cloudfoundry/client/lib/rest/CloudControllerClientFactory.java
@@ -97,12 +97,7 @@ public class CloudControllerClientFactory {
 		String authEndPoint = (String) infoMap.get("authorization_endpoint");
 
 		try {
-			URL authEndPointUrl = new URL(authEndPoint);
-			if (cloudControllerUrl.getProtocol().equals("http") && authEndPointUrl.getProtocol().equals("https")) {
-				return new URL("http", authEndPointUrl.getHost(), authEndPointUrl.getPort(), authEndPointUrl.getFile());
-			} else {
-				return authEndPointUrl;
-			}
+			return new URL(authEndPoint);
 		} catch (MalformedURLException e) {
 			throw new IllegalArgumentException("Error creating auth endpoint URL for endpoint " + authEndPoint, e);
 		}


### PR DESCRIPTION
Some code was moved in the previous refactoring. It turns out the code was dead in the previous location but became active after being moved, and the code should not run. 

Here is the code in its previous location: 
https://github.com/cloudfoundry/cf-java-client/blob/17c3589dd3b4f3bd1537aba2abec7fec62015152/cloudfoundry-client-lib/src/main/java/org/cloudfoundry/client/lib/rest/CloudControllerClientImpl.java#L191-L195. 

The value returned from `determineAuthorizationEndPointToUse` was saved in a class field, but the field was never used. The parameter with the same name as the assigned field is used further down in the method. Sneaky. 
