### PR TITLE
Possibility to use one time passcodes for auth

### DIFF
--- a/cloudfoundry-client-lib/src/main/java/org/cloudfoundry/client/lib/CloudCredentials.java
+++ b/cloudfoundry-client-lib/src/main/java/org/cloudfoundry/client/lib/CloudCredentials.java
@@ -39,6 +39,8 @@ public class CloudCredentials {
 
 	private String proxyUser;
 
+	private String passcode;
+
 	/**
 	 * Create credentials using email and password.
 	 *
@@ -137,6 +139,15 @@ public class CloudCredentials {
 	}
 
 	/**
+	 * Create credentials using OTP passcode.
+	 *
+	 * @param passcode passcode to authenticate with
+	 */
+	public CloudCredentials(String passcode) {
+		this.passcode = passcode;
+	}
+
+	/**
 	 * Get the email.
 	 *
 	 * @return the email
@@ -220,5 +231,21 @@ public class CloudCredentials {
 	 */
 	public boolean isRefreshable() {
 		return refreshable;
+	}
+
+	/**
+	 * Get the OTP passcode
+	 *
+	 * @return the passcode
+	 */
+	public String getPasscode() { return passcode; }
+
+	/**
+	 * Is this a authentication attempt with OTP passcode?
+	 *
+	 * @return whether a passcode is set
+	 */
+	public boolean isPasscodeSet()  {
+		return passcode != null;
 	}
 }

--- a/cloudfoundry-client-lib/src/main/java/org/cloudfoundry/client/lib/oauth2/OauthClient.java
+++ b/cloudfoundry-client-lib/src/main/java/org/cloudfoundry/client/lib/oauth2/OauthClient.java
@@ -103,7 +103,7 @@ public class OauthClient {
 
 	private OAuth2AccessToken createToken(String username, String password, String clientId, String clientSecret) {
 		OAuth2ProtectedResourceDetails resource = getResourceDetails(username, password, clientId, clientSecret);
-		AccessTokenRequest request = createAccessTokenRequest(username, password);
+		AccessTokenRequest request = createAccessTokenRequest();
 
 		ResourceOwnerPasswordAccessTokenProvider provider = createResourceOwnerPasswordAccessTokenProvider();
 		try {
@@ -119,7 +119,7 @@ public class OauthClient {
 
 	private OAuth2AccessToken refreshToken(OAuth2AccessToken currentToken, String username, String password, String clientId, String clientSecret) {
 		OAuth2ProtectedResourceDetails resource = getResourceDetails(username, password, clientId, clientSecret);
-		AccessTokenRequest request = createAccessTokenRequest(username, password);
+		AccessTokenRequest request = createAccessTokenRequest();
 
 		ResourceOwnerPasswordAccessTokenProvider provider = createResourceOwnerPasswordAccessTokenProvider();
 
@@ -148,7 +148,7 @@ public class OauthClient {
 		return resourceOwnerPasswordAccessTokenProvider;
 	}
 
-	private AccessTokenRequest createAccessTokenRequest(String username, String password) {
+	private AccessTokenRequest createAccessTokenRequest() {
 		AccessTokenRequest request = new DefaultAccessTokenRequest();
 		return request;
 	}

--- a/cloudfoundry-client-lib/src/main/java/org/cloudfoundry/client/lib/oauth2/ResourceOwnerPasscodeAccessTokenProvider.java
+++ b/cloudfoundry-client-lib/src/main/java/org/cloudfoundry/client/lib/oauth2/ResourceOwnerPasscodeAccessTokenProvider.java
@@ -1,0 +1,74 @@
+package org.cloudfoundry.client.lib.oauth2;
+
+import org.springframework.http.HttpHeaders;
+import org.springframework.security.access.AccessDeniedException;
+import org.springframework.security.oauth2.client.resource.OAuth2AccessDeniedException;
+import org.springframework.security.oauth2.client.resource.OAuth2ProtectedResourceDetails;
+import org.springframework.security.oauth2.client.resource.UserRedirectRequiredException;
+import org.springframework.security.oauth2.client.token.AccessTokenRequest;
+import org.springframework.security.oauth2.client.token.grant.password.ResourceOwnerPasswordAccessTokenProvider;
+import org.springframework.security.oauth2.client.token.grant.password.ResourceOwnerPasswordResourceDetails;
+import org.springframework.security.oauth2.common.OAuth2AccessToken;
+import org.springframework.util.LinkedMultiValueMap;
+import org.springframework.util.MultiValueMap;
+
+import java.util.Iterator;
+import java.util.List;
+
+/**
+ * This class extends the Spring Security OAuth ResourceOwnerPasswordAccessTokenProvider
+ * to pass a passcode param instead of a username and password param.
+ *
+ * This is needed because CloudFoundry uses this passcode submission which is not part of the OAuth2 standard
+ * and thus it's not provided by Spring Security Oauth.
+ *
+ * It is used in SSO scenarios, similar to what the CF CLI with <code>cf login --sso</code> does.
+ *
+ * @author Matthias Winzeler <matthias.winzeler@gmail.com>
+ */
+public class ResourceOwnerPasscodeAccessTokenProvider extends ResourceOwnerPasswordAccessTokenProvider {
+    // copied from ResourceOwnerPasswordAccessTokenProvider and modified to use
+    // ResourceOwnerPasscodeResourceDetails
+    @Override
+    public boolean supportsResource(OAuth2ProtectedResourceDetails resource) {
+        return resource instanceof ResourceOwnerPasscodeResourceDetails && "password".equals(resource.getGrantType());
+    }
+
+    @Override
+    public OAuth2AccessToken obtainAccessToken(OAuth2ProtectedResourceDetails details, AccessTokenRequest request)
+            throws UserRedirectRequiredException, AccessDeniedException, OAuth2AccessDeniedException {
+
+        ResourceOwnerPasscodeResourceDetails resource = (ResourceOwnerPasscodeResourceDetails) details;
+        return retrieveToken(request, resource, getParametersForTokenRequest(resource, request), new HttpHeaders());
+    }
+
+    // copied from ResourceOwnerPasswordAccessTokenProvider and modified to send passcode instead of user/pw
+    private MultiValueMap<String, String> getParametersForTokenRequest(ResourceOwnerPasscodeResourceDetails resource, AccessTokenRequest request) {
+        MultiValueMap<String, String> form = new LinkedMultiValueMap<String, String>();
+        form.set("grant_type", "password");
+
+        form.set("passcode", resource.getPasscode());
+        form.putAll(request);
+
+        if (resource.isScoped()) {
+
+            StringBuilder builder = new StringBuilder();
+            List<String> scope = resource.getScope();
+
+            if (scope != null) {
+                Iterator<String> scopeIt = scope.iterator();
+                while (scopeIt.hasNext()) {
+                    builder.append(scopeIt.next());
+                    if (scopeIt.hasNext()) {
+                        builder.append(' ');
+                    }
+                }
+            }
+
+            form.set("scope", builder.toString());
+        }
+
+        return form;
+
+    }
+}

--- a/cloudfoundry-client-lib/src/main/java/org/cloudfoundry/client/lib/oauth2/ResourceOwnerPasscodeResourceDetails.java
+++ b/cloudfoundry-client-lib/src/main/java/org/cloudfoundry/client/lib/oauth2/ResourceOwnerPasscodeResourceDetails.java
@@ -1,0 +1,26 @@
+package org.cloudfoundry.client.lib.oauth2;
+
+import org.springframework.security.oauth2.client.resource.BaseOAuth2ProtectedResourceDetails;
+
+/**
+ * Resource details for passcode auth.
+ *
+ * @see ResourceOwnerPasscodeAccessTokenProvider
+ *
+ * @author Matthias Winzeler <matthias.winzeler@gmail.com>
+ */
+public class ResourceOwnerPasscodeResourceDetails extends BaseOAuth2ProtectedResourceDetails {
+    private String passcode;
+
+    public ResourceOwnerPasscodeResourceDetails() {
+        setGrantType("password");
+    }
+
+    public String getPasscode() {
+        return passcode;
+    }
+
+    public void setPasscode(String passcode) {
+        this.passcode = passcode;
+    }
+}

--- a/cloudfoundry-client-lib/src/test/java/org/cloudfoundry/client/lib/CloudFoundryClientTest.java
+++ b/cloudfoundry-client-lib/src/test/java/org/cloudfoundry/client/lib/CloudFoundryClientTest.java
@@ -12,6 +12,7 @@ import static org.junit.Assert.assertSame;
 import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
+import static org.junit.Assume.assumeNotNull;
 import static org.junit.Assume.assumeTrue;
 
 import java.io.File;
@@ -34,6 +35,8 @@ import java.util.Map;
 import java.util.Set;
 import java.util.UUID;
 import java.util.concurrent.atomic.AtomicInteger;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
 import org.apache.commons.io.IOUtils;
 import org.cloudfoundry.client.lib.domain.ApplicationLog;
@@ -91,14 +94,15 @@ import org.junit.rules.TestWatcher;
 import org.junit.runner.Description;
 import org.junit.runner.RunWith;
 import org.springframework.core.io.ClassPathResource;
-import org.springframework.http.HttpMethod;
-import org.springframework.http.HttpStatus;
+import org.springframework.http.*;
 import org.springframework.http.client.ClientHttpRequestFactory;
 import org.springframework.http.client.ClientHttpResponse;
 import org.springframework.http.client.HttpComponentsClientHttpRequestFactory;
 import org.springframework.http.client.SimpleClientHttpRequestFactory;
 import org.springframework.security.oauth2.common.DefaultOAuth2AccessToken;
 import org.springframework.security.oauth2.common.OAuth2AccessToken;
+import org.springframework.util.LinkedMultiValueMap;
+import org.springframework.util.MultiValueMap;
 import org.springframework.web.client.HttpClientErrorException;
 import org.springframework.web.client.HttpServerErrorException;
 import org.springframework.web.client.ResponseExtractor;
@@ -2246,6 +2250,137 @@ public class CloudFoundryClientTest {
 		} catch(Exception e){
 			// Nothing we can do at this point except protect other teardown logic from not running
 		}
+	}
+
+	@Test
+	public void loginWithPasscode() throws Exception {
+		String passcode = getOtpPasscodeForTest();
+		assumeNotNull(passcode);
+		CloudCredentials credentials = new CloudCredentials(passcode);
+
+		URL cloudControllerUrl = new URL(CCNG_API_URL);
+		CloudFoundryClient clientForPasscodeLogin =
+				new CloudFoundryClient(credentials, cloudControllerUrl, httpProxyConfiguration);
+		// setting up client triggers login - so no need to login() again
+		assertTrue("orgs should be retrieved (login successful)", !clientForPasscodeLogin.getOrganizations().isEmpty());
+	}
+
+	@Test
+	public void loginWithPasscodeHandlesMultipleCallsToLogin() throws Exception {
+		String passcode = getOtpPasscodeForTest();
+		assumeNotNull(passcode);
+		CloudCredentials credentials = new CloudCredentials(passcode);
+
+		URL cloudControllerUrl = new URL(CCNG_API_URL);
+		CloudFoundryClient clientForPasscodeLogin =
+				new CloudFoundryClient(credentials, cloudControllerUrl, httpProxyConfiguration);
+		clientForPasscodeLogin.login();
+		clientForPasscodeLogin.login();
+		clientForPasscodeLogin.login();
+		assertTrue("orgs should be retrieved (login successful)", !clientForPasscodeLogin.getOrganizations().isEmpty());
+	}
+
+	@Test
+	public void refreshTokenOnExpirationWithPasscodeLogin() throws Exception {
+		String passcode = getOtpPasscodeForTest();
+		assumeNotNull(passcode);
+		CloudCredentials credentials = new CloudCredentials(passcode);
+
+		URL cloudControllerUrl = new URL(CCNG_API_URL);
+
+		CloudControllerClientFactory factory =
+				new CloudControllerClientFactory(httpProxyConfiguration, CCNG_API_SSL);
+		CloudControllerClient client = factory.newCloudController(cloudControllerUrl, credentials, CCNG_USER_ORG, CCNG_USER_SPACE);
+
+		client.login();
+
+		validateClientAccess(client);
+
+		OauthClient oauthClient = factory.getOauthClient();
+		OAuth2AccessToken token = oauthClient.getToken();
+		if (token instanceof DefaultOAuth2AccessToken) {
+			// set the token expiration to "now", forcing the access token to be refreshed
+			((DefaultOAuth2AccessToken) token).setExpiration(new Date());
+			validateClientAccess(client);
+		} else {
+			fail("Error forcing expiration of access token");
+		}
+	}
+
+	@Test
+	public void obtainPasscodeForLoggedInUser() throws Exception {
+		String passcodePattern = "[A-Za-z0-9]{6}";
+
+		String passcode1 = getOtpPasscodeForTest();
+		assumeNotNull(passcode1);
+		assertTrue("Passcode is retrieved and looks valid", passcode1.matches(passcodePattern));
+
+		String passcode2 = getOtpPasscodeForTest();
+		assertTrue("Can obtain multiple passcodes", !passcode2.equals(passcode1));
+		assertTrue("Can obtain multiple passcodes", passcode2.matches(passcodePattern));
+	}
+
+	private String getOtpPasscodeForTest() throws Exception {
+		try {
+			CloudInfo info = connectedClient.getCloudInfo();
+			List<String> cookies = doFormAuthOnLoginServer(info.getAuthorizationEndpoint());
+			return retrieveOtpPasscodeFromLoginServerSession(info.getAuthorizationEndpoint(), cookies);
+		}
+		catch(Exception e) {
+			System.err.println("WARNING: Skipping some tests since obtaining passcodes failed: " + e.getMessage());
+			e.printStackTrace();
+			return null;
+		}
+	}
+
+	private List<String> doFormAuthOnLoginServer(String loginServerUrl) {
+		String loginEndpointUrl = loginServerUrl + "/login.do";
+
+		RestUtil restUtil = new RestUtil();
+		RestTemplate restTemplate = restUtil.createRestTemplate(httpProxyConfiguration, CCNG_API_SSL);
+		MultiValueMap<String, String> loginRequestBody = new LinkedMultiValueMap<>();
+		loginRequestBody.add("username", CCNG_USER_EMAIL);
+		loginRequestBody.add("password", CCNG_USER_PASS);
+		HttpHeaders loginRequestHeaders = new HttpHeaders();
+		loginRequestHeaders.setContentType(MediaType.APPLICATION_FORM_URLENCODED);
+		HttpEntity<MultiValueMap<String, String>> loginRequest = new HttpEntity<>(loginRequestBody, loginRequestHeaders);
+		HttpEntity<String> response = restTemplate.exchange(loginEndpointUrl, HttpMethod.POST, loginRequest, String.class);
+
+		HttpHeaders headers = response.getHeaders();
+		List<String> cookies = headers.get("Set-Cookie");
+		if(cookies == null || cookies.isEmpty()) {
+			throw new RuntimeException("No cookies set when logging in on login server for passcodes: " + response);
+		}
+		return cookies;
+	}
+
+	private String retrieveOtpPasscodeFromLoginServerSession(String loginServerUrl, List<String> sessionCookies) {
+		String passcodeUrl = loginServerUrl + "/passcode";
+
+		RestUtil restUtil = new RestUtil();
+		RestTemplate restTemplate = restUtil.createRestTemplate(httpProxyConfiguration, CCNG_API_SSL);
+
+		HttpHeaders requestHeaders = new HttpHeaders();
+		for(String cookie : sessionCookies) {
+			requestHeaders.add("Cookie", cookie);
+		}
+		requestHeaders.add("Accept", "*/*");
+		HttpEntity requestEntity = new HttpEntity(null, requestHeaders);
+		ResponseEntity passcodeResponse = restTemplate.exchange(
+				passcodeUrl,
+				HttpMethod.GET,
+				requestEntity,
+				String.class);
+		return parseOtpPasscodeFromHtml((String) passcodeResponse.getBody());
+	}
+
+	private String parseOtpPasscodeFromHtml(String html) {
+		String passcodeRegex = "<h1>Temporary Authentication Code</h1>.*<h2>([A-Za-z0-9]{6})</h2>";
+		Pattern passcodePattern = Pattern.compile(passcodeRegex, Pattern.DOTALL);
+		Matcher passcodeMatcher = passcodePattern.matcher(html);
+		assertTrue(passcodeMatcher.find());
+
+		return passcodeMatcher.group(1);
 	}
 
 	//

--- a/cloudfoundry-client-lib/src/test/java/org/cloudfoundry/client/lib/CloudFoundryClientTest.java
+++ b/cloudfoundry-client-lib/src/test/java/org/cloudfoundry/client/lib/CloudFoundryClientTest.java
@@ -153,7 +153,7 @@ public class CloudFoundryClientTest {
 	private static final String MYSQL_SERVICE_LABEL = System.getProperty("vcap.mysql.label", "p-mysql");
 	private static final String MYSQL_SERVICE_PLAN = System.getProperty("vcap.mysql.plan", "100mb-dev");
 
-	private static final String DEFAULT_STACK_NAME = "lucid64";
+	private static final String DEFAULT_STACK_NAME = System.getProperty("ccng.stackName", "lucid64");
 
 	private static final boolean SILENT_TEST_TIMINGS = Boolean.getBoolean("silent.testTimings");
 
@@ -176,6 +176,8 @@ public class CloudFoundryClientTest {
 	private static final String CCNG_QUOTA_NAME_TEST = System.getProperty("ccng.quota", "test_quota");
 
 	private static final String CCNG_SECURITY_GROUP_NAME_TEST = System.getProperty("ccng.securityGroup", "test_security_group");
+
+	private static final String APP_DOMAIN = System.getProperty("ccng.appDomain", "cf.deepsouthcloud.com");
 
 	private static boolean tearDownComplete = false;
 
@@ -1364,18 +1366,18 @@ public class CloudFoundryClientTest {
 		boolean pass = ensureApplicationRunning("haash-broker");
 		assertTrue("haash-broker failed to start", pass);
 
-		CloudServiceBroker newBroker = new CloudServiceBroker(CloudEntity.Meta.defaultMeta(), "haash-broker", "http://haash-broker.cf.deepsouthcloud.com", "warreng", "snoopdogg");
+		String brokerUrl = "http://haash-broker." +  APP_DOMAIN;
+		CloudServiceBroker newBroker = new CloudServiceBroker(CloudEntity.Meta.defaultMeta(), "haash-broker", brokerUrl, "warreng", "snoopdogg");
 		connectedClient.createServiceBroker(newBroker);
 
 		CloudServiceBroker broker = connectedClient.getServiceBroker("haash-broker");
 		assertNotNull(broker);
 		assertNotNull(broker.getMeta());
-		assertEquals("haash-broker", broker.getName());
-		assertEquals("http://haash-broker.cf.deepsouthcloud.com", broker.getUrl());
+		assertEquals(brokerUrl, broker.getUrl());
 		assertEquals("warreng", broker.getUsername());
 		assertNull(broker.getPassword());
 
-		newBroker = new CloudServiceBroker(CloudEntity.Meta.defaultMeta(), "haash-broker", "http://haash-broker.cf.deepsouthcloud.com", "warreng", "snoopdogg");
+		newBroker = new CloudServiceBroker(CloudEntity.Meta.defaultMeta(), "haash-broker", brokerUrl, "warreng", "snoopdogg");
 		connectedClient.updateServiceBroker(newBroker);
 
 		connectedClient.updateServicePlanVisibilityForBroker("haash-broker", true);


### PR DESCRIPTION
The CF CLI provides a way to log in with one time passcodes (received from the login server) instead of username and password: `cf login --sso <url>`
Details see [CLI source]
(https://github.com/cloudfoundry/cli/blob/6d59cac36ae6ac296b4d7cc07cf362a2438b58ce/cf/commands/login.go#L128)

This is needed in SSO scenarios (where SAML federation is enabled on the CF login server).

This pull request extends the cf-java-client to allow authentication with these one time passcodes. 
We need this to extend the Eclipse plugin, which currently does not provide a way to authenticate users in SSO scenarios (see https://github.com/cloudfoundry/eclipse-integration-cloudfoundry/issues/36).

Integration tests are basically passing against a default bosh-lite, although I had to make some hardcoded values configurable to get them passing.
I couldn't get the integration test `checkByteManrulesAndInJvmProxyAssertMechanisms` working on my env - can you check that it's not because of my commit?

Note: [The newly added tests](https://github.com/MatthiasWinzeler/cf-java-client/commit/64c127c4b488b86f914d52a866bd4767bb464a78#diff-3aef6600ac97aad8bb889e4a41326d6eR2311) retrieve the passcodes from the login server they run against by simulating a browser login. This works well for a default CF instance (i.e. bosh-lite). When run against a non-default CF instance that does not offer a login server or passcodes, these tests might (gracefully) fail/be skipped.