### PR TITLE
Amended protobuf install location

### DIFF
--- a/bin/install-protoc-apt.sh
+++ b/bin/install-protoc-apt.sh
@@ -1,7 +1,7 @@
 #!/bin/sh
 VERSION=2.6.1
 sudo apt-get -y install build-essential
-wget https://github.com/google/protobuf/releases/download/$VERSION/protobuf-$VERSION.tar.gz
+wget https://github.com/google/protobuf/releases/download/v$VERSION/protobuf-$VERSION.tar.gz
 tar xvfz protobuf-$VERSION.tar.gz
 cd protobuf-$VERSION
 ./configure --prefix=/usr

--- a/bin/install-protoc-osx.sh
+++ b/bin/install-protoc-osx.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 VERSION=2.6.1
-wget https://github.com/google/protobuf/releases/download/$VERSION/protobuf-$VERSION.tar.gz
+wget https://github.com/google/protobuf/releases/download/v$VERSION/protobuf-$VERSION.tar.gz
 tar xvfz protobuf-$VERSION.tar.gz
 cd protobuf-$VERSION
 ./configure --prefix=/usr


### PR DESCRIPTION
The location for the install of protobuf was missing v within the version part of the url.

Have amended in both installation scripts