### PR TITLE
Fix date parser for UTC Z dates

### DIFF
--- a/cloudfoundry-client-lib/src/main/java/org/cloudfoundry/client/lib/util/CloudEntityResourceMapper.java
+++ b/cloudfoundry-client-lib/src/main/java/org/cloudfoundry/client/lib/util/CloudEntityResourceMapper.java
@@ -361,7 +361,7 @@ public class CloudEntityResourceMapper {
 			try {
 				// if the time zone part of the dateString contains a colon (e.g. 2013-09-19T21:56:36+00:00)
 				// then remove it before parsing
-				String isoDateString = dateString.replaceFirst(":(?=[0-9]{2}$)", "");
+				String isoDateString = dateString.replaceFirst(":(?=[0-9]{2}$)", "").replaceFirst("Z$", "+0000");
 				return dateFormatter.parse(isoDateString);
 			} catch (Exception ignore) {}
 		}


### PR DESCRIPTION
Sometime between PCF 1.3 and CF-202 the events api endpoint changed from returning UTC formatted timestamps to UTC zulu formatted timestamps.  This is a fix to make date parser work with either format.