### PR TITLE
Associate any organization user to a space.

### DIFF
--- a/cloudfoundry-client-lib/src/main/java/org/cloudfoundry/client/lib/CloudFoundryClient.java
+++ b/cloudfoundry-client-lib/src/main/java/org/cloudfoundry/client/lib/CloudFoundryClient.java
@@ -45,6 +45,7 @@ import org.cloudfoundry.client.lib.domain.CloudStack;
 import org.cloudfoundry.client.lib.domain.CrashesInfo;
 import org.cloudfoundry.client.lib.domain.InstancesInfo;
 import org.cloudfoundry.client.lib.domain.Staging;
+import org.cloudfoundry.client.lib.domain.CloudUser;
 import org.cloudfoundry.client.lib.rest.CloudControllerClient;
 import org.cloudfoundry.client.lib.rest.CloudControllerClientFactory;
 import org.springframework.security.oauth2.common.OAuth2AccessToken;
@@ -625,32 +626,48 @@ public class CloudFoundryClient implements CloudFoundryOperations {
 
 	@Override
 	public void associateManagerWithSpace(String spaceName) {
-		cc.associateManagerWithSpace(null, spaceName);
+		cc.associateManagerWithSpace(null, spaceName, null);
 	}
 
 	@Override
 	public void associateDeveloperWithSpace(String spaceName) {
-		cc.associateDeveloperWithSpace(null, spaceName);
+		cc.associateDeveloperWithSpace(null, spaceName, null);
 	}
 
 	@Override
 	public void associateAuditorWithSpace(String spaceName) {
-		cc.associateAuditorWithSpace(null, spaceName);
+		cc.associateAuditorWithSpace(null, spaceName, null);
 	}
 
 	@Override
 	public void associateManagerWithSpace(String orgName, String spaceName) {
-		cc.associateManagerWithSpace(orgName, spaceName);
+		cc.associateManagerWithSpace(orgName, spaceName, null);
 	}
 
 	@Override
 	public void associateDeveloperWithSpace(String orgName, String spaceName) {
-		cc.associateDeveloperWithSpace(orgName, spaceName);
+		cc.associateDeveloperWithSpace(orgName, spaceName, null);
 	}
 
 	@Override
 	public void associateAuditorWithSpace(String orgName, String spaceName) {
-		cc.associateAuditorWithSpace(orgName, spaceName);
+		cc.associateAuditorWithSpace(orgName, spaceName, null);
+	}
+
+
+	@Override
+	public void associateManagerWithSpace(String orgName, String spaceName, String userGuid) {
+		cc.associateManagerWithSpace(orgName, spaceName, userGuid);
+	}
+
+	@Override
+	public void associateDeveloperWithSpace(String orgName, String spaceName, String userGuid) {
+		cc.associateDeveloperWithSpace(orgName, spaceName, userGuid);
+	}
+
+	@Override
+	public void associateAuditorWithSpace(String orgName, String spaceName, String userGuid) {
+		cc.associateAuditorWithSpace(orgName, spaceName, userGuid);
 	}
 
 	@Override
@@ -726,6 +743,11 @@ public class CloudFoundryClient implements CloudFoundryOperations {
 	@Override
 	public void unbindSecurityGroup(String orgName, String spaceName, String securityGroupName) {
 		cc.unbindSecurityGroup(orgName, spaceName, securityGroupName);
+	}
+
+	@Override
+	public Map<String, CloudUser> getOrganizationUsers(String orgName) {
+		return cc.getOrganizationUsers(orgName);
 	}
 
 	@Override

--- a/cloudfoundry-client-lib/src/main/java/org/cloudfoundry/client/lib/CloudFoundryOperations.java
+++ b/cloudfoundry-client-lib/src/main/java/org/cloudfoundry/client/lib/CloudFoundryOperations.java
@@ -44,6 +44,7 @@ import org.cloudfoundry.client.lib.domain.CloudStack;
 import org.cloudfoundry.client.lib.domain.CrashesInfo;
 import org.cloudfoundry.client.lib.domain.InstancesInfo;
 import org.cloudfoundry.client.lib.domain.Staging;
+import org.cloudfoundry.client.lib.domain.CloudUser;
 import org.springframework.security.oauth2.common.OAuth2AccessToken;
 import org.springframework.web.client.ResponseErrorHandler;
 
@@ -182,6 +183,33 @@ public interface CloudFoundryOperations {
 	 * @param spaceName name of the space
 	 */
 	void associateManagerWithSpace(String orgName, String spaceName);
+
+	/**
+	 * Associate a user to the space auditors role
+	 *
+	 * @param orgName   name of the organization containing the space
+	 * @param spaceName name of the space
+	 * @param userGuid  guid of the user. If null, use current user. To retrieve user guid, use {@link #getOrganizationUsers(String) getOrganizationUsers } and search for username
+	 */
+	void associateAuditorWithSpace(String orgName, String spaceName, String userGuid);
+
+	/**
+	 * Associate a user to the space developer role
+	 *
+	 * @param orgName   name of the organization containing the space
+	 * @param spaceName name of the space
+	 * @param userGuid  guid of the user. If null, use current user. To retrieve user guid, use {@link #getOrganizationUsers(String) getOrganizationUsers } and search for username
+	 */
+	void associateDeveloperWithSpace(String orgName, String spaceName, String userGuid);
+
+	/**
+	 * Associate a user to the space managers role
+	 *
+	 * @param orgName   name of the organization containing the space
+	 * @param spaceName name of the space
+	 * @param userGuid  guid of the user. If null, use current user. To retrieve user guid, use {@link #getOrganizationUsers(String) getOrganizationUsers } and search for username
+	 */
+	void associateManagerWithSpace(String orgName, String spaceName, String userGuid);
 
 	/**
 	 * Create a space with the specified name
@@ -1151,4 +1179,14 @@ public interface CloudFoundryOperations {
 	 * @throws IllegalArgumentException if the org, space, or security group do not exist
 	 */
 	void unbindSecurityGroup(String orgName, String spaceName, String securityGroupName);
+
+    /**
+     * Get all users in the specified organization
+     *
+     * @param orgName organization name
+     * @return a Map CloudUser with username as key
+     * @throws IllegalArgumentException if the org do not exist
+     */
+    Map<String, CloudUser> getOrganizationUsers(String orgName);
+
 }

--- a/cloudfoundry-client-lib/src/main/java/org/cloudfoundry/client/lib/domain/CloudUser.java
+++ b/cloudfoundry-client-lib/src/main/java/org/cloudfoundry/client/lib/domain/CloudUser.java
@@ -4,12 +4,38 @@ package org.cloudfoundry.client.lib.domain;
  * @author Olivier Orand
  */
 public class CloudUser extends CloudEntity{
-	
+
+	private boolean admin;
+	private boolean active;
+	private String defaultSpaceGuid;
+	private String username;
+
 	private CloudOrganization organization;
 
-	public CloudUser(Meta meta, String name, CloudOrganization organization) {
-		super(meta, name);
-		this.organization = organization;
+	public boolean isAdmin() {
+		return admin;
+	}
+
+	public boolean isActive() {
+		return active;
+	}
+
+	public String getDefaultSpaceGuid() {
+		return defaultSpaceGuid;
+	}
+
+	public String getUsername() {
+		return username;
+	}
+
+	public CloudUser(Meta meta, String username, boolean admin, boolean active, String defaultSpaceGuid) {
+		super(meta, username);
+		this.username=username;
+		this.admin=admin;
+		this.active=active;
+
+		this.defaultSpaceGuid =defaultSpaceGuid;
+		//this.organization = organization;
 	}
 
 	public CloudOrganization getOrganization() {

--- a/cloudfoundry-client-lib/src/main/java/org/cloudfoundry/client/lib/rest/CloudControllerClient.java
+++ b/cloudfoundry-client-lib/src/main/java/org/cloudfoundry/client/lib/rest/CloudControllerClient.java
@@ -51,6 +51,7 @@ import org.cloudfoundry.client.lib.domain.CloudStack;
 import org.cloudfoundry.client.lib.domain.CrashesInfo;
 import org.cloudfoundry.client.lib.domain.InstancesInfo;
 import org.cloudfoundry.client.lib.domain.Staging;
+import org.cloudfoundry.client.lib.domain.CloudUser;
 import org.springframework.security.oauth2.common.OAuth2AccessToken;
 import org.springframework.web.client.ResponseErrorHandler;
 
@@ -267,11 +268,11 @@ public interface CloudControllerClient {
 
 	List<UUID> getSpaceAuditors(String orgName, String spaceName);
 
-	void associateManagerWithSpace(String orgName, String spaceName);
+	void associateManagerWithSpace(String orgName, String spaceName, String userGuid);
 
-	void associateDeveloperWithSpace(String orgName, String spaceName);
+	void associateDeveloperWithSpace(String orgName, String spaceName, String userGuid);
 
-	void associateAuditorWithSpace(String orgName, String spaceName);
+	void associateAuditorWithSpace(String orgName, String spaceName, String userGuid);
 
 	// Security Group Operations
 
@@ -307,4 +308,5 @@ public interface CloudControllerClient {
 
 	void unbindSecurityGroup(String orgName, String spaceName, String securityGroupName);
 
+	Map<String, CloudUser> getOrganizationUsers(String orgName);
 }

--- a/cloudfoundry-client-lib/src/main/java/org/cloudfoundry/client/lib/util/CloudEntityResourceMapper.java
+++ b/cloudfoundry-client-lib/src/main/java/org/cloudfoundry/client/lib/util/CloudEntityResourceMapper.java
@@ -35,6 +35,7 @@ import org.cloudfoundry.client.lib.domain.CloudSpace;
 import org.cloudfoundry.client.lib.domain.CloudStack;
 import org.cloudfoundry.client.lib.domain.SecurityGroupRule;
 import org.cloudfoundry.client.lib.domain.Staging;
+import org.cloudfoundry.client.lib.domain.CloudUser;
 
 import java.text.SimpleDateFormat;
 import java.util.ArrayList;
@@ -106,11 +107,23 @@ public class CloudEntityResourceMapper {
 		if (targetClass == CloudJob.class) {
 			return (T) mapJobResource(resource);
 		}
+		if (targetClass == CloudUser.class){
+            return (T) mapUserResource(resource);
+        }
 		throw new IllegalArgumentException(
 				"Error during mapping - unsupported class for entity mapping " + targetClass.getName());
 	}
 
-	private CloudSpace mapSpaceResource(Map<String, Object> resource) {
+    private CloudUser mapUserResource(Map<String, Object> resource) {
+        boolean isActiveUser = getEntityAttribute(resource, "active", Boolean.class);
+        boolean isAdminUser = getEntityAttribute(resource, "admin", Boolean.class);
+        String defaultSpaceGuid = getEntityAttribute(resource, "default_space_guid", String.class);
+        String username = getEntityAttribute(resource, "username", String.class);
+
+        return new CloudUser(getMeta(resource), username,isAdminUser,isActiveUser,defaultSpaceGuid);
+    }
+
+    private CloudSpace mapSpaceResource(Map<String, Object> resource) {
 		Map<String, Object> organizationMap = getEmbeddedResource(resource, "organization");
 		CloudOrganization organization = null;
 		if (organizationMap != null) {


### PR DESCRIPTION
Add userdGuid to  associatexxxxWithSpace method, if null, use current user.
Fix associatexxxxWithSpace orgName param used to search for space: if null use current org, else use orgName.
Add getOrganizationUsers to be able to retrieve all users of an organization indexed by username.
Change associatexxxxWithSpace method signatures introduced with #271 - getSpaceDevelopers(String spaceName) returns NPE in version 1.1.1

This closes #278 - As CLI does, add any user to a space.