### PR TITLE
Added operations for management of security groups.

### DIFF
--- a/cloudfoundry-client-lib/src/main/java/org/cloudfoundry/client/lib/CloudFoundryClient.java
+++ b/cloudfoundry-client-lib/src/main/java/org/cloudfoundry/client/lib/CloudFoundryClient.java
@@ -29,6 +29,7 @@ import org.cloudfoundry.client.lib.domain.ApplicationLog;
 import org.cloudfoundry.client.lib.domain.ApplicationStats;
 import org.cloudfoundry.client.lib.domain.CloudApplication;
 import org.cloudfoundry.client.lib.domain.CloudApplication.DebugMode;
+import org.cloudfoundry.client.lib.domain.CloudSecurityGroup;
 import org.cloudfoundry.client.lib.domain.CloudDomain;
 import org.cloudfoundry.client.lib.domain.CloudInfo;
 import org.cloudfoundry.client.lib.domain.CloudOrganization;
@@ -568,5 +569,85 @@ public class CloudFoundryClient implements CloudFoundryOperations {
 	@Override
 	public CloudSpace getSpace(String spaceName) {
 		return cc.getSpace(spaceName);
+	}
+	
+	@Override
+	public List<CloudSecurityGroup> getSecurityGroups(){
+		return cc.getSecurityGroups();
+	}
+
+	@Override
+	public CloudSecurityGroup getSecurityGroup(String securityGroupName) {
+		return cc.getSecurityGroup(securityGroupName);
+	}
+	
+	@Override
+	public void createSecurityGroup(CloudSecurityGroup securityGroup){
+		cc.createSecurityGroup(securityGroup);
+	}
+
+	@Override
+	public void createSecurityGroup(String name, InputStream jsonRulesFile) {
+		cc.createSecurityGroup(name, jsonRulesFile);
+	}
+
+	@Override
+	public void updateSecurityGroup(CloudSecurityGroup securityGroup) {
+		cc.updateSecurityGroup(securityGroup);
+	}
+
+	@Override
+	public void updateSecurityGroup(String name, InputStream jsonRulesFile) {
+		cc.updateSecurityGroup(name, jsonRulesFile);
+	}
+	
+	@Override
+	public void deleteSecurityGroup(String securityGroupName) {
+		cc.deleteSecurityGroup(securityGroupName);
+	}
+
+	@Override
+	public List<CloudSecurityGroup> getStagingSecurityGroups() {
+		return cc.getStagingSecurityGroups();
+	}
+
+	@Override
+	public void bindStagingSecurityGroup(String securityGroupName) {
+		cc.bindStagingSecurityGroup(securityGroupName);
+	}
+
+	@Override
+	public void unbindStagingSecurityGroup(String securityGroupName) {
+		cc.unbindStagingSecurityGroup(securityGroupName);
+	}
+
+	@Override
+	public List<CloudSecurityGroup> getRunningSecurityGroups() {
+		return cc.getRunningSecurityGroups();
+	}
+
+	@Override
+	public void bindRunningSecurityGroup(String securityGroupName) {
+		cc.bindRunningSecurityGroup(securityGroupName);
+	}
+
+	@Override
+	public void unbindRunningSecurityGroup(String securityGroupName) {
+		cc.unbindRunningSecurityGroup(securityGroupName);
+	}
+
+	@Override
+	public void bindSecurityGroup(String orgName, String spaceName, String securityGroupName) {
+		cc.bindSecurityGroup(orgName, spaceName, securityGroupName);
+	}
+
+	@Override
+	public void unbindSecurityGroup(String orgName, String spaceName, String securityGroupName) {
+		cc.unbindSecurityGroup(orgName, spaceName, securityGroupName);
+	}
+
+	@Override
+	public List<CloudSpace> getSpacesBoundToSecurityGroup(String securityGroupName) {
+		return cc.getSpacesBoundToSecurityGroup(securityGroupName);
 	}
 }

--- a/cloudfoundry-client-lib/src/main/java/org/cloudfoundry/client/lib/CloudFoundryOperations.java
+++ b/cloudfoundry-client-lib/src/main/java/org/cloudfoundry/client/lib/CloudFoundryOperations.java
@@ -27,6 +27,7 @@ import org.cloudfoundry.client.lib.archive.ApplicationArchive;
 import org.cloudfoundry.client.lib.domain.ApplicationLog;
 import org.cloudfoundry.client.lib.domain.ApplicationStats;
 import org.cloudfoundry.client.lib.domain.CloudApplication;
+import org.cloudfoundry.client.lib.domain.CloudSecurityGroup;
 import org.cloudfoundry.client.lib.domain.CloudDomain;
 import org.cloudfoundry.client.lib.domain.CloudInfo;
 import org.cloudfoundry.client.lib.domain.CloudOrganization;
@@ -805,4 +806,187 @@ public interface CloudFoundryOperations {
 	 * @param name
 	 */
 	void updateQuota(CloudQuota quota, String name);
+	
+	/**
+	 * Get a List of all application security groups.
+	 * <p/>
+	 * This method requires the logged in user to have admin permissions in the cloud controller.
+	 * 
+	 * @return a list of all the {@link CloudSecurityGroup}s in the system
+	 */
+	List<CloudSecurityGroup> getSecurityGroups();
+	
+	/**
+	 * Get a specific security group by name.
+	 * <p/>
+	 * This method requires the logged in user to have admin permissions in the cloud controller.
+	 * 
+	 * @param securityGroupName The name of the security group
+	 * @return the CloudSecurityGroup or <code>null</code> if no security groups exist with the 
+	 * given name
+	 */
+	CloudSecurityGroup getSecurityGroup(String securityGroupName);
+	
+	/**
+	 * Create a new CloudSecurityGroup.
+	 * <p/>
+	 * This method requires the logged in user to have admin permissions in the cloud controller.
+	 * 
+	 * @param securityGroup
+	 */
+	void createSecurityGroup(CloudSecurityGroup securityGroup);
+
+	/**
+	 * Create a new CloudSecurityGroup using a JSON rules file. This is equivalent to <code>cf create-security-group SECURITY-GROUP PATH-TO-RULES-FILE</code>
+	 * when using the cf command line. See the Application Security Group documentation for more details.
+	 * <p/>
+	 * Example JSON-formatted rules file:
+	 * <pre>
+	 * {@code
+	 * [
+	 *  {
+	 * 		"protocol":"tcp",
+	 * 		"destination":"10.0.11.0/24",
+	 * 		"ports":"1-65535"
+	 *  },
+	 *  {
+	 *  	"protocol":"udp",
+	 *  	"destination":"10.0.11.0/24",
+	 *  	"ports":"1-65535"
+	 *  }
+	 * ]
+	 *  }
+	 * </pre>
+	 * <p/>
+	 * This method requires the logged in user to have admin permissions in the cloud controller.
+	 * 
+	 * @param name the name for the security group
+	 * @param jsonRulesFile An input stream that has a single array with JSON objects inside describing the rules
+	 * @see http://docs.cloudfoundry.org/adminguide/app-sec-groups.html
+	 */
+	void createSecurityGroup(String name, InputStream jsonRulesFile);
+	
+	/**
+	 * Update an existing security group.
+	 * <p/>
+	 * This method requires the logged in user to have admin permissions in the cloud controller.
+	 * 
+	 * @param securityGroup
+	 * @throws IllegalArgumentException if a security group does not exist with the name of the given CloudSecurityGroup
+	 */
+	void updateSecurityGroup(CloudSecurityGroup securityGroup);
+	
+	/**
+	 * Updates a existing CloudSecurityGroup using a JSON rules file. This is equivalent to <code>cf update-security-group SECURITY-GROUP PATH-TO-RULES-FILE</code>
+	 * when using the cf command line. See the Application Security Group documentation for more details.
+	 * <p/>
+	 * Example JSON-formatted rules file:
+	 * <pre>
+	 * {@code
+	 * [
+	 *  {
+	 * 		"protocol":"tcp",
+	 * 		"destination":"10.0.11.0/24",
+	 * 		"ports":"1-65535"
+	 *  },
+	 *  {
+	 *  	"protocol":"udp",
+	 *  	"destination":"10.0.11.0/24",
+	 *  	"ports":"1-65535"
+	 *  }
+	 * ]
+	 *  }
+	 * </pre>
+	 * <p/>
+	 * This method requires the logged in user to have admin permissions in the cloud controller.
+	 * 
+	 * @param jsonRulesFile An input stream that has a single array with JSON objects inside describing the rules
+	 * @throws IllegalArgumentException if a security group does not exist with the given name
+	 * @see http://docs.cloudfoundry.org/adminguide/app-sec-groups.html
+	 */
+	void updateSecurityGroup(String name, InputStream jsonRulesFile);
+	
+	/**
+	 * Deletes the security group with the given name.
+	 * <p/>
+	 * This method requires the logged in user to have admin permissions in the cloud controller.
+	 * 
+	 * @param securityGroupName
+	 * @throws IllegalArgumentException if a security group does not exist with the given name
+	 */
+	void deleteSecurityGroup(String securityGroupName); 
+
+	/**
+	 * Lists security groups in the staging set for applications.
+	 * <p/>
+	 * This method requires the logged in user to have admin permissions in the cloud controller.
+	 */
+	List<CloudSecurityGroup> getStagingSecurityGroups();
+	
+	/**
+	 * Bind a security group to the list of security groups to be used for staging applications.
+	 * <p/>
+	 * This method requires the logged in user to have admin permissions in the cloud controller.
+	 */
+	void bindStagingSecurityGroup(String securityGroupName);
+	
+	/**
+	 * Unbind a security group from the set of security groups for staging applications.
+	 * <p/>
+	 * This method requires the logged in user to have admin permissions in the cloud controller.
+	 */
+	void unbindStagingSecurityGroup(String securityGroupName);
+	
+	/**
+	 * List security groups in the set of security groups for running applications.
+	 * <p/>
+	 * This method requires the logged in user to have admin permissions in the cloud controller.
+	 */
+	List<CloudSecurityGroup> getRunningSecurityGroups(); 
+	
+	/**
+	 * Bind a security group to the list of security groups to be used for running applications.
+	 * <p/>
+	 * This method requires the logged in user to have admin permissions in the cloud controller.
+	 */
+	void bindRunningSecurityGroup(String securityGroupName);
+
+	/**
+	 * Unbind a security group from the set of security groups for running applications.
+	 * <p/>
+	 * This method requires the logged in user to have admin permissions in the cloud controller.
+	 */
+	void unbindRunningSecurityGroup(String securityGroupName);
+	
+	/**
+	 * Gets all the spaces that are bound to the given security group.
+	 * <p/>
+	 * This method requires the logged in user to have admin permissions in the cloud controller.
+	 */
+	List<CloudSpace> getSpacesBoundToSecurityGroup(String securityGroupName); 
+	
+	/**
+	 * Bind a security group to a space.
+	 * <p/>
+	 * This method requires the logged in user to have admin permissions in the cloud controller.
+	 * 
+	 * @param orgName The name of the organization that the space is in.
+	 * @param spaceName The name of the space
+	 * @param securityGroupName The name of the security group to bind to the space
+	 * @throws IllegalArgumentException if the org, space, or security group do not exist
+	 */
+	void bindSecurityGroup(String orgName, String spaceName, String securityGroupName);
+	
+	/**
+	 * Unbind a security group from a space.
+	 * <p/>
+	 * This method requires the logged in user to have admin permissions in the cloud controller.
+	 *  
+	 * @param orgName The name of the organization that the space is in.
+	 * @param spaceName The name of the space
+	 * @param securityGroupName The name of the security group to bind to the space
+	 * @throws IllegalArgumentException if the org, space, or security group do not exist
+	 */
+	void unbindSecurityGroup(String orgName, String spaceName, String securityGroupName);
+	
 }

--- a/cloudfoundry-client-lib/src/main/java/org/cloudfoundry/client/lib/domain/CloudSecurityGroup.java
+++ b/cloudfoundry-client-lib/src/main/java/org/cloudfoundry/client/lib/domain/CloudSecurityGroup.java
@@ -1,0 +1,74 @@
+/*
+ * Copyright 2015 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.cloudfoundry.client.lib.domain;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Application security groups act as virtual firewalls to control outbound
+ * traffic from the applications in your deployment. A security group consists
+ * of a list of network egress access rules.
+ * <p/>
+ * An administrator can assign one or more security groups to a Cloud Foundry
+ * deployment or to a specific space in an org within a deployment.
+ * 
+ * @author David Ehringer
+ * @see http://docs.cloudfoundry.org/adminguide/app-sec-groups.html
+ */
+public class CloudSecurityGroup extends CloudEntity {
+
+	private final boolean runningDefault;
+	private final boolean stagingDefault;
+	private final List<SecurityGroupRule> rules = new ArrayList<SecurityGroupRule>();
+
+	public CloudSecurityGroup(String name, List<SecurityGroupRule> rules) {
+		this(CloudEntity.Meta.defaultMeta(), name, rules);
+	}
+
+	public CloudSecurityGroup(Meta meta, String name,
+			List<SecurityGroupRule> rules) {
+		this(meta, name, rules, false, false);
+	}
+
+	public CloudSecurityGroup(String name, List<SecurityGroupRule> rules,
+			boolean runningDefault, boolean stagingDefault) {
+		this(CloudEntity.Meta.defaultMeta(), name, rules, runningDefault,
+				stagingDefault);
+	}
+
+	public CloudSecurityGroup(Meta meta, String name,
+			List<SecurityGroupRule> rules, boolean runningDefault,
+			boolean stagingDefault) {
+		super(meta, name);
+		this.rules.addAll(rules);
+		this.runningDefault = runningDefault;
+		this.stagingDefault = stagingDefault;
+	}
+
+	public List<SecurityGroupRule> getRules() {
+		return rules;
+	}
+
+	public boolean isRunningDefault() {
+		return runningDefault;
+	}
+
+	public boolean isStagingDefault() {
+		return stagingDefault;
+	}
+
+}

--- a/cloudfoundry-client-lib/src/main/java/org/cloudfoundry/client/lib/domain/SecurityGroupRule.java
+++ b/cloudfoundry-client-lib/src/main/java/org/cloudfoundry/client/lib/domain/SecurityGroupRule.java
@@ -1,0 +1,84 @@
+/*
+ * Copyright 2015 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.cloudfoundry.client.lib.domain;
+
+/**
+ * A single rule within a security group. See <a href="http://docs.cloudfoundry.org/adminguide/app-sec-groups.html">
+ * http://docs.cloudfoundry.org/adminguide/app-sec-groups.html</a> for more details.
+ * 
+ * @author David Ehringer
+ * @see http://docs.cloudfoundry.org/adminguide/app-sec-groups.html
+ */
+public class SecurityGroupRule {
+
+	private final String protocol;
+	private final String ports;
+	private final String destination;
+	private final Boolean log;
+	private final Integer type;
+	private final Integer code;
+	
+	public SecurityGroupRule(String protocol, String ports, String destination) {
+		this(protocol, ports, destination, null);
+	}
+	
+	public SecurityGroupRule(String protocol, String ports, String destination, Boolean log) {
+		this(protocol, ports, destination, log, null, null);
+	}
+	
+	/**
+	 * 
+	 * @param protocol network protocol (tcp,icmp,udp,all)
+	 * @param ports port or port range (applicable for tcp,udp,all), may be conditionally <code>null</code>
+	 * @param destination destination CIDR or destination range
+	 * @param log enables logging for the egress rule, may be <code>null</code>
+	 * @param type control signal for icmp, may be <code>null</code>
+	 * @param code control signal for icmp, may be <code>null</code>
+	 */
+	public SecurityGroupRule(String protocol, String ports, String destination, Boolean log, Integer type, Integer code) {
+		this.protocol = protocol;
+		this.ports = ports;
+		this.destination = destination;
+		this.log = log;
+		this.type = type;
+		this.code = code;
+	}
+
+	public String getProtocol() {
+		return protocol;
+	}
+	
+	public String getPorts() {
+		return ports;
+	}
+	
+	public String getDestination() {
+		return destination;
+	}
+
+	public Boolean getLog() {
+		return log;
+	}
+
+	public Integer getType() {
+		return type;
+	}
+
+	public Integer getCode() {
+		return code;
+	}
+	
+}

--- a/cloudfoundry-client-lib/src/main/java/org/cloudfoundry/client/lib/rest/CloudControllerClient.java
+++ b/cloudfoundry-client-lib/src/main/java/org/cloudfoundry/client/lib/rest/CloudControllerClient.java
@@ -35,6 +35,7 @@ import org.cloudfoundry.client.lib.archive.ApplicationArchive;
 import org.cloudfoundry.client.lib.domain.ApplicationLog;
 import org.cloudfoundry.client.lib.domain.ApplicationStats;
 import org.cloudfoundry.client.lib.domain.CloudApplication;
+import org.cloudfoundry.client.lib.domain.CloudSecurityGroup;
 import org.cloudfoundry.client.lib.domain.CloudDomain;
 import org.cloudfoundry.client.lib.domain.CloudInfo;
 import org.cloudfoundry.client.lib.domain.CloudOrganization;
@@ -247,4 +248,38 @@ public interface CloudControllerClient {
 	void deleteQuota(String quotaName);
 
 	void setQuotaToOrg(String orgName, String quotaName);
+	
+	// Security Group Operations
+	
+	List<CloudSecurityGroup> getSecurityGroups();
+
+	CloudSecurityGroup getSecurityGroup(String securityGroupName);
+	
+	void createSecurityGroup(CloudSecurityGroup securityGroup);
+
+	void createSecurityGroup(String name, InputStream jsonRulesFile);
+
+	void updateSecurityGroup(CloudSecurityGroup securityGroup);
+
+	void updateSecurityGroup(String name, InputStream jsonRulesFile);
+
+	void deleteSecurityGroup(String securityGroupName);
+
+	List<CloudSecurityGroup> getStagingSecurityGroups();
+
+	void bindStagingSecurityGroup(String securityGroupName);
+
+	void unbindStagingSecurityGroup(String securityGroupName);
+
+	List<CloudSecurityGroup> getRunningSecurityGroups();
+
+	void bindRunningSecurityGroup(String securityGroupName);
+
+	void unbindRunningSecurityGroup(String securityGroupName);
+
+	List<CloudSpace> getSpacesBoundToSecurityGroup(String securityGroupName);
+
+	void bindSecurityGroup(String orgName, String spaceName, String securityGroupName);
+
+	void unbindSecurityGroup(String orgName, String spaceName, String securityGroupName);
 }

--- a/cloudfoundry-client-lib/src/main/java/org/cloudfoundry/client/lib/util/CloudEntityResourceMapper.java
+++ b/cloudfoundry-client-lib/src/main/java/org/cloudfoundry/client/lib/util/CloudEntityResourceMapper.java
@@ -17,6 +17,7 @@
 package org.cloudfoundry.client.lib.util;
 
 import org.cloudfoundry.client.lib.domain.CloudApplication;
+import org.cloudfoundry.client.lib.domain.CloudSecurityGroup;
 import org.cloudfoundry.client.lib.domain.CloudDomain;
 import org.cloudfoundry.client.lib.domain.CloudEntity;
 import org.cloudfoundry.client.lib.domain.CloudOrganization;
@@ -28,6 +29,7 @@ import org.cloudfoundry.client.lib.domain.CloudServicePlan;
 import org.cloudfoundry.client.lib.domain.CloudServiceBroker;
 import org.cloudfoundry.client.lib.domain.CloudSpace;
 import org.cloudfoundry.client.lib.domain.CloudStack;
+import org.cloudfoundry.client.lib.domain.SecurityGroupRule;
 import org.cloudfoundry.client.lib.domain.Staging;
 
 import java.text.SimpleDateFormat;
@@ -86,6 +88,9 @@ public class CloudEntityResourceMapper {
 		}
 		if (targetClass == CloudQuota.class) {
             return (T) mapQuotaResource(resource);
+        }
+		if (targetClass == CloudSecurityGroup.class) {
+            return (T) mapApplicationSecurityGroupResource(resource);
         }
 		throw new IllegalArgumentException(
 				"Error during mapping - unsupported class for entity mapping " + targetClass.getName());
@@ -257,6 +262,30 @@ public class CloudEntityResourceMapper {
 				getEntityAttribute(resource, "description", String.class));
 	}
 
+	private CloudSecurityGroup mapApplicationSecurityGroupResource(Map<String, Object> resource) {
+		return new CloudSecurityGroup(getMeta(resource),
+				getNameOfResource(resource),
+				getSecurityGroupRules(resource),
+				getEntityAttribute(resource, "running_default", Boolean.class),
+				getEntityAttribute(resource, "staging_default", Boolean.class));
+	}
+	
+	@SuppressWarnings("unchecked")
+	private List<SecurityGroupRule> getSecurityGroupRules(Map<String, Object> resource){
+		List<SecurityGroupRule> rules = new ArrayList<SecurityGroupRule>();
+		List<Map<String, Object>> jsonRules = getEntityAttribute(resource, "rules", List.class);
+		for(Map<String, Object> jsonRule : jsonRules){
+			rules.add(new SecurityGroupRule(
+					(String) jsonRule.get("protocol"), 
+					(String) jsonRule.get("ports"), 
+					(String) jsonRule.get("destination"), 
+					(Boolean) jsonRule.get("log"), 
+					(Integer) jsonRule.get("type"), 
+					(Integer) jsonRule.get("code")));
+		}
+		return rules;
+	}
+	
 	@SuppressWarnings("unchecked")
 	public static CloudEntity.Meta getMeta(Map<String, Object> resource) {
 		Map<String, Object> metadata = (Map<String, Object>) resource.get("metadata");

--- a/cloudfoundry-client-lib/src/main/java/org/cloudfoundry/client/lib/util/JsonUtil.java
+++ b/cloudfoundry-client-lib/src/main/java/org/cloudfoundry/client/lib/util/JsonUtil.java
@@ -20,11 +20,14 @@ package org.cloudfoundry.client.lib.util;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.cloudfoundry.client.lib.domain.CloudResource;
+import org.codehaus.jackson.JsonParseException;
+import org.codehaus.jackson.map.JsonMappingException;
 import org.codehaus.jackson.map.ObjectMapper;
 import org.codehaus.jackson.type.TypeReference;
 import org.springframework.http.MediaType;
 
 import java.io.IOException;
+import java.io.InputStream;
 import java.nio.charset.Charset;
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -99,4 +102,19 @@ public class JsonUtil {
 		}
 	}
 
+	@SuppressWarnings("unchecked")
+	public static List<Map<String, Object>> convertToJsonList(InputStream jsonInputStream){
+		try {
+			return mapper.readValue(jsonInputStream, List.class);
+		} catch (JsonParseException e) {
+			logger.error("Unable to parse JSON from InputStream", e);
+			throw new IllegalArgumentException("Unable to parse JSON from InputStream", e);
+		} catch (JsonMappingException e) {
+			logger.error("Unable to parse JSON from InputStream", e);
+			throw new IllegalArgumentException("Unable to parse JSON from InputStream", e);
+		} catch (IOException e) {
+			logger.error("Unable to process InputStream", e);
+			throw new IllegalArgumentException("Unable to parse JSON from InputStream", e);
+		}
+	}
 }

--- a/cloudfoundry-client-lib/src/test/java/org/cloudfoundry/client/lib/CloudFoundryClientTest.java
+++ b/cloudfoundry-client-lib/src/test/java/org/cloudfoundry/client/lib/CloudFoundryClientTest.java
@@ -9,12 +9,14 @@ import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertSame;
+import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 import static org.junit.Assume.assumeTrue;
 
 import java.io.File;
 import java.io.FileInputStream;
+import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.io.InputStream;
 import java.net.InetSocketAddress;
@@ -43,6 +45,7 @@ import org.cloudfoundry.client.lib.domain.CloudInfo;
 import org.cloudfoundry.client.lib.domain.CloudOrganization;
 import org.cloudfoundry.client.lib.domain.CloudQuota;
 import org.cloudfoundry.client.lib.domain.CloudRoute;
+import org.cloudfoundry.client.lib.domain.CloudSecurityGroup;
 import org.cloudfoundry.client.lib.domain.CloudService;
 import org.cloudfoundry.client.lib.domain.CloudServiceBroker;
 import org.cloudfoundry.client.lib.domain.CloudServiceOffering;
@@ -55,6 +58,7 @@ import org.cloudfoundry.client.lib.domain.InstanceInfo;
 import org.cloudfoundry.client.lib.domain.InstanceState;
 import org.cloudfoundry.client.lib.domain.InstanceStats;
 import org.cloudfoundry.client.lib.domain.InstancesInfo;
+import org.cloudfoundry.client.lib.domain.SecurityGroupRule;
 import org.cloudfoundry.client.lib.domain.Staging;
 import org.cloudfoundry.client.lib.util.RestUtil;
 import org.eclipse.jetty.server.Server;
@@ -157,6 +161,8 @@ public class CloudFoundryClientTest {
 	private static final int FIVE_MINUTES = 300 * 1000;
 	
 	private static final String CCNG_QUOTA_NAME_TEST = System.getProperty("ccng.quota", "test_quota");
+	
+	private static final String CCNG_SECURITY_GROUP_NAME_TEST = System.getProperty("ccng.securityGroup", "test_security_group");
 
 	private static boolean tearDownComplete = false;
 
@@ -249,6 +255,7 @@ public class CloudFoundryClientTest {
 			connectedClient.deleteAllApplications();
 			connectedClient.deleteAllServices();
 			clearTestDomainAndRoutes();
+			deleteAnyOrphanedTestSecurityGroups();
 		}
 		tearDownComplete = true;
 	}
@@ -1715,7 +1722,256 @@ public class CloudFoundryClientTest {
 		connectedClient.setQuotaToOrg(CCNG_USER_ORG, oldQuota.getName());
 		connectedClient.deleteQuota(CCNG_QUOTA_NAME_TEST);
 	}
+	
+	@Test
+	public void crudSecurityGroups() throws Exception {
+		assumeTrue(CCNG_USER_IS_ADMIN);
 
+		List<SecurityGroupRule> rules = new ArrayList<SecurityGroupRule>();
+		SecurityGroupRule rule = new SecurityGroupRule("tcp", "80, 443", "205.158.11.29");
+		rules.add(rule);
+		rule = new SecurityGroupRule("all", null, "0.0.0.0-255.255.255.255");
+		rules.add(rule);
+		rule = new SecurityGroupRule("icmp", null, "0.0.0.0/0", true, 0, 1);
+		rules.add(rule);
+		CloudSecurityGroup securityGroup = new CloudSecurityGroup(CCNG_SECURITY_GROUP_NAME_TEST, rules);
+		
+		// Create
+		connectedClient.createSecurityGroup(securityGroup);
+		
+		// Verify created
+		securityGroup = connectedClient.getSecurityGroup(CCNG_SECURITY_GROUP_NAME_TEST);
+		assertNotNull(securityGroup);
+		assertThat(securityGroup.getRules().size(), is(3));
+		assertRulesMatchTestData(securityGroup);
+		
+		// Update group
+		rules = new ArrayList<SecurityGroupRule>();
+		rule = new SecurityGroupRule("all", null, "0.0.0.0-255.255.255.255");
+		rules.add(rule);
+		securityGroup = new CloudSecurityGroup(CCNG_SECURITY_GROUP_NAME_TEST, rules);
+		connectedClient.updateSecurityGroup(securityGroup);
+		
+		// Verify update
+		securityGroup = connectedClient.getSecurityGroup(CCNG_SECURITY_GROUP_NAME_TEST);
+		assertThat(securityGroup.getRules().size(), is(1));
+		
+		// Delete group
+		connectedClient.deleteSecurityGroup(CCNG_SECURITY_GROUP_NAME_TEST);
+		// Verify deleted
+		securityGroup = connectedClient.getSecurityGroup(CCNG_SECURITY_GROUP_NAME_TEST);
+		assertNull(securityGroup);
+	}
+	
+	private void assertRulesMatchTestData(CloudSecurityGroup securityGroup) {
+		// This asserts against the test data defined in the crudSecurityGroups method
+		// Rule ordering is preserved so we can depend on it here
+		SecurityGroupRule rule = securityGroup.getRules().get(0);
+		assertThat(rule.getProtocol(), is("tcp"));
+		assertThat(rule.getPorts(), is("80, 443"));
+		assertThat(rule.getDestination(), is("205.158.11.29"));
+		assertNull(rule.getLog());
+		assertNull(rule.getType());
+		assertNull(rule.getCode());
+		
+		rule = securityGroup.getRules().get(1);
+		assertThat(rule.getProtocol(), is("all"));
+		assertNull(rule.getPorts());
+		assertThat(rule.getDestination(), is("0.0.0.0-255.255.255.255"));
+		assertNull(rule.getLog());
+		assertNull(rule.getType());
+		assertNull(rule.getCode());
+
+		rule = securityGroup.getRules().get(2);
+		assertThat(rule.getProtocol(), is("icmp"));
+		assertNull(rule.getPorts());
+		assertThat(rule.getDestination(), is("0.0.0.0/0"));
+		assertTrue(rule.getLog());
+		assertThat(rule.getType(), is(0));
+		assertThat(rule.getCode(), is(1));
+	}
+
+	@Test
+	public void securityGroupsCanBeCreatedAndUpdatedFromJsonFiles() throws FileNotFoundException{
+		assumeTrue(CCNG_USER_IS_ADMIN);
+
+		// Create
+		connectedClient.createSecurityGroup(CCNG_SECURITY_GROUP_NAME_TEST, new FileInputStream(new File("src/test/resources/security-groups/test-rules-1.json")));
+		
+		// Verify created
+		CloudSecurityGroup securityGroup = connectedClient.getSecurityGroup(CCNG_SECURITY_GROUP_NAME_TEST);
+		assertNotNull(securityGroup);
+		assertThat(securityGroup.getRules().size(), is(4));
+		assertRulesMatchThoseInJsonFile1(securityGroup);
+		
+		// Update group
+		connectedClient.updateSecurityGroup(CCNG_SECURITY_GROUP_NAME_TEST, new FileInputStream(new File("src/test/resources/security-groups/test-rules-2.json")));
+		
+		// Verify update
+		securityGroup = connectedClient.getSecurityGroup(CCNG_SECURITY_GROUP_NAME_TEST);
+		assertThat(securityGroup.getRules().size(), is(1));
+		
+		// Clean up after ourselves
+		connectedClient.deleteSecurityGroup(CCNG_SECURITY_GROUP_NAME_TEST);
+	}
+	
+	private void assertRulesMatchThoseInJsonFile1(CloudSecurityGroup securityGroup) {
+		// Rule ordering is preserved so we can depend on it here
+
+		SecurityGroupRule rule = securityGroup.getRules().get(0);
+		assertThat(rule.getProtocol(), is("icmp"));
+		assertNull(rule.getPorts());
+		assertThat(rule.getDestination(), is("0.0.0.0/0"));
+		assertNull(rule.getLog());
+		assertThat(rule.getType(), is(0));
+		assertThat(rule.getCode(), is(1));
+		
+		rule = securityGroup.getRules().get(1);
+		assertThat(rule.getProtocol(), is("tcp"));
+		assertThat(rule.getPorts(), is("2048-3000"));
+		assertThat(rule.getDestination(), is("1.0.0.0/0"));
+		assertTrue(rule.getLog());
+		assertNull(rule.getType());
+		assertNull(rule.getCode());
+
+		rule = securityGroup.getRules().get(2);
+		assertThat(rule.getProtocol(), is("udp"));
+		assertThat(rule.getPorts(), is("53, 5353"));
+		assertThat(rule.getDestination(), is("2.0.0.0/0"));
+		assertNull(rule.getLog());
+		assertNull(rule.getType());
+		assertNull(rule.getCode());
+
+		rule = securityGroup.getRules().get(3);
+		assertThat(rule.getProtocol(), is("all"));
+		assertNull(rule.getPorts());
+		assertThat(rule.getDestination(), is("3.0.0.0/0"));
+		assertNull(rule.getLog());
+		assertNull(rule.getType());
+		assertNull(rule.getCode());
+	}
+
+	@Test(expected=IllegalArgumentException.class)
+	public void attemptingToDeleteANonExistentSecurityGroupThrowsAnIllegalArgumentException(){
+		assumeTrue(CCNG_USER_IS_ADMIN);
+		
+		connectedClient.deleteSecurityGroup(randomSecurityGroupName());
+	}
+	
+	@Test(expected=IllegalArgumentException.class)
+	public void attemptingToUpdateANonExistentSecurityGroupThrowsAnIllegalArgumentException() throws FileNotFoundException{
+		assumeTrue(CCNG_USER_IS_ADMIN);
+		
+		connectedClient.updateSecurityGroup(randomSecurityGroupName(), new FileInputStream(new File("src/test/resources/security-groups/test-rules-2.json")));
+	}
+
+	private String randomSecurityGroupName() {
+		return UUID.randomUUID().toString();
+	}
+	
+	@Test
+	public void bindingAndUnbindingSecurityGroupToDefaultStagingSet() throws FileNotFoundException{
+		assumeTrue(CCNG_USER_IS_ADMIN);
+
+		// Given
+		assertFalse(containsSecurityGroupNamed(connectedClient.getStagingSecurityGroups(), CCNG_SECURITY_GROUP_NAME_TEST));
+		connectedClient.createSecurityGroup(CCNG_SECURITY_GROUP_NAME_TEST, new FileInputStream(new File("src/test/resources/security-groups/test-rules-2.json")));
+		
+		// When
+		connectedClient.bindStagingSecurityGroup(CCNG_SECURITY_GROUP_NAME_TEST);
+		
+		// Then
+		assertTrue(containsSecurityGroupNamed(connectedClient.getStagingSecurityGroups(), CCNG_SECURITY_GROUP_NAME_TEST));
+
+		// When
+		connectedClient.unbindStagingSecurityGroup(CCNG_SECURITY_GROUP_NAME_TEST);
+		
+		// Then
+		assertFalse(containsSecurityGroupNamed(connectedClient.getStagingSecurityGroups(), CCNG_SECURITY_GROUP_NAME_TEST));
+		
+		// Cleanup
+		connectedClient.deleteSecurityGroup(CCNG_SECURITY_GROUP_NAME_TEST);
+	}
+	
+	@Test
+	public void bindingAndUnbindingSecurityGroupToDefaultRunningSet() throws FileNotFoundException{
+		assumeTrue(CCNG_USER_IS_ADMIN);
+
+		// Given
+		assertFalse(containsSecurityGroupNamed(connectedClient.getRunningSecurityGroups(), CCNG_SECURITY_GROUP_NAME_TEST));
+		connectedClient.createSecurityGroup(CCNG_SECURITY_GROUP_NAME_TEST, new FileInputStream(new File("src/test/resources/security-groups/test-rules-2.json")));
+		
+		// When
+		connectedClient.bindRunningSecurityGroup(CCNG_SECURITY_GROUP_NAME_TEST);
+		
+		// Then
+		assertTrue(containsSecurityGroupNamed(connectedClient.getRunningSecurityGroups(), CCNG_SECURITY_GROUP_NAME_TEST));
+
+		// When
+		connectedClient.unbindRunningSecurityGroup(CCNG_SECURITY_GROUP_NAME_TEST);
+		
+		// Then
+		assertFalse(containsSecurityGroupNamed(connectedClient.getRunningSecurityGroups(), CCNG_SECURITY_GROUP_NAME_TEST));
+		
+		// Cleanup
+		connectedClient.deleteSecurityGroup(CCNG_SECURITY_GROUP_NAME_TEST);
+	}
+	
+	@Test
+	public void bindingAndUnbindingSecurityGroupToSpaces() throws FileNotFoundException{
+		assumeTrue(CCNG_USER_IS_ADMIN);
+
+		// Given
+		connectedClient.createSecurityGroup(CCNG_SECURITY_GROUP_NAME_TEST, new FileInputStream(new File("src/test/resources/security-groups/test-rules-2.json")));
+		
+		// When
+		connectedClient.bindSecurityGroup(CCNG_USER_ORG, CCNG_USER_SPACE, CCNG_SECURITY_GROUP_NAME_TEST);
+		// Then
+		assertTrue(isSpaceBoundToSecurityGroup(CCNG_USER_SPACE, CCNG_SECURITY_GROUP_NAME_TEST));
+
+		// When
+		connectedClient.unbindSecurityGroup(CCNG_USER_ORG, CCNG_USER_SPACE, CCNG_SECURITY_GROUP_NAME_TEST);
+		//Then
+		assertFalse(isSpaceBoundToSecurityGroup(CCNG_USER_SPACE, CCNG_SECURITY_GROUP_NAME_TEST));
+		
+		// Cleanup
+		connectedClient.deleteSecurityGroup(CCNG_SECURITY_GROUP_NAME_TEST);
+	}
+
+	private boolean isSpaceBoundToSecurityGroup(String spaceName, String securityGroupName) {
+		List<CloudSpace> boundSpaces = connectedClient.getSpacesBoundToSecurityGroup(securityGroupName);
+		for(CloudSpace space: boundSpaces){
+			if(spaceName.equals(space.getName())){
+				return true;
+			}
+		}
+		return false;
+	}
+
+	private boolean containsSecurityGroupNamed(List<CloudSecurityGroup> groups, String groupName) {
+		for(CloudSecurityGroup group: groups){
+			if(groupName.equalsIgnoreCase(group.getName())){
+				return true;
+			}
+		}
+		return false;
+	}
+	
+	/**
+	 * Try to clean up any security group test data left behind in the case of assertions failing and
+	 * test security groups not being deleted as part of test logic.
+	 */
+	private void deleteAnyOrphanedTestSecurityGroups(){
+		try{
+			CloudSecurityGroup securityGroup = connectedClient.getSecurityGroup(CCNG_SECURITY_GROUP_NAME_TEST);
+			if(securityGroup != null){
+				connectedClient.deleteSecurityGroup(CCNG_SECURITY_GROUP_NAME_TEST);
+			}
+		} catch(Exception e){
+			// Nothing we can do at this point except protect other teardown logic from not running
+		}
+	}
+	
 	//
 	// Shared test methods
 	//

--- a/cloudfoundry-client-lib/src/test/resources/security-groups/test-rules-1.json
+++ b/cloudfoundry-client-lib/src/test/resources/security-groups/test-rules-1.json
@@ -1,0 +1,23 @@
+[
+  {
+    "protocol": "icmp",
+    "destination": "0.0.0.0/0",
+    "type": 0,
+    "code": 1
+  },
+  {
+    "protocol": "tcp",
+    "destination": "1.0.0.0/0",
+    "ports": "2048-3000",
+    "log": true
+  },
+  {
+    "protocol": "udp",
+    "destination": "2.0.0.0/0",
+    "ports": "53, 5353"
+  },
+  {
+    "protocol": "all",
+    "destination": "3.0.0.0/0"
+  }
+]

--- a/cloudfoundry-client-lib/src/test/resources/security-groups/test-rules-2.json
+++ b/cloudfoundry-client-lib/src/test/resources/security-groups/test-rules-2.json
@@ -1,0 +1,8 @@
+[
+  {
+    "protocol": "tcp",
+    "destination": "205.158.11.57",
+    "ports": "80, 443",
+    "log": true
+  }
+]


### PR DESCRIPTION
Added operations for management of security groups. The functionality included is equivalent to the following cf CLI commands:
- security-group
- security-groups
- create-security-group
- update-security-group
- delete-security-group
- bind-security-group
- unbind-security-group
- bind-staging-security-group
- staging-security-groups
- unbind-staging-security-group
- bind-running-security-group
- running-security-groups 
- unbind-running-security-group

The integration tests provided require the test user to have admin permissions.