### PR TITLE
Allow users to specify weather a token is refreshable or not

### DIFF
--- a/cloudfoundry-client-lib/src/main/java/org/cloudfoundry/client/lib/CloudCredentials.java
+++ b/cloudfoundry-client-lib/src/main/java/org/cloudfoundry/client/lib/CloudCredentials.java
@@ -25,7 +25,9 @@ import org.springframework.security.oauth2.common.OAuth2AccessToken;
  */
 public class CloudCredentials {
 
-	private String email;
+    private boolean refreshable = true;
+
+    private String email;
 
 	private String password;
 
@@ -83,6 +85,18 @@ public class CloudCredentials {
 	public CloudCredentials(OAuth2AccessToken token) {
 		this.token = token;
 	}
+
+    /**
+     * Create credentials using a token and indicates if the token is
+     * refreshable or not.
+     *
+     * @param token token to use for authorization
+     * @param refreshable indicates if the token can be refreshed or not
+     */
+    public CloudCredentials(OAuth2AccessToken token, boolean refreshable) {
+        this.token = token;
+        this.refreshable=refreshable;
+    }
 
 	/**
 	 * Create credentials using a token.
@@ -195,4 +209,16 @@ public class CloudCredentials {
 	public CloudCredentials proxyForUser(String user) {
 		return new CloudCredentials(this, user);
 	}
+
+    /**
+     * Indicates weather the token stored in the cloud credentials can be
+     * refreshed or not. This is useful when the token stored in this
+     * object was obtained via implicit OAuth2 authentication and therefore
+     * can not be refreshed.
+     *
+     * @return weather the token can be refreshed
+     */
+    public boolean isRefreshable() {
+        return refreshable;
+    }
 }

--- a/cloudfoundry-client-lib/src/main/java/org/cloudfoundry/client/lib/CloudCredentials.java
+++ b/cloudfoundry-client-lib/src/main/java/org/cloudfoundry/client/lib/CloudCredentials.java
@@ -25,9 +25,9 @@ import org.springframework.security.oauth2.common.OAuth2AccessToken;
  */
 public class CloudCredentials {
 
-    private boolean refreshable = true;
+	private boolean refreshable = true;
 
-    private String email;
+	private String email;
 
 	private String password;
 
@@ -210,15 +210,15 @@ public class CloudCredentials {
 		return new CloudCredentials(this, user);
 	}
 
-    /**
-     * Indicates weather the token stored in the cloud credentials can be
-     * refreshed or not. This is useful when the token stored in this
-     * object was obtained via implicit OAuth2 authentication and therefore
-     * can not be refreshed.
-     *
-     * @return weather the token can be refreshed
-     */
-    public boolean isRefreshable() {
-        return refreshable;
-    }
+	/**
+	 * Indicates weather the token stored in the cloud credentials can be
+	 * refreshed or not. This is useful when the token stored in this
+	 * object was obtained via implicit OAuth2 authentication and therefore
+	 * can not be refreshed.
+	 *
+	 * @return weather the token can be refreshed
+	 */
+	public boolean isRefreshable() {
+		return refreshable;
+	}
 }

--- a/cloudfoundry-client-lib/src/main/java/org/cloudfoundry/client/lib/oauth2/OauthClient.java
+++ b/cloudfoundry-client-lib/src/main/java/org/cloudfoundry/client/lib/oauth2/OauthClient.java
@@ -83,10 +83,12 @@ public class OauthClient {
 			return null;
 		}
 
-		if (token.getExpiresIn() < 50) { // 50 seconds before expiration? Then refresh it.
-			token = refreshToken(token, credentials.getEmail(), credentials.getPassword(),
-					credentials.getClientId(), credentials.getClientSecret());
-		}
+        if(this.credentials.isRefreshable()) {
+            if (token.getExpiresIn() < 50) { // 50 seconds before expiration? Then refresh it.
+                token = refreshToken(token, credentials.getEmail(), credentials.getPassword(),
+                        credentials.getClientId(), credentials.getClientSecret());
+            }
+        }
 
 		return token;
 	}

--- a/cloudfoundry-client-lib/src/main/java/org/cloudfoundry/client/lib/oauth2/OauthClient.java
+++ b/cloudfoundry-client-lib/src/main/java/org/cloudfoundry/client/lib/oauth2/OauthClient.java
@@ -83,12 +83,12 @@ public class OauthClient {
 			return null;
 		}
 
-        if(this.credentials.isRefreshable()) {
-            if (token.getExpiresIn() < 50) { // 50 seconds before expiration? Then refresh it.
-                token = refreshToken(token, credentials.getEmail(), credentials.getPassword(),
-                        credentials.getClientId(), credentials.getClientSecret());
-            }
-        }
+		if(this.credentials.isRefreshable()) {
+			if (token.getExpiresIn() < 50) { // 50 seconds before expiration? Then refresh it.
+				token = refreshToken(token, credentials.getEmail(), credentials.getPassword(),
+						credentials.getClientId(), credentials.getClientSecret());
+			}
+		}
 
 		return token;
 	}


### PR DESCRIPTION
OAuth2 tokens obtain via implicit OAuth 2.0 authentication can not be refreshed,
and since there is no username / password passed in to the cloud credentials we
just need to use the provided token without trying to refresh.

Resolves issue https://github.com/cloudfoundry/cf-java-client/issues/214