### PR TITLE
Remove unused credentials from access token request

### DIFF
--- a/cloudfoundry-client-lib/src/main/java/org/cloudfoundry/client/lib/oauth2/OauthClient.java
+++ b/cloudfoundry-client-lib/src/main/java/org/cloudfoundry/client/lib/oauth2/OauthClient.java
@@ -148,11 +148,7 @@ public class OauthClient {
 	}
 
 	private AccessTokenRequest createAccessTokenRequest(String username, String password) {
-		Map<String, String> parameters = new LinkedHashMap<String, String>();
-		parameters.put("credentials", String.format("{\"username\":\"%s\",\"password\":\"%s\"}", username, password));
 		AccessTokenRequest request = new DefaultAccessTokenRequest();
-		request.setAll(parameters);
-
 		return request;
 	}
 


### PR DESCRIPTION
The "credentiels" parameter isn't used by the resource owner password grant on the server, so this code has been dead for well over a year (I suspect).
