### PR TITLE
[gradle-plugin] overriding of the file attribute from the command line

### DIFF
--- a/cloudfoundry-gradle-plugin/src/main/groovy/org/cloudfoundry/gradle/tasks/AbstractCloudFoundryTask.groovy
+++ b/cloudfoundry-gradle-plugin/src/main/groovy/org/cloudfoundry/gradle/tasks/AbstractCloudFoundryTask.groovy
@@ -324,9 +324,15 @@ abstract class AbstractCloudFoundryTask extends DefaultTask {
     }
 
     File getFile() {
-        ((project.cloudfoundry.file ?:
+        ((getCommandLineFile()?:
+                project.cloudfoundry.file ?:
                 getDefaultArchiveForTask(WarPlugin.WAR_TASK_NAME)) ?:
                 getDefaultArchiveForTask(JavaPlugin.JAR_TASK_NAME))
+    }
+
+    def File getCommandLineFile() {
+        File commandLineFile = new File(propertyOrExtension('file'))
+        commandLineFile.exists()? commandLineFile: null
     }
 
     File getDefaultArchiveForTask(String taskName) {

--- a/cloudfoundry-gradle-plugin/src/main/groovy/org/cloudfoundry/gradle/tasks/AbstractCloudFoundryTask.groovy
+++ b/cloudfoundry-gradle-plugin/src/main/groovy/org/cloudfoundry/gradle/tasks/AbstractCloudFoundryTask.groovy
@@ -331,8 +331,12 @@ abstract class AbstractCloudFoundryTask extends DefaultTask {
     }
 
     def File getCommandLineFile() {
-        File commandLineFile = new File(propertyOrExtension('file'))
-        commandLineFile.exists()? commandLineFile: null
+        def fileName = propertyOrExtension('file')
+        if(fileName) {
+            File commandLineFile = new File(propertyOrExtension('file'))
+            commandLineFile.exists() ? commandLineFile : null
+        }
+        null
     }
 
     File getDefaultArchiveForTask(String taskName) {

--- a/cloudfoundry-gradle-plugin/src/main/groovy/org/cloudfoundry/gradle/tasks/AbstractCloudFoundryTask.groovy
+++ b/cloudfoundry-gradle-plugin/src/main/groovy/org/cloudfoundry/gradle/tasks/AbstractCloudFoundryTask.groovy
@@ -331,9 +331,9 @@ abstract class AbstractCloudFoundryTask extends DefaultTask {
     }
 
     def File getCommandLineFile() {
-        def fileName = propertyOrExtension('file')
+        String fileName = propertyOrExtension('file')
         if(fileName) {
-            File commandLineFile = new File(propertyOrExtension('file'))
+            File commandLineFile = new File(fileName)
             commandLineFile.exists() ? commandLineFile : null
         }
         null

--- a/cloudfoundry-gradle-plugin/src/main/groovy/org/cloudfoundry/gradle/tasks/AbstractCloudFoundryTask.groovy
+++ b/cloudfoundry-gradle-plugin/src/main/groovy/org/cloudfoundry/gradle/tasks/AbstractCloudFoundryTask.groovy
@@ -334,7 +334,11 @@ abstract class AbstractCloudFoundryTask extends DefaultTask {
         String fileName = propertyOrExtension('file')
         if(fileName) {
             File commandLineFile = new File(fileName)
-            commandLineFile.exists() ? commandLineFile : null
+            if (commandLineFile.exists()){
+                return commandLineFile
+            } else {
+                throw new RuntimeException("could not use file [${file.getAbsolutePath()}] as it does not exist")
+            }
         }
         null
     }


### PR DESCRIPTION
Allow deploy and push actions with an override from the command line with the gradle plugin.

E.G.: -PcfFile=a-new-file.jar

This throws a runtime exception if the override is used and it cannot be found.  

I did not want it to be invoked then silently fail to deploy a file that does not exist.  Currently it will then try to see if there is a jar to deploy and then the war.