### PR TITLE
Fix mapping of a job's error details

### DIFF
--- a/cloudfoundry-client-lib/src/main/java/org/cloudfoundry/client/lib/util/CloudEntityResourceMapper.java
+++ b/cloudfoundry-client-lib/src/main/java/org/cloudfoundry/client/lib/util/CloudEntityResourceMapper.java
@@ -367,12 +367,12 @@ public class CloudEntityResourceMapper {
 
 	private CloudJob mapJobResource(Map<String, Object> resource) {
 		String status = getEntityAttribute(resource, "status", String.class);
-		Map<String, Object> errorDetailsResource = (Map<String, Object>) resource.get("error_details");
+		Map<String, Object> errorDetailsResource = getEntityAttribute(resource, "error_details", Map.class);
 		CloudJob.ErrorDetails errorDetails = null;
 		if (errorDetailsResource != null) {
-			Long code = getEntityAttribute(errorDetailsResource, "code", Long.class);
-			String description = getEntityAttribute(errorDetailsResource, "description", String.class);
-			String errorCode = getEntityAttribute(errorDetailsResource, "error_code", String.class);
+			Long code = Long.valueOf(String.valueOf(errorDetailsResource.get("code")));
+			String description = (String) errorDetailsResource.get("description");
+			String errorCode = (String) errorDetailsResource.get("error_code");
 			errorDetails = new CloudJob.ErrorDetails(code, description, errorCode);
 		}
 


### PR DESCRIPTION
As seen [in the API](http://apidocs.cloudfoundry.org/215/jobs/retrieve_job_with_known_failure.html), when retrieving the status of a failed job, the error is returned under `entity>error_details>*`. However, the CF java client tries to fetch `error_details>entity>*` instead.

This later causes a NullPointerException [here](https://github.com/cloudfoundry/cf-java-client/blob/7a8ab8c0770bde2854f798cbe97e6a90f8273a71/cloudfoundry-client-lib/src/main/java/org/cloudfoundry/client/lib/rest/CloudControllerClientImpl.java#L2148) instead of the correct CloudOperationException, and hides the true error message coming from the target.