### PR TITLE
fixed bug in the constructor of CloudServiceOffering + added unit tests

### DIFF
--- a/cloudfoundry-client-lib/src/main/java/org/cloudfoundry/client/lib/domain/CloudServiceOffering.java
+++ b/cloudfoundry-client-lib/src/main/java/org/cloudfoundry/client/lib/domain/CloudServiceOffering.java
@@ -55,6 +55,11 @@ public class CloudServiceOffering extends CloudEntity {
 		this.description = description;
 		this.active = active;
 		this.bindable = bindable;
+        this.url = url;
+        this.infoUrl = infoUrl;
+        this.uniqueId = uniqueId;
+        this.extra = extra;
+        this.docUrl = docUrl;
 	}
 
 	public String getLabel() {

--- a/cloudfoundry-client-lib/src/test/java/org/cloudfoundry/client/lib/domain/CloudServiceOfferingTest.java
+++ b/cloudfoundry-client-lib/src/test/java/org/cloudfoundry/client/lib/domain/CloudServiceOfferingTest.java
@@ -1,0 +1,114 @@
+////////////////////////////////////////////////////////////////////////////////
+
+package org.cloudfoundry.client.lib.domain;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+////////////////////////////////////////////////////////////////////////////////
+
+public class CloudServiceOfferingTest {
+    @Test
+    public void testConstructor0 () {
+        CloudServiceOffering offering = new CloudServiceOffering(
+            CloudEntity.Meta.defaultMeta(),
+            "<name>"
+        );
+
+        Assert.assertEquals("<name>", offering.getName());
+        Assert.assertEquals("<name>", offering.getLabel());
+        Assert.assertNull  (          offering.getDescription());
+        Assert.assertNull  (          offering.getProvider());
+        Assert.assertNull  (          offering.getVersion());
+        Assert.assertFalse (          offering.isActive());
+        Assert.assertFalse (          offering.isBindable());
+        Assert.assertNull  (          offering.getUrl());
+        Assert.assertNull  (          offering.getInfoUrl());
+        Assert.assertNull  (          offering.getUniqueId());
+        Assert.assertNull  (          offering.getExtra());
+        Assert.assertNull  (          offering.getDocumenationUrl());
+        Assert.assertTrue  (          offering.getCloudServicePlans().isEmpty());
+    }
+
+    @Test
+    public void testConstructor1 () {
+        CloudServiceOffering offering = new CloudServiceOffering(
+            CloudEntity.Meta.defaultMeta(),
+            "<name>",
+            "<provider>",
+            "<version>"
+        );
+
+        Assert.assertEquals("<name>",     offering.getName());
+        Assert.assertEquals("<name>",     offering.getLabel());
+        Assert.assertNull  (              offering.getDescription());
+        Assert.assertEquals("<provider>", offering.getProvider());
+        Assert.assertEquals("<version>", offering.getVersion());
+        Assert.assertFalse (              offering.isActive());
+        Assert.assertFalse (              offering.isBindable());
+        Assert.assertNull  (              offering.getUrl());
+        Assert.assertNull  (              offering.getInfoUrl());
+        Assert.assertNull  (              offering.getUniqueId());
+        Assert.assertNull  (              offering.getExtra());
+        Assert.assertNull  (              offering.getDocumenationUrl());
+        Assert.assertTrue  (              offering.getCloudServicePlans().isEmpty());
+    }
+
+    @Test
+    public void testConstructor2 () {
+        CloudServiceOffering offering = new CloudServiceOffering(
+            CloudEntity.Meta.defaultMeta(),
+            "<name>",
+            "<provider>",
+            "<version>",
+            "<description>",
+            true,
+            true,
+            "<url>",
+            "<infoUrl>",
+            "<uniqueId>",
+            "<extra>",
+            "<docUrl>"
+        );
+
+        Assert.assertEquals("<name>",        offering.getName());
+        Assert.assertEquals("<name>",        offering.getLabel());
+        Assert.assertEquals("<description>", offering.getDescription());
+        Assert.assertEquals("<provider>",    offering.getProvider());
+        Assert.assertEquals("<version>",     offering.getVersion());
+        Assert.assertTrue  (                 offering.isActive());
+        Assert.assertTrue  (                 offering.isBindable());
+        Assert.assertEquals("<url>",         offering.getUrl());
+        Assert.assertEquals("<infoUrl>",     offering.getInfoUrl());
+        Assert.assertEquals("<uniqueId>",    offering.getUniqueId());
+        Assert.assertEquals("<extra>",       offering.getExtra());
+        Assert.assertEquals("<docUrl>",      offering.getDocumenationUrl());
+        Assert.assertTrue  (                 offering.getCloudServicePlans().isEmpty());
+    }
+
+    ////////////////////////////////////////////////////////////////////////////
+
+    @Test
+    public void testAddCloudServicePlan () {
+        CloudServiceOffering offering = new CloudServiceOffering(
+            CloudEntity.Meta.defaultMeta(),
+            "<name>"
+        );
+
+        Assert.assertTrue(offering.getCloudServicePlans().isEmpty());
+
+        CloudServicePlan plan0 = new CloudServicePlan();
+        CloudServicePlan plan1 = new CloudServicePlan();
+        CloudServicePlan plan2 = new CloudServicePlan();
+        offering.addCloudServicePlan(plan0);
+        offering.addCloudServicePlan(plan1);
+        offering.addCloudServicePlan(plan2);
+
+        Assert.assertEquals(3,     offering.getCloudServicePlans().size());
+        Assert.assertEquals(plan0, offering.getCloudServicePlans().get(0));
+        Assert.assertEquals(plan1, offering.getCloudServicePlans().get(1));
+        Assert.assertEquals(plan2, offering.getCloudServicePlans().get(2));
+    }
+}
+
+////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
The constructor of CloudServiceOffering does not store some of the arguments passed into it (url, infoUrl, uniqueId, extra & docUrl).

The unit tests provided fail with the old constructor and pass with the new version.
