### PR TITLE
Using an external gradle.properties file

### DIFF
--- a/cloudfoundry-gradle-plugin/README.md
+++ b/cloudfoundry-gradle-plugin/README.md
@@ -184,8 +184,8 @@ file can be placed in a user's home directory (e.g. `~/.gradle/gradle.properties
 An example `gradle.properties` file might look like this:
 
 ~~~
-cf.username='user@example.com'
-cf.password='s3cr3t'
+cfUsername='user@example.com'
+cfPassword='s3cr3t'
 ~~~
 
 ### Using saved tokens


### PR DESCRIPTION
(`~/.gradle/gradle.properties`), required using camel-case property
names instead of dot separated ones.  Ex: `cfUsername` worked,
`cf.username` didn't.
