### PR TITLE
Use File.pathSeparator instead of platform-specific "/".

### DIFF
--- a/cloudfoundry-client-lib/src/main/java/org/cloudfoundry/client/lib/archive/DirectoryApplicationArchive.java
+++ b/cloudfoundry-client-lib/src/main/java/org/cloudfoundry/client/lib/archive/DirectoryApplicationArchive.java
@@ -73,8 +73,8 @@ public class DirectoryApplicationArchive implements ApplicationArchive {
         public EntryAdapter(File file) {
             this.file = file;
             this.name = file.getAbsolutePath().substring(directory.getAbsolutePath().length()+1);
-            if(isDirectory()) {
-                this.name = this.name + "/";
+            if (isDirectory()) {
+                this.name = this.name + File.separatorChar;
             }
         }
 


### PR DESCRIPTION
Likely fixes #37.
