### PR TITLE
Add minimal space management (get/create/delete).

### DIFF
--- a/cloudfoundry-client-lib/src/main/java/org/cloudfoundry/client/lib/CloudFoundryClient.java
+++ b/cloudfoundry-client-lib/src/main/java/org/cloudfoundry/client/lib/CloudFoundryClient.java
@@ -541,5 +541,19 @@ public class CloudFoundryClient implements CloudFoundryOperations {
 	public void updateQuota(CloudQuota quota, String name) {
 		cc.updateQuota(quota, name);
 	}
+	@Override
+	public void createSpace(String spaceName) {
+		cc.createSpace(spaceName);
+	}
 
+	@Override
+	public void deleteSpace(String spaceName) {
+		cc.deleteSpace(spaceName);
+	}
+
+	
+	@Override
+	public CloudSpace getSpace(String spaceName) {
+		return cc.getSpace(spaceName);
+	}
 }

--- a/cloudfoundry-client-lib/src/main/java/org/cloudfoundry/client/lib/CloudFoundryOperations.java
+++ b/cloudfoundry-client-lib/src/main/java/org/cloudfoundry/client/lib/CloudFoundryOperations.java
@@ -83,6 +83,29 @@ public interface CloudFoundryOperations {
 	List<CloudSpace> getSpaces();
 
 	/**
+	 * Create a space with the specified name 
+	 * @param spaceName
+	 */
+	void createSpace(String spaceName);
+	
+	/**
+	 * Get space name with the specified name.
+	 *
+	 * @param spaceName name of the space
+	 * @return the cloud space
+	 */
+	CloudSpace getSpace(String spaceName);
+	
+	/**
+	 * Delete a space with the specified name
+	 * 
+	 * @param spaceName name of the space
+	 */
+	void deleteSpace(String spaceName);
+
+	
+	
+	/**
 	 * Get list of CloudOrganizations for the current cloud.
 	 *
 	 * @return List of CloudOrganizations objects containing the organization info

--- a/cloudfoundry-client-lib/src/main/java/org/cloudfoundry/client/lib/rest/CloudControllerClient.java
+++ b/cloudfoundry-client-lib/src/main/java/org/cloudfoundry/client/lib/rest/CloudControllerClient.java
@@ -187,6 +187,14 @@ public interface CloudControllerClient {
 
 	CloudStack getStack(String name);
 
+	// Space management	
+	
+	void createSpace(String spaceName);
+	
+	CloudSpace getSpace(String spaceName);
+	
+	void deleteSpace(String spaceName);
+	
 	// Domains and routes management
 
 

--- a/cloudfoundry-client-lib/src/main/java/org/cloudfoundry/client/lib/rest/CloudControllerClientImpl.java
+++ b/cloudfoundry-client-lib/src/main/java/org/cloudfoundry/client/lib/rest/CloudControllerClientImpl.java
@@ -565,7 +565,67 @@ public class CloudControllerClientImpl implements CloudControllerClient {
 		return new CloudInfo(name, support, authorizationEndpoint, build, version, (String)userMap.get("user_name"),
 				description, limits, usage, debug, loggregatorEndpoint);
 	}
+	
+	@Override
+	public void createSpace(String spaceName) {
+		UUID orgGuid = sessionSpace.getOrganization().getMeta().getGuid();
+		UUID spaceGuid = getSpaceGuid(spaceName, orgGuid);
+		if (spaceGuid == null) {
+			doCreateSpace(spaceName, orgGuid);
+		}
+	}
 
+	@Override
+	public CloudSpace getSpace(String spaceName) {
+		String urlPath = "/v2/spaces?inline-relations-depth=1&q=name:{name}";
+		HashMap<String, Object> spaceRequest = new HashMap<String, Object>();
+		spaceRequest.put("name", spaceName);
+		List<Map<String, Object>> resourceList = getAllResources(urlPath, spaceRequest);
+		CloudSpace space = null;
+		if (resourceList.size() > 0) {
+			Map<String, Object> resource = resourceList.get(0);
+			space = resourceMapper.mapResource(resource, CloudSpace.class);
+		}
+		return space;
+	}
+
+	@Override
+	public void deleteSpace(String spaceName) {
+		UUID orgGuid = sessionSpace.getOrganization().getMeta().getGuid();
+		UUID spaceGuid = getSpaceGuid(spaceName, orgGuid);
+		if (spaceGuid != null) {
+			doDeleteSpace(spaceGuid);
+		}
+	}
+
+	private UUID doCreateSpace(String spaceName, UUID orgGuid) {
+		String urlPath = "/v2/spaces";
+		HashMap<String, Object> spaceRequest = new HashMap<String, Object>();
+		spaceRequest.put("organization_guid", orgGuid);
+		spaceRequest.put("name", spaceName);
+		String resp = getRestTemplate().postForObject(getUrl(urlPath), spaceRequest, String.class);
+		Map<String, Object> respMap = JsonUtil.convertJsonToMap(resp);
+		return resourceMapper.getGuidOfResource(respMap);
+	}
+
+	private UUID getSpaceGuid(String spaceName, UUID orgGuid) {
+		Map<String, Object> urlVars = new HashMap<String, Object>();
+		String urlPath = "/v2/organizations/{orgGuid}/spaces?inline-relations-depth=1&q=name:{name}";
+		urlVars.put("orgGuid", orgGuid);
+		urlVars.put("name", spaceName);
+		List<Map<String, Object>> resourceList = getAllResources(urlPath, urlVars);
+		UUID spaceGuid = null;
+		if (resourceList.size() > 0) {
+			Map<String, Object> resource = resourceList.get(0);
+			spaceGuid = resourceMapper.getGuidOfResource(resource);
+		}
+		return spaceGuid;
+	}
+
+	private void doDeleteSpace(UUID spaceGuid) {
+		getRestTemplate().delete(getUrl("/v2/spaces/{guid}?async=false"), spaceGuid);
+	}
+	
 	@Override
 	public List<CloudSpace> getSpaces() {
 		String urlPath = "/v2/spaces?inline-relations-depth=1";

--- a/cloudfoundry-client-lib/src/test/java/org/cloudfoundry/client/lib/CloudFoundryClientTest.java
+++ b/cloudfoundry-client-lib/src/test/java/org/cloudfoundry/client/lib/CloudFoundryClientTest.java
@@ -1397,6 +1397,28 @@ public class CloudFoundryClientTest {
 	}
 
 	@Test
+	public void shouldCreateGetAndDeleteSpaceOnCurrentOrg() throws Exception {
+		String spaceName = "dummy space";
+		CloudSpace newSpace = connectedClient.getSpace(spaceName);
+		assertNull("Space '"+spaceName+  "' should not exist before creation",newSpace);
+		connectedClient.createSpace(spaceName);
+		newSpace = connectedClient.getSpace(spaceName);
+		assertNotNull("newSpace should not be null",newSpace);
+		assertEquals(spaceName,newSpace.getName());
+		boolean foundSpaceInCurrentOrg = false;
+		for (CloudSpace aSpace : connectedClient.getSpaces()) {
+			if (spaceName.equals(aSpace.getName())){
+				foundSpaceInCurrentOrg = true;
+			}
+		}
+		assertTrue(foundSpaceInCurrentOrg);
+		connectedClient.deleteSpace(spaceName);
+		CloudSpace deletedSpace = connectedClient.getSpace(spaceName);
+		assertNull("Space '"+spaceName+  "' should not exist after deletion",deletedSpace);
+
+	}
+
+	@Test
 	public void defaultDomainFound() throws Exception {
 		assertNotNull(connectedClient.getDefaultDomain());
 	}


### PR DESCRIPTION
Hi,
This PR is a minimal API to manage space.
Create and delete are restricted to current organization retrieved by current space.
Space creation only support required parameters (no user support, security-groups, etc...).
Get is not restricted to current org.

This could be part of story Add APIs for managing spaces [https://www.pivotaltracker.com/story/show/53169449]

I'll try to add user support in space management. Do you have some design preferences (like adding this support in space creation, or add a new command, or ....) ?
Regards,
 Olivier
