### PR TITLE
Add space user role assignation for current user.

### DIFF
--- a/cloudfoundry-client-lib/src/main/java/org/cloudfoundry/client/lib/CloudFoundryClient.java
+++ b/cloudfoundry-client-lib/src/main/java/org/cloudfoundry/client/lib/CloudFoundryClient.java
@@ -569,4 +569,34 @@ public class CloudFoundryClient implements CloudFoundryOperations {
 	public CloudSpace getSpace(String spaceName) {
 		return cc.getSpace(spaceName);
 	}
+
+	@Override
+	public List<UUID> listSpaceManagers(String spaceName) {
+		return cc.listSpaceManagers(spaceName);
+	}
+
+	@Override
+	public List<UUID> listSpaceDevelopers(String spaceName) {
+		return cc.listSpaceDevelopers(spaceName);
+	}
+
+	@Override
+	public List<UUID> listSpaceAuditors(String spaceName) {
+		return cc.listSpaceAuditors(spaceName);
+	}
+
+	@Override
+	public void associateManagerWithSpace(String spaceName) {
+		cc.associateManagerWithSpace(spaceName);
+	}
+
+	@Override
+	public void associateDeveloperWithSpace(String spaceName) {
+		cc.associateDeveloperWithSpace(spaceName);
+	}
+
+	@Override
+	public void associateAuditorWithSpace(String spaceName) {
+		cc.associateAuditorWithSpace(spaceName);
+	}
 }

--- a/cloudfoundry-client-lib/src/main/java/org/cloudfoundry/client/lib/CloudFoundryOperations.java
+++ b/cloudfoundry-client-lib/src/main/java/org/cloudfoundry/client/lib/CloudFoundryOperations.java
@@ -22,6 +22,7 @@ import java.io.InputStream;
 import java.net.URL;
 import java.util.List;
 import java.util.Map;
+import java.util.UUID;
 
 import org.cloudfoundry.client.lib.archive.ApplicationArchive;
 import org.cloudfoundry.client.lib.domain.ApplicationLog;
@@ -82,6 +83,53 @@ public interface CloudFoundryOperations {
 	 * @return List of CloudSpace objects containing the space info
 	 */
 	List<CloudSpace> getSpaces();
+
+	
+	/**
+	 * Get list of space manager UUID  for the space.
+	 *
+	 * @param spaceName name of the space
+	 * @return List of space manager UUID
+	 */
+	List<UUID> listSpaceManagers(String spaceName);
+
+	/**
+	 * Get list of space developer UUID  for the space.
+	 *
+	 * @param spaceName name of the space
+	 * @return List of space developer UUID
+	 */
+	List<UUID> listSpaceDevelopers(String spaceName);
+
+	/**
+	 * Get list of space auditor UUID  for the space.
+	 *
+	 * @param spaceName name of the space
+	 * @return List of space auditor UUID
+	 */
+	List<UUID> listSpaceAuditors(String spaceName);
+
+
+	/**
+	 * Associate current user to the space auditors role 
+	 *
+	 * @param spaceName name of the space 
+	 */
+	void associateAuditorWithSpace(String spaceName);
+
+	/**
+	 * Associate current user to the space developer role 
+	 *
+	 * @param spaceName name of the space 
+	 */
+	void associateDeveloperWithSpace(String spaceName);
+
+	/**
+	 * Associate current user to the space managers role 
+	 *
+	 * @param spaceName name of the space 
+	 */
+	void associateManagerWithSpace(String spaceName);
 
 	/**
 	 * Create a space with the specified name 
@@ -805,4 +853,5 @@ public interface CloudFoundryOperations {
 	 * @param name
 	 */
 	void updateQuota(CloudQuota quota, String name);
+
 }

--- a/cloudfoundry-client-lib/src/main/java/org/cloudfoundry/client/lib/domain/CloudUser.java
+++ b/cloudfoundry-client-lib/src/main/java/org/cloudfoundry/client/lib/domain/CloudUser.java
@@ -1,0 +1,19 @@
+package org.cloudfoundry.client.lib.domain;
+
+/**
+ * @author Olivier Orand
+ */
+public class CloudUser extends CloudEntity{
+	
+	private CloudOrganization organization;
+
+	public CloudUser(Meta meta, String name, CloudOrganization organization) {
+		super(meta, name);
+		this.organization = organization;
+	}
+
+	public CloudOrganization getOrganization() {
+		return organization;
+	}
+
+}

--- a/cloudfoundry-client-lib/src/main/java/org/cloudfoundry/client/lib/rest/CloudControllerClient.java
+++ b/cloudfoundry-client-lib/src/main/java/org/cloudfoundry/client/lib/rest/CloudControllerClient.java
@@ -200,6 +200,8 @@ public interface CloudControllerClient {
 	
 	void deleteSpace(String spaceName);
 	
+	List<UUID> listSpaceManagers(String spaceName);
+
 	// Domains and routes management
 
 
@@ -247,4 +249,15 @@ public interface CloudControllerClient {
 	void deleteQuota(String quotaName);
 
 	void setQuotaToOrg(String orgName, String quotaName);
+
+	List<UUID> listSpaceDevelopers(String spaceName);
+
+	List<UUID> listSpaceAuditors(String spaceName);
+
+	void associateManagerWithSpace(String spaceName);
+
+	void associateDeveloperWithSpace(String spaceName);
+
+	void associateAuditorWithSpace(String spaceName);
+
 }

--- a/cloudfoundry-client-lib/src/test/java/org/cloudfoundry/client/lib/CloudFoundryClientTest.java
+++ b/cloudfoundry-client-lib/src/test/java/org/cloudfoundry/client/lib/CloudFoundryClientTest.java
@@ -1430,6 +1430,38 @@ public class CloudFoundryClientTest {
 		assertNull("Space '"+spaceName+  "' should not exist after deletion",deletedSpace);
 
 	}
+	
+	@Test
+	public void shouldAssignDefaultUserRolesToASpace(){
+		String spaceName = "dummy space";
+		connectedClient.createSpace(spaceName);
+		
+		List<UUID> spaceManagers=connectedClient.listSpaceManagers(spaceName);
+		assertEquals("Space should have no manager when created", 0,spaceManagers.size());
+		connectedClient.associateManagerWithSpace(spaceName);
+		spaceManagers=connectedClient.listSpaceManagers(spaceName);
+		assertEquals("Space should have one manager", 1,spaceManagers.size());
+
+
+		List<UUID> spaceDevelopers=connectedClient.listSpaceDevelopers(spaceName);
+		assertEquals("Space should have no developer when created",0, spaceDevelopers.size());
+		connectedClient.associateDeveloperWithSpace(spaceName);
+		spaceDevelopers=connectedClient.listSpaceDevelopers(spaceName);
+		assertEquals("Space should have one developer", 1,spaceDevelopers.size());
+
+		List<UUID> spaceAuditors=connectedClient.listSpaceAuditors(spaceName);
+		assertEquals("Space should have no auditor when created", 0,spaceAuditors.size());
+
+		connectedClient.associateAuditorWithSpace(spaceName);
+
+		spaceAuditors=connectedClient.listSpaceAuditors(spaceName);
+		assertEquals("Space should have one auditor ", 1,spaceAuditors.size());
+
+		connectedClient.deleteSpace(spaceName);
+		CloudSpace deletedSpace = connectedClient.getSpace(spaceName);
+		assertNull("Space '"+spaceName+  "' should not exist after deletion",deletedSpace);
+		
+	}
 
 	@Test
 	public void defaultDomainFound() throws Exception {


### PR DESCRIPTION
Hello Scott
As space creation does not handle user role, it has to be done after. So once a space is created, current logged user can be assign to it. Assigned user roles are identical to CF CLI ones, ie Manager, Developer
and Auditor.

Only assign and list are implemented.

Related to PR #238