### PR TITLE
FIX: Skip SSL Validation

### DIFF
--- a/cloudfoundry-client-spring/src/main/lombok/org/cloudfoundry/client/spring/SpringCloudFoundryClient.java
+++ b/cloudfoundry-client-spring/src/main/lombok/org/cloudfoundry/client/spring/SpringCloudFoundryClient.java
@@ -107,7 +107,7 @@ public final class SpringCloudFoundryClient implements CloudFoundryClient {
                              String username, String password, RestOperations bootstrapRestOperations,
                              SslCertificateTruster sslCertificateTruster) {
 
-        if (!Optional.of(skipSslValidation).orElse(false)) {
+        if (!Optional.ofNullable(skipSslValidation).orElse(false)) {
             try {
                 sslCertificateTruster.trust(host, 443, 5, SECONDS);
             } catch (GeneralSecurityException | IOException e) {


### PR DESCRIPTION
- No negation: if skipSslValidation is set to true then we need to trust the target host
- Use of Optional.ofNullable otherwise a Nullpointer will be raised when skipSslValidation is not provided