### PR TITLE
Added the detected_start_command attribute to Staging.

### DIFF
--- a/cloudfoundry-client-lib/src/main/java/org/cloudfoundry/client/lib/domain/Staging.java
+++ b/cloudfoundry-client-lib/src/main/java/org/cloudfoundry/client/lib/domain/Staging.java
@@ -27,6 +27,7 @@ package org.cloudfoundry.client.lib.domain;
  */
 public class Staging {
 	private String command;
+	private String detectedStartCommand;
 	private String buildpackUrl;
 	private String detectedBuildpack;
 	private String stack;
@@ -85,6 +86,21 @@ public class Staging {
 		this(command, buildpackUrl, stack, healthCheckTimeout);
 		this.detectedBuildpack = detectedBuildpack;
 	}
+	   
+    /**
+     *
+     * @param command the application command; may be null
+     * @param buildpackUrl a custom buildpack url (e.g. https://github.com/cloudfoundry/java-buildpack.git); may be null
+     * @param stack the stack to use when staging the application; may be null
+     * @param healthCheckTimeout the amount of time the platform should wait when verifying that an app started; may be null
+     * @param detectedBuildpack raw, free-form information regarding a detected buildpack. It is a read-only property, and should not be set except when parsing a response. May be null.
+     * @param detectedStartCommand The command detected by the buildpack during staging.
+     */
+    public Staging(String command, String buildpackUrl, String stack, Integer healthCheckTimeout, String detectedBuildpack, String detectedStartCommand) {
+        this(command, buildpackUrl, stack, healthCheckTimeout);
+        this.detectedBuildpack = detectedBuildpack;
+        this.detectedStartCommand = detectedStartCommand;
+    }
 
 	/**
 	 *
@@ -93,8 +109,16 @@ public class Staging {
 	public String getCommand() {
 		return command;
 	}
-
+	
 	/**
+	 * 
+	 * @return The command detected by the buildpack during staging.
+	 */
+	public String getDetectedStartCommand() {
+        return detectedStartCommand;
+    }
+
+    /**
 	 *
 	 * @return The buildpack url, or null to use the default
 	 *         buildpack detected based on application content
@@ -132,7 +156,9 @@ public class Staging {
 	@Override
 	public String toString() {
 		return "Staging [command=" + getCommand() +
+                " detectedCommand=" + getDetectedStartCommand() +
 				" buildpack=" + getBuildpackUrl() +
+                " detectedBuildpack=" + getDetectedBuildpack() +
 				" stack=" + getStack() +
 				" healthCheckTimeout=" + getHealthCheckTimeout() +
 				"]";

--- a/cloudfoundry-client-lib/src/main/java/org/cloudfoundry/client/lib/util/CloudEntityResourceMapper.java
+++ b/cloudfoundry-client-lib/src/main/java/org/cloudfoundry/client/lib/util/CloudEntityResourceMapper.java
@@ -189,12 +189,13 @@ public class CloudEntityResourceMapper {
 			app.setRunningInstances(runningInstancesAttribute);
 		}
 		String command = getEntityAttribute(resource, "command", String.class);
+        String detectedStartCommand = getEntityAttribute(resource, "detected_start_command", String.class);
 		String buildpack = getEntityAttribute(resource, "buildpack", String.class);
 		String detectedBuildpack = getEntityAttribute(resource, "detected_buildpack", String.class);
 		Map<String, Object> stackResource = getEmbeddedResource(resource, "stack");
 		CloudStack stack = mapStackResource(stackResource);
 		Integer healthCheckTimeout = getEntityAttribute(resource, "health_check_timeout", Integer.class);
-		Staging staging = new Staging(command, buildpack, stack.getName(), healthCheckTimeout, detectedBuildpack);
+		Staging staging = new Staging(command, buildpack, stack.getName(), healthCheckTimeout, detectedBuildpack, detectedStartCommand);
 		app.setStaging(staging);
 
 		Map<String, Object> spaceResource = getEmbeddedResource(resource, "space");

--- a/cloudfoundry-client-lib/src/test/java/org/cloudfoundry/client/lib/CloudFoundryClientTest.java
+++ b/cloudfoundry-client-lib/src/test/java/org/cloudfoundry/client/lib/CloudFoundryClientTest.java
@@ -548,6 +548,8 @@ public class CloudFoundryClientTest {
 		assertNull(app.getStaging().getCommand());
 		assertNull(app.getStaging().getBuildpackUrl());
 		assertNull(app.getStaging().getHealthCheckTimeout());
+		
+		assertNotNull(app.getStaging().getDetectedStartCommand());
 	}
 
 	@Test


### PR DESCRIPTION
Added a field to the Staging class to exposed the command detected by the buildpack during staging.

This attribute was already being returned in the payload and didn't require any additional calls to the Cloud Controller.