### PR TITLE
Close streaming session when cancelled

### DIFF
--- a/cloudfoundry-client-lib/src/main/java/org/cloudfoundry/client/lib/rest/StreamingLogTokenImpl.java
+++ b/cloudfoundry-client-lib/src/main/java/org/cloudfoundry/client/lib/rest/StreamingLogTokenImpl.java
@@ -1,5 +1,6 @@
 package org.cloudfoundry.client.lib.rest;
 
+import java.io.IOException;
 import java.util.Timer;
 import java.util.TimerTask;
 
@@ -22,6 +23,11 @@ public class StreamingLogTokenImpl implements StreamingLogToken {
     
     public void cancel() {
         keepAliveTimer.cancel();
+        try {
+            session.close();
+        } catch (IOException e) {
+            // Ignore
+        }
     }
 
     private class KeepAliveTimerTask extends TimerTask {


### PR DESCRIPTION
I think we should attempt to actively close the session when streaming is cancelled instead of just letting the session time out.

I need to clean resources after cancelling a stream.  If the stream keeps using these resources it causes errors.
