### PR TITLE
Remove Space from the Space Quota Definition

### DIFF
--- a/cloudfoundry-client-spring/src/main/lombok/org/cloudfoundry/client/spring/v2/spacequotadefinitions/SpringSpaceQuotaDefinitions.java
+++ b/cloudfoundry-client-spring/src/main/lombok/org/cloudfoundry/client/spring/v2/spacequotadefinitions/SpringSpaceQuotaDefinitions.java
@@ -25,6 +25,7 @@ import org.cloudfoundry.client.v2.spacequotadefinitions.GetSpaceQuotaDefinitionR
 import org.cloudfoundry.client.v2.spacequotadefinitions.GetSpaceQuotaDefinitionResponse;
 import org.cloudfoundry.client.v2.spacequotadefinitions.ListSpaceQuotaDefinitionsRequest;
 import org.cloudfoundry.client.v2.spacequotadefinitions.ListSpaceQuotaDefinitionsResponse;
+import org.cloudfoundry.client.v2.spacequotadefinitions.RemoveSpaceQuotaDefinitionRequest;
 import org.cloudfoundry.client.v2.spacequotadefinitions.SpaceQuotaDefinitions;
 import org.cloudfoundry.client.v2.spaces.Spaces;
 import org.springframework.web.client.RestOperations;
@@ -84,6 +85,18 @@ public final class SpringSpaceQuotaDefinitions extends AbstractSpringOperations 
             public void accept(UriComponentsBuilder builder) {
                 builder.pathSegment("v2", "space_quota_definitions");
                 QueryBuilder.augment(builder, request);
+            }
+
+        });
+    }
+
+    @Override
+    public Mono<Void> removeSpace(final RemoveSpaceQuotaDefinitionRequest request) {
+        return delete(request, new Consumer<UriComponentsBuilder>() {
+
+            @Override
+            public void accept(UriComponentsBuilder builder) {
+                builder.pathSegment("v2", "space_quota_definitions", request.getId(), "spaces", request.getSpaceId());
             }
 
         });

--- a/cloudfoundry-client-spring/src/test/java/org/cloudfoundry/client/spring/v2/spacequotadefinitions/SpringSpaceQuotaDefinitionsTest.java
+++ b/cloudfoundry-client-spring/src/test/java/org/cloudfoundry/client/spring/v2/spacequotadefinitions/SpringSpaceQuotaDefinitionsTest.java
@@ -23,14 +23,17 @@ import org.cloudfoundry.client.v2.spacequotadefinitions.GetSpaceQuotaDefinitionR
 import org.cloudfoundry.client.v2.spacequotadefinitions.GetSpaceQuotaDefinitionResponse;
 import org.cloudfoundry.client.v2.spacequotadefinitions.ListSpaceQuotaDefinitionsRequest;
 import org.cloudfoundry.client.v2.spacequotadefinitions.ListSpaceQuotaDefinitionsResponse;
+import org.cloudfoundry.client.v2.spacequotadefinitions.RemoveSpaceQuotaDefinitionRequest;
 import org.cloudfoundry.client.v2.spacequotadefinitions.SpaceQuotaDefinitionEntity;
 import org.cloudfoundry.client.v2.spacequotadefinitions.SpaceQuotaDefinitionResource;
 import org.reactivestreams.Publisher;
 import reactor.Mono;
 
 import static org.cloudfoundry.client.v2.Resource.Metadata;
+import static org.springframework.http.HttpMethod.DELETE;
 import static org.springframework.http.HttpMethod.GET;
 import static org.springframework.http.HttpMethod.PUT;
+import static org.springframework.http.HttpStatus.NO_CONTENT;
 import static org.springframework.http.HttpStatus.OK;
 
 public final class SpringSpaceQuotaDefinitionsTest {
@@ -197,6 +200,38 @@ public final class SpringSpaceQuotaDefinitionsTest {
             return this.spaceQuotaDefinitions.list(request);
         }
 
+    }
+
+    public static final class RemoveSpace extends AbstractApiTest<RemoveSpaceQuotaDefinitionRequest, Void> {
+
+        private final SpringSpaceQuotaDefinitions spaceQuotaDefinitions = new SpringSpaceQuotaDefinitions(this.restTemplate, this.root, PROCESSOR_GROUP);
+
+        @Override
+        protected RemoveSpaceQuotaDefinitionRequest getInvalidRequest() {
+            return RemoveSpaceQuotaDefinitionRequest.builder().build();
+        }
+
+        @Override
+        protected RequestContext getRequestContext() {
+            return new RequestContext()
+                    .method(DELETE).path("/v2/space_quota_definitions/test-id/spaces/test-space-id")
+                    .status(NO_CONTENT);
+        }
+
+        @Override
+        protected Void getResponse() {
+            return null;
+        }
+
+        @Override
+        protected RemoveSpaceQuotaDefinitionRequest getValidRequest() throws Exception {
+            return RemoveSpaceQuotaDefinitionRequest.builder().id("test-id").spaceId("test-space-id").build();
+        }
+
+        @Override
+        protected Mono<Void> invoke(RemoveSpaceQuotaDefinitionRequest request) {
+            return this.spaceQuotaDefinitions.removeSpace(request);
+        }
     }
 
 }

--- a/cloudfoundry-client/src/main/java/org/cloudfoundry/client/v2/spacequotadefinitions/SpaceQuotaDefinitions.java
+++ b/cloudfoundry-client/src/main/java/org/cloudfoundry/client/v2/spacequotadefinitions/SpaceQuotaDefinitions.java
@@ -47,5 +47,13 @@ public interface SpaceQuotaDefinitions {
      */
     Mono<ListSpaceQuotaDefinitionsResponse> list(ListSpaceQuotaDefinitionsRequest request);
 
+    /**
+     * Makes the <a href="http://apidocs.cloudfoundry.org/214/space_quota_definitions/remove_space_from_the_space_quota_definition.html">Remove a Space from a Space Quota Definition</a> request
+     *
+     * @param request the Remove a Space from a Space Quota Definition request
+     * @return the response from the Remove a Space from a Space Quota Definition request
+     */
+    Mono<Void> removeSpace(RemoveSpaceQuotaDefinitionRequest request);
+
 
 }

--- a/cloudfoundry-client/src/main/lombok/org/cloudfoundry/client/v2/spacequotadefinitions/RemoveSpaceQuotaDefinitionRequest.java
+++ b/cloudfoundry-client/src/main/lombok/org/cloudfoundry/client/v2/spacequotadefinitions/RemoveSpaceQuotaDefinitionRequest.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright 2013-2016 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.cloudfoundry.client.v2.spacequotadefinitions;
+
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import lombok.Builder;
+import lombok.Data;
+import lombok.Getter;
+import org.cloudfoundry.client.Validatable;
+import org.cloudfoundry.client.ValidationResult;
+
+/**
+ * The request payload for the Remove Space from the Space Quota Definition operation
+ */
+@Data
+public class RemoveSpaceQuotaDefinitionRequest implements Validatable {
+
+    /**
+     * The id
+     *
+     * @param id the id
+     * @return the id
+     */
+    @Getter(onMethod = @__(@JsonIgnore))
+    private final String id;
+
+    /**
+     * The space id
+     *
+     * @param spaceId the space id
+     * @return the space id
+     */
+    @Getter(onMethod = @__(@JsonIgnore))
+    private final String spaceId;
+
+    @Builder
+    RemoveSpaceQuotaDefinitionRequest(String spaceId, String id) {
+        this.spaceId = spaceId;
+        this.id = id;
+    }
+
+    @Override
+    public ValidationResult isValid() {
+        ValidationResult.ValidationResultBuilder builder = ValidationResult.builder();
+
+        if (this.id == null) {
+            builder.message("id must be specified");
+        }
+
+        if (this.spaceId == null) {
+            builder.message("space id must be specified");
+        }
+
+        return builder.build();
+    }
+
+}

--- a/cloudfoundry-client/src/test/java/org/cloudfoundry/client/v2/spacequotadefinitions/RemoveSpaceQuotaDefinitionRequestTest.java
+++ b/cloudfoundry-client/src/test/java/org/cloudfoundry/client/v2/spacequotadefinitions/RemoveSpaceQuotaDefinitionRequestTest.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright 2013-2016 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.cloudfoundry.client.v2.spacequotadefinitions;
+
+import org.cloudfoundry.client.ValidationResult;
+import org.junit.Test;
+
+import static org.cloudfoundry.client.ValidationResult.Status.INVALID;
+import static org.cloudfoundry.client.ValidationResult.Status.VALID;
+import static org.junit.Assert.assertEquals;
+
+public class RemoveSpaceQuotaDefinitionRequestTest {
+
+    @Test
+    public void isValid() {
+        ValidationResult result = RemoveSpaceQuotaDefinitionRequest.builder()
+                .id("test-id")
+                .spaceId("space-id")
+                .build()
+                .isValid();
+
+        assertEquals(VALID, result.getStatus());
+    }
+
+    @Test
+    public void isValidNoId() {
+        ValidationResult result = RemoveSpaceQuotaDefinitionRequest.builder()
+                .build()
+                .isValid();
+
+        assertEquals(INVALID, result.getStatus());
+        assertEquals("id must be specified", result.getMessages().get(0));
+    }
+
+    @Test
+    public void isValidNoSpaceId() {
+        ValidationResult result = RemoveSpaceQuotaDefinitionRequest.builder()
+                .id("test-id")
+                .build()
+                .isValid();
+
+        assertEquals(INVALID, result.getStatus());
+        assertEquals("space id must be specified", result.getMessages().get(0));
+    }
+}


### PR DESCRIPTION
This change adds the API for Remove Space from the Space Quota Definition
(DELETE /v2/space_quota_definitions/:guid/spaces/:space_guid).

 [#101527374]