### PR TITLE
fix http proxy support in spring4

### DIFF
--- a/cloudfoundry-client-lib/src/main/java/org/cloudfoundry/client/lib/util/RestUtil.java
+++ b/cloudfoundry-client-lib/src/main/java/org/cloudfoundry/client/lib/util/RestUtil.java
@@ -5,10 +5,12 @@ import static org.apache.http.conn.ssl.SSLSocketFactory.BROWSER_COMPATIBLE_HOSTN
 import org.apache.http.HttpHost;
 import org.apache.http.client.HttpClient;
 import org.apache.http.client.config.RequestConfig;
+import org.apache.http.conn.routing.HttpRoutePlanner;
 import org.apache.http.conn.ssl.SSLContextBuilder;
 import org.apache.http.conn.ssl.TrustSelfSignedStrategy;
 import org.apache.http.impl.client.HttpClientBuilder;
 import org.apache.http.impl.client.HttpClients;
+import org.apache.http.impl.conn.DefaultProxyRoutePlanner;
 import org.cloudfoundry.client.lib.HttpProxyConfiguration;
 import org.cloudfoundry.client.lib.oauth2.OauthClient;
 import org.cloudfoundry.client.lib.rest.CloudControllerClientImpl;
@@ -58,6 +60,8 @@ public class RestUtil {
 			HttpHost proxy = new HttpHost(httpProxyConfiguration.getProxyHost(), httpProxyConfiguration.getProxyPort());
 			RequestConfig requestConfig = RequestConfig.custom().setProxy(proxy).build();
 			httpClientBuilder.setDefaultRequestConfig(requestConfig);
+			HttpRoutePlanner routePlanner = new DefaultProxyRoutePlanner(proxy);
+			httpClientBuilder.setRoutePlanner(routePlanner);
 		}
 
 		HttpClient httpClient = httpClientBuilder.build();


### PR DESCRIPTION
Hi,
This is a workaround waiting for Spring to fix proxy support. In RequestFactory, I set a default route planner to handle proxy otherwise proxy is ignored. I've also updated test case to explicitly show if a restTemplate use a proxy or not.

https://jira.spring.io/browse/SPR-12335 When using HttpComponentsClientHttpRequestFactory, setting a proxy through RequestConfig should not be ignored.

Regards,
 Olivier
