### PR TITLE
Fix environment variable casting issue.

### DIFF
--- a/cloudfoundry-client-lib/src/main/java/org/cloudfoundry/client/lib/domain/CloudApplication.java
+++ b/cloudfoundry-client-lib/src/main/java/org/cloudfoundry/client/lib/domain/CloudApplication.java
@@ -202,7 +202,7 @@ public class CloudApplication extends CloudEntity {
 	public void setEnv(Map<String, String> env) {
 		List<String> joined = new ArrayList<String>();
 		for (Map.Entry<String, String> entry : env.entrySet()) {
-			joined.add(entry.getKey() + '=' + entry.getValue());
+			joined.add(entry.getKey() + '=' + String.valueOf(entry.getValue()));
 		}
 		this.env = joined;
 	}


### PR DESCRIPTION
...tring fails.  Adding String.valueOf(value) to safely get string value without casting issue.
