### PR TITLE
Refactored token management into OauthClient.

### DIFF
--- a/cloudfoundry-client-lib/src/main/java/org/cloudfoundry/client/lib/CloudFoundryClient.java
+++ b/cloudfoundry-client-lib/src/main/java/org/cloudfoundry/client/lib/CloudFoundryClient.java
@@ -157,6 +157,13 @@ public class CloudFoundryClient implements CloudFoundryOperations {
 		this.cc = cloudControllerClientFactory.newCloudController(cloudControllerUrl, credentials, orgName, spaceName);
 	}
 
+	/**
+	 * Construct a client with a pre-configured CloudControllerClient
+	 */
+	public CloudFoundryClient(CloudControllerClient cc) {
+		this.cc = cc;
+	}
+
 	public void setResponseErrorHandler(ResponseErrorHandler errorHandler) {
 		cc.setResponseErrorHandler(errorHandler);
 	}

--- a/cloudfoundry-client-lib/src/main/java/org/cloudfoundry/client/lib/rest/CloudControllerClientFactory.java
+++ b/cloudfoundry-client-lib/src/main/java/org/cloudfoundry/client/lib/rest/CloudControllerClientFactory.java
@@ -42,6 +42,8 @@ public class CloudControllerClientFactory {
 	private final RestUtil restUtil;
 	private final RestTemplate restTemplate;
 
+	private OauthClient oauthClient;
+
 	private final HttpProxyConfiguration httpProxyConfiguration;
 	private final boolean trustSelfSignedCerts;
 
@@ -61,9 +63,7 @@ public class CloudControllerClientFactory {
 
 	public CloudControllerClient newCloudController(URL cloudControllerUrl, CloudCredentials cloudCredentials,
 	                                                CloudSpace sessionSpace) {
-		Map<String, Object> infoMap = getInfoMap(cloudControllerUrl);
-		URL authorizationEndpoint = getAuthorizationEndpoint(infoMap, cloudControllerUrl);
-		OauthClient oauthClient = restUtil.createOauthClient(authorizationEndpoint, httpProxyConfiguration, trustSelfSignedCerts);
+		createOauthClient(cloudControllerUrl);
 		LoggregatorClient loggregatorClient = new LoggregatorClient(trustSelfSignedCerts);
 
 		return new CloudControllerClientImpl(cloudControllerUrl, restTemplate, oauthClient, loggregatorClient,
@@ -72,15 +72,27 @@ public class CloudControllerClientFactory {
 
 	public CloudControllerClient newCloudController(URL cloudControllerUrl, CloudCredentials cloudCredentials,
 	                                                String orgName, String spaceName) {
-		Map<String, Object> infoMap = getInfoMap(cloudControllerUrl);
-		URL authorizationEndpoint = getAuthorizationEndpoint(infoMap, cloudControllerUrl);
-		OauthClient oauthClient = restUtil.createOauthClient(authorizationEndpoint, httpProxyConfiguration, trustSelfSignedCerts);
+		createOauthClient(cloudControllerUrl);
 		LoggregatorClient loggregatorClient = new LoggregatorClient(trustSelfSignedCerts);
 
 		return new CloudControllerClientImpl(cloudControllerUrl, restTemplate, oauthClient, loggregatorClient,
 				cloudCredentials, orgName, spaceName);
 	}
-	
+
+	public RestTemplate getRestTemplate() {
+		return restTemplate;
+	}
+
+	public OauthClient getOauthClient() {
+		return oauthClient;
+	}
+
+	private void createOauthClient(URL cloudControllerUrl) {
+		Map<String, Object> infoMap = getInfoMap(cloudControllerUrl);
+		URL authorizationEndpoint = getAuthorizationEndpoint(infoMap, cloudControllerUrl);
+		this.oauthClient = restUtil.createOauthClient(authorizationEndpoint, httpProxyConfiguration, trustSelfSignedCerts);
+	}
+
 	private Map<String, Object> getInfoMap(URL cloudControllerUrl) {
 		if (infoCache.containsKey(cloudControllerUrl)) {
 			return infoCache.get(cloudControllerUrl);


### PR DESCRIPTION
This change moves all the responsibility of Oauth token management from `CloudControllerClientImpl` to `OauthClient`. This makes it possible for code other than `CloudControllerClientImpl` to access the token and build an authorization header for a REST request (at the expense of adding state to `OauthClient`). 

This change also makes it possible to construct a `CloudFoundryClient` in such a way that it is possible to re-use the `RestTemplate` and `OauthClient` used by `CloudFoundryClient` in other code. To take advantage of this, you would replace code like this: 

```
CloudFoundryClient client = new CloudFoundryClient(credentials, cloudControllerUrl, orgName, spaceName, httpProxyConfiguration, trustSelfSignedCerts);
```

with code like this: 

```
CloudControllerClientFactory clientFactory =
    new CloudControllerClientFactory(httpProxyConfiguration, trustSelfSignedCerts);
CloudControllerClient cc = clientFactory.newCloudController(cloudControllerUrl, credentials, orgName, spaceName); 

CloudFoundryClient client = new CloudFoundryClient(cc);

// access the same RestTemplate and OauthClient that CloudControllerClient will use
RestTemplate restTemplate = clientFactory.getRestTemplate();
OauthClient oauthClient = clientFactory.getOauthClient();
```
