### PR TITLE
Support for proxy servers requiring authentication

### DIFF
--- a/cloudfoundry-client-lib/src/main/java/org/cloudfoundry/client/lib/HttpProxyConfiguration.java
+++ b/cloudfoundry-client-lib/src/main/java/org/cloudfoundry/client/lib/HttpProxyConfiguration.java
@@ -28,9 +28,23 @@ public class HttpProxyConfiguration {
 
 	private int proxyPort;
 
+	private boolean authRequired;
+	
+	private String username;
+	
+	private String password;
+
 	public HttpProxyConfiguration(String proxyHost, int proxyPort) {
-		this.proxyHost = proxyHost;
-		this.proxyPort = proxyPort;
+		this(proxyHost, proxyPort, false, null, null);
+	}
+	
+	public HttpProxyConfiguration(String proxyHost, int proxyPort,
+		boolean authRequired, String username, String password) {
+	    this.proxyHost = proxyHost;
+	    this.proxyPort = proxyPort;
+	    this.authRequired = authRequired;
+	    this.username = username;
+	    this.password = password;
 	}
 
 	public String getProxyHost() {
@@ -39,5 +53,17 @@ public class HttpProxyConfiguration {
 
 	public int getProxyPort() {
 		return proxyPort;
+	}
+
+	public boolean isAuthRequired() {
+	    return authRequired;
+	}
+	
+	public String getUsername() {
+	    return username;
+	}
+	
+	public String getPassword() {
+	    return password;
 	}
 }

--- a/cloudfoundry-client-lib/src/main/java/org/cloudfoundry/client/lib/util/RestUtil.java
+++ b/cloudfoundry-client-lib/src/main/java/org/cloudfoundry/client/lib/util/RestUtil.java
@@ -2,12 +2,21 @@ package org.cloudfoundry.client.lib.util;
 
 import static org.apache.http.conn.ssl.SSLSocketFactory.STRICT_HOSTNAME_VERIFIER;
 
+import java.net.URL;
+import java.security.GeneralSecurityException;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
 import org.apache.http.HttpHost;
+import org.apache.http.auth.AuthScope;
+import org.apache.http.auth.UsernamePasswordCredentials;
 import org.apache.http.client.HttpClient;
 import org.apache.http.conn.params.ConnRoutePNames;
 import org.apache.http.conn.scheme.Scheme;
 import org.apache.http.conn.ssl.SSLSocketFactory;
 import org.apache.http.conn.ssl.TrustSelfSignedStrategy;
+import org.apache.http.impl.client.DefaultHttpClient;
 import org.cloudfoundry.client.lib.HttpProxyConfiguration;
 import org.cloudfoundry.client.lib.oauth2.OauthClient;
 import org.cloudfoundry.client.lib.rest.CloudControllerClientImpl;
@@ -22,12 +31,6 @@ import org.springframework.http.converter.ResourceHttpMessageConverter;
 import org.springframework.http.converter.StringHttpMessageConverter;
 import org.springframework.http.converter.json.MappingJacksonHttpMessageConverter;
 import org.springframework.web.client.RestTemplate;
-
-import java.net.URL;
-import java.security.GeneralSecurityException;
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.List;
 
 /**
  * Some helper utilities for creating classes used for the REST support.
@@ -47,13 +50,19 @@ public class RestUtil {
 
 	public ClientHttpRequestFactory createRequestFactory(HttpProxyConfiguration httpProxyConfiguration, boolean trustSelfSignedCerts) {
 		HttpComponentsClientHttpRequestFactory requestFactory = new HttpComponentsClientHttpRequestFactory();
-		HttpClient httpClient = requestFactory.getHttpClient();
+		DefaultHttpClient httpClient = (DefaultHttpClient) requestFactory.getHttpClient();
 
 		if (trustSelfSignedCerts) {
 			registerSslSocketFactory(httpClient);
 		}
-
+		
 		if (httpProxyConfiguration != null) {
+		    	if (httpProxyConfiguration.isAuthRequired()) {
+        		    	httpClient.getCredentialsProvider().setCredentials(
+        		        	new AuthScope(httpProxyConfiguration.getProxyHost(), httpProxyConfiguration.getProxyPort()),
+        		        	new UsernamePasswordCredentials(httpProxyConfiguration.getUsername(), httpProxyConfiguration.getPassword()));
+			}
+		    
 			HttpHost proxy = new HttpHost(httpProxyConfiguration.getProxyHost(), httpProxyConfiguration.getProxyPort());
 			httpClient.getParams().setParameter(ConnRoutePNames.DEFAULT_PROXY, proxy);
 		}

--- a/cloudfoundry-client-lib/src/test/java/org/cloudfoundry/client/lib/CloudFoundryClientTest.java
+++ b/cloudfoundry-client-lib/src/test/java/org/cloudfoundry/client/lib/CloudFoundryClientTest.java
@@ -111,6 +111,10 @@ public class CloudFoundryClientTest {
 	private static final String CCNG_API_PROXY_HOST = System.getProperty("http.proxyHost", null);
 
 	private static final int CCNG_API_PROXY_PORT = Integer.getInteger("http.proxyPort", 80);
+	
+	private static final String CCNG_API_PROXY_USER = System.getProperty("http.proxyUsername", null);
+
+	private static final String CCNG_API_PROXY_PASSWD = System.getProperty("http.proxyPassword", null);
 
 	private static final boolean CCNG_API_SSL = Boolean.getBoolean("ccng.ssl");
 
@@ -190,7 +194,11 @@ public class CloudFoundryClientTest {
 		}
 
 		if (CCNG_API_PROXY_HOST != null) {
-			httpProxyConfiguration = new HttpProxyConfiguration(CCNG_API_PROXY_HOST, CCNG_API_PROXY_PORT);
+			if (CCNG_API_PROXY_USER != null) {
+			    httpProxyConfiguration = new HttpProxyConfiguration(CCNG_API_PROXY_HOST, CCNG_API_PROXY_PORT, true, CCNG_API_PROXY_USER, CCNG_API_PROXY_PASSWD);
+			} else {
+			    httpProxyConfiguration = new HttpProxyConfiguration(CCNG_API_PROXY_HOST, CCNG_API_PROXY_PORT);
+			}
 		}
 		if (!SKIP_INJVM_PROXY) {
 			startInJvmProxy();


### PR DESCRIPTION
This is intended to fix the shortcomings of the library when used behind proxy server requiring authentication (supports authentication using HTTP BASIC and DIGEST methods).

The integration test included does test proxy connections, however an external proxy server (e.g. Squid) needs to be configured to test the proxy authentication as the "InJVM"-proxy server (Jetty Servlet) does not support it (maybe consider to replace with LittleProxy).
