### PR TITLE
Added support for recursive deletion of spaces

### DIFF
--- a/cloudfoundry-client-lib/src/main/java/org/cloudfoundry/client/lib/CloudFoundryClient.java
+++ b/cloudfoundry-client-lib/src/main/java/org/cloudfoundry/client/lib/CloudFoundryClient.java
@@ -588,6 +588,11 @@ public class CloudFoundryClient implements CloudFoundryOperations {
 		cc.deleteSpace(spaceName);
 	}
 
+	@Override
+	public void deleteSpaceRecursively(String spaceName) {
+		cc.deleteSpaceRecursively(spaceName);
+	}
+
 
 	@Override
 	public CloudSpace getSpace(String spaceName) {

--- a/cloudfoundry-client-lib/src/main/java/org/cloudfoundry/client/lib/CloudFoundryOperations.java
+++ b/cloudfoundry-client-lib/src/main/java/org/cloudfoundry/client/lib/CloudFoundryOperations.java
@@ -233,6 +233,14 @@ public interface CloudFoundryOperations {
 	void deleteSpace(String spaceName);
 
 	/**
+	 * Delete a space with the specified name recursively, deleting all resources contained in the space
+	 * as well as the space itself
+	 *
+	 * @param spaceName name of the space
+	 */
+	void deleteSpaceRecursively(String spaceName);
+
+	/**
 	 * Get list of CloudOrganizations for the current cloud.
 	 *
 	 * @return List of CloudOrganizations objects containing the organization info

--- a/cloudfoundry-client-lib/src/main/java/org/cloudfoundry/client/lib/rest/CloudControllerClient.java
+++ b/cloudfoundry-client-lib/src/main/java/org/cloudfoundry/client/lib/rest/CloudControllerClient.java
@@ -214,6 +214,8 @@ public interface CloudControllerClient {
 
 	void deleteSpace(String spaceName);
 
+	void deleteSpaceRecursively(String spaceName);
+
 	// Domains and routes management
 
 

--- a/cloudfoundry-client-lib/src/main/java/org/cloudfoundry/client/lib/rest/CloudControllerClientImpl.java
+++ b/cloudfoundry-client-lib/src/main/java/org/cloudfoundry/client/lib/rest/CloudControllerClientImpl.java
@@ -609,6 +609,16 @@ public class CloudControllerClientImpl implements CloudControllerClient {
 		}
 	}
 
+	@Override
+	public void deleteSpaceRecursively(String spaceName) {
+		assertSpaceProvided("delete a space recursively");
+		UUID orgGuid = sessionSpace.getOrganization().getMeta().getGuid();
+		UUID spaceGuid = getSpaceGuid(spaceName, orgGuid);
+		if (spaceGuid != null) {
+			doDeleteSpaceRecursively(spaceGuid);
+		}
+	}
+
 	private UUID doCreateSpace(String spaceName, UUID orgGuid) {
 		String urlPath = "/v2/spaces";
 		HashMap<String, Object> spaceRequest = new HashMap<String, Object>();
@@ -639,6 +649,10 @@ public class CloudControllerClientImpl implements CloudControllerClient {
 
 	private void doDeleteSpace(UUID spaceGuid) {
 		getRestTemplate().delete(getUrl("/v2/spaces/{guid}?async=false"), spaceGuid);
+	}
+
+	private void doDeleteSpaceRecursively(UUID spaceGuid) {
+		getRestTemplate().delete(getUrl("/v2/spaces/{guid}?async=false&recursive=true"), spaceGuid);
 	}
 
 	@Override


### PR DESCRIPTION
We have a need to delete many CloudFoundry spaces that have various resources in them (applications, services, routes). Being able to call the recursive delete space operation through the Java library is very useful to us.

This is a continuation of [Pull Request 300](https://github.com/cloudfoundry/cf-java-client/pull/300) that had been done on the master branch, causing unintended commits to enter the pull request.