### PR TITLE
Add support to cf-maven-plugin for proxies that require authentication

### DIFF
--- a/cloudfoundry-maven-plugin/src/main/java/org/cloudfoundry/maven/AbstractCloudFoundryMojo.java
+++ b/cloudfoundry-maven-plugin/src/main/java/org/cloudfoundry/maven/AbstractCloudFoundryMojo.java
@@ -197,7 +197,12 @@ public abstract class AbstractCloudFoundryMojo extends AbstractMojo {
 		Proxy proxy = getMavenProxy();
 		if (proxy != null) {
 			if (!targetIsExcludedFromProxy(target.getHost(), proxy)) {
-				return new HttpProxyConfiguration(proxy.getHost(), proxy.getPort());
+        if( proxy.getPassword() != null && proxy.getUsername() != null ) {
+          return new HttpProxyConfiguration(proxy.getHost(), proxy.getPort(), true, proxy.getUsername(), proxy.getPassword());
+        }
+        else {
+          return new HttpProxyConfiguration(proxy.getHost(), proxy.getPort());
+        }
 			}
 		}
 		return null;

--- a/cloudfoundry-maven-plugin/src/main/java/org/cloudfoundry/maven/AbstractCloudFoundryMojo.java
+++ b/cloudfoundry-maven-plugin/src/main/java/org/cloudfoundry/maven/AbstractCloudFoundryMojo.java
@@ -197,12 +197,12 @@ public abstract class AbstractCloudFoundryMojo extends AbstractMojo {
 		Proxy proxy = getMavenProxy();
 		if (proxy != null) {
 			if (!targetIsExcludedFromProxy(target.getHost(), proxy)) {
-        if( proxy.getPassword() != null && proxy.getUsername() != null ) {
-          return new HttpProxyConfiguration(proxy.getHost(), proxy.getPort(), true, proxy.getUsername(), proxy.getPassword());
-        }
-        else {
-          return new HttpProxyConfiguration(proxy.getHost(), proxy.getPort());
-        }
+				if( proxy.getPassword() != null && proxy.getUsername() != null ) {
+					return new HttpProxyConfiguration(proxy.getHost(), proxy.getPort(), true, proxy.getUsername(), proxy.getPassword());
+				}
+				else {
+					return new HttpProxyConfiguration(proxy.getHost(), proxy.getPort());
+				}
 			}
 		}
 		return null;


### PR DESCRIPTION
I found recently that cf-maven-plugin ignores the username and password settings in the maven proxies. This pull request fixes this issue.