### PR TITLE
Add binding for org memory_usage API endpoint

### DIFF
--- a/cloudfoundry-client-lib/src/main/java/org/cloudfoundry/client/lib/CloudFoundryClient.java
+++ b/cloudfoundry-client-lib/src/main/java/org/cloudfoundry/client/lib/CloudFoundryClient.java
@@ -754,4 +754,9 @@ public class CloudFoundryClient implements CloudFoundryOperations {
 	public List<CloudSpace> getSpacesBoundToSecurityGroup(String securityGroupName) {
 		return cc.getSpacesBoundToSecurityGroup(securityGroupName);
 	}
+
+	@Override
+	public int getOrganizationMemoryUsage(CloudOrganization org) {
+		return cc.getOrganizationMemoryUsage(org);
+	}
 }

--- a/cloudfoundry-client-lib/src/main/java/org/cloudfoundry/client/lib/CloudFoundryOperations.java
+++ b/cloudfoundry-client-lib/src/main/java/org/cloudfoundry/client/lib/CloudFoundryOperations.java
@@ -1189,4 +1189,11 @@ public interface CloudFoundryOperations {
      */
     Map<String, CloudUser> getOrganizationUsers(String orgName);
 
+	/**
+	 * Get the memory usage
+	 * @param org An org
+	 * @return the total used memory in MB
+	 */
+	int getOrganizationMemoryUsage(CloudOrganization org);
+
 }

--- a/cloudfoundry-client-lib/src/main/java/org/cloudfoundry/client/lib/rest/CloudControllerClient.java
+++ b/cloudfoundry-client-lib/src/main/java/org/cloudfoundry/client/lib/rest/CloudControllerClient.java
@@ -309,4 +309,6 @@ public interface CloudControllerClient {
 	void unbindSecurityGroup(String orgName, String spaceName, String securityGroupName);
 
 	Map<String, CloudUser> getOrganizationUsers(String orgName);
+	
+	int getOrganizationMemoryUsage(CloudOrganization org);
 }

--- a/cloudfoundry-client-lib/src/main/java/org/cloudfoundry/client/lib/rest/CloudControllerClientImpl.java
+++ b/cloudfoundry-client-lib/src/main/java/org/cloudfoundry/client/lib/rest/CloudControllerClientImpl.java
@@ -763,6 +763,22 @@ public class CloudControllerClientImpl implements CloudControllerClient {
 		}
 		return orgs;
 	}
+	
+	@Override
+	public int getOrganizationMemoryUsage(CloudOrganization org) {
+		UUID orgUuid = org.getMeta().getGuid();
+
+		String path = "/v2/organizations/{org_guid}/memory_usage";
+
+		Map<String, Object> pathVariables = 
+				Collections.<String, Object> singletonMap("org_guid", orgUuid);
+		
+		@SuppressWarnings("unchecked")
+		Map<String, Integer> usageMap = 
+		getRestTemplate().getForObject(getUrl(path), Map.class, pathVariables);
+		
+		return usageMap.get("memory_usage_in_mb");
+	}
 
 	@Override
 	public OAuth2AccessToken login() {

--- a/cloudfoundry-client-lib/src/test/java/org/cloudfoundry/client/lib/CloudFoundryClientTest.java
+++ b/cloudfoundry-client-lib/src/test/java/org/cloudfoundry/client/lib/CloudFoundryClientTest.java
@@ -393,6 +393,14 @@ public class CloudFoundryClientTest {
 		assertNotNull(orgs);
 		assertTrue(orgs.size() > 0);
 	}
+	
+	@Test
+	public void orgUsage() throws Exception {
+		createAndUploadAndStartSimpleSpringApp("org-usage-test");
+		CloudOrganization org = connectedClient.getOrgByName(CCNG_USER_ORG, true);
+		long mem = connectedClient.getOrganizationMemoryUsage(org);
+		assertTrue(mem > 0);
+	}
 
 	//
 	// Basic Event Tests


### PR DESCRIPTION
Add binding for the `memory_usage` API endpoint (available since v193) to allow folks to see how much RAM your org is using