### PR TITLE
Check for null when deleting service

### DIFF
--- a/cloudfoundry-client-lib/src/main/java/org/cloudfoundry/client/lib/rest/CloudControllerClientImpl.java
+++ b/cloudfoundry-client-lib/src/main/java/org/cloudfoundry/client/lib/rest/CloudControllerClientImpl.java
@@ -928,7 +928,9 @@ public class CloudControllerClientImpl implements CloudControllerClient {
 	@Override
 	public void deleteService(String serviceName) {
 		CloudService cloudService = getService(serviceName);
-		doDeleteService(cloudService);
+		if (cloudService != null) {
+			doDeleteService(cloudService);
+		}
 	}
 
 	@Override


### PR DESCRIPTION
Avoid NPE when deleting a service that does not exist.
