### PR TITLE
URL getter javadoc is referencing a wrong property

### DIFF
--- a/cloudfoundry-maven-plugin/src/main/java/org/cloudfoundry/maven/AbstractApplicationAwareCloudFoundryMojo.java
+++ b/cloudfoundry-maven-plugin/src/main/java/org/cloudfoundry/maven/AbstractApplicationAwareCloudFoundryMojo.java
@@ -249,7 +249,7 @@ abstract class AbstractApplicationAwareCloudFoundryMojo extends AbstractCloudFou
 	}
 
 	/**
-	 * If the application name was specified via the command line ({@link SystemProperties})
+	 * If the URL was specified via the command line ({@link SystemProperties})
 	 * then that property is used. Otherwise return the appname.
 	 *
 	 * @return Returns the Cloud Foundry application url.


### PR DESCRIPTION
getUrl javadoc is referencing application name property.
It seems to me to be a copy-paste error.

This patch fixes the issue by referencing URL property in getUrl javadoc.
