### PR TITLE
List Service Bindings for a Service Instance

### DIFF
--- a/cloudfoundry-client-spring/src/main/lombok/org/cloudfoundry/client/spring/v2/serviceinstances/SpringServiceInstances.java
+++ b/cloudfoundry-client-spring/src/main/lombok/org/cloudfoundry/client/spring/v2/serviceinstances/SpringServiceInstances.java
@@ -22,6 +22,8 @@ import org.cloudfoundry.client.spring.util.QueryBuilder;
 import org.cloudfoundry.client.spring.v2.FilterBuilder;
 import org.cloudfoundry.client.v2.serviceinstances.GetServiceInstanceRequest;
 import org.cloudfoundry.client.v2.serviceinstances.GetServiceInstanceResponse;
+import org.cloudfoundry.client.v2.serviceinstances.ListServiceInstanceServiceBindingsRequest;
+import org.cloudfoundry.client.v2.serviceinstances.ListServiceInstanceServiceBindingsResponse;
 import org.cloudfoundry.client.v2.serviceinstances.ListServiceInstancesRequest;
 import org.cloudfoundry.client.v2.serviceinstances.ListServiceInstancesResponse;
 import org.cloudfoundry.client.v2.serviceinstances.ServiceInstances;
@@ -75,4 +77,19 @@ public final class SpringServiceInstances extends AbstractSpringOperations imple
 
         });
     }
+
+    @Override
+    public Mono<ListServiceInstanceServiceBindingsResponse> listServiceBindings(final ListServiceInstanceServiceBindingsRequest request) {
+        return get(request, ListServiceInstanceServiceBindingsResponse.class, new Consumer<UriComponentsBuilder>() {
+
+            @Override
+            public void accept(UriComponentsBuilder builder) {
+                builder.pathSegment("v2", "service_instances", request.getId(), "service_bindings");
+                FilterBuilder.augment(builder, request);
+                QueryBuilder.augment(builder, request);
+            }
+
+        });
+    }
+
 }

--- a/cloudfoundry-client-spring/src/test/java/org/cloudfoundry/client/spring/v2/serviceinstances/SpringServiceInstancesTest.java
+++ b/cloudfoundry-client-spring/src/test/java/org/cloudfoundry/client/spring/v2/serviceinstances/SpringServiceInstancesTest.java
@@ -17,8 +17,13 @@
 package org.cloudfoundry.client.spring.v2.serviceinstances;
 
 import org.cloudfoundry.client.spring.AbstractApiTest;
+import org.cloudfoundry.client.v2.Resource;
+import org.cloudfoundry.client.v2.servicebindings.ServiceBindingEntity;
+import org.cloudfoundry.client.v2.servicebindings.ServiceBindingResource;
 import org.cloudfoundry.client.v2.serviceinstances.GetServiceInstanceRequest;
 import org.cloudfoundry.client.v2.serviceinstances.GetServiceInstanceResponse;
+import org.cloudfoundry.client.v2.serviceinstances.ListServiceInstanceServiceBindingsRequest;
+import org.cloudfoundry.client.v2.serviceinstances.ListServiceInstanceServiceBindingsResponse;
 import org.cloudfoundry.client.v2.serviceinstances.ListServiceInstancesRequest;
 import org.cloudfoundry.client.v2.serviceinstances.ListServiceInstancesResponse;
 import org.cloudfoundry.client.v2.serviceinstances.ServiceInstanceEntity;
@@ -161,6 +166,65 @@ public final class SpringServiceInstancesTest {
         @Override
         protected Mono<ListServiceInstancesResponse> invoke(ListServiceInstancesRequest request) {
             return this.serviceInstances.list(request);
+        }
+
+    }
+
+    public static final class ListServiceBindings
+            extends AbstractApiTest<ListServiceInstanceServiceBindingsRequest, ListServiceInstanceServiceBindingsResponse> {
+
+        private final SpringServiceInstances serviceInstances = new SpringServiceInstances(this.restTemplate, this.root, PROCESSOR_GROUP);
+
+        @Override
+        protected ListServiceInstanceServiceBindingsRequest getInvalidRequest() {
+            return ListServiceInstanceServiceBindingsRequest.builder()
+                    .build();
+        }
+
+        @Override
+        protected RequestContext getRequestContext() {
+            return new RequestContext()
+                    .method(GET)
+                    .path("v2/service_instances/test-id/service_bindings?q=app_guid%20IN%20test-application-id&page=-1")
+                    .status(OK)
+                    .responsePayload("v2/service_instances/GET_{id}_service_bindings_response.json");
+        }
+
+        @Override
+        protected ListServiceInstanceServiceBindingsResponse getResponse() {
+            return ListServiceInstanceServiceBindingsResponse.builder()
+                    .totalResults(1)
+                    .totalPages(1)
+                    .resource(ServiceBindingResource.builder()
+                            .metadata(Resource.Metadata.builder()
+                                    .createdAt("2015-07-27T22:43:09Z")
+                                    .id("05f3ec3c-8d97-4bd8-bf86-e44cc835a154")
+                                    .url("/v2/service_bindings/05f3ec3c-8d97-4bd8-bf86-e44cc835a154")
+                                    .build())
+                            .entity(ServiceBindingEntity.builder()
+                                    .applicationId("8a50163b-a39d-4f44-aece-dc5a956da848")
+                                    .serviceInstanceId("a5a0567e-edbf-4da9-ae90-dce24af308a1")
+                                    .credential("creds-key-85", "creds-val-85")
+                                    .gatewayName("")
+                                    .applicationUrl("/v2/apps/8a50163b-a39d-4f44-aece-dc5a956da848")
+                                    .serviceInstanceUrl("/v2/service_instances/a5a0567e-edbf-4da9-ae90-dce24af308a1")
+                                    .build())
+                            .build())
+                    .build();
+        }
+
+        @Override
+        protected ListServiceInstanceServiceBindingsRequest getValidRequest() throws Exception {
+            return ListServiceInstanceServiceBindingsRequest.builder()
+                    .id("test-id")
+                    .applicationId("test-application-id")
+                    .page(-1)
+                    .build();
+        }
+
+        @Override
+        protected Mono<ListServiceInstanceServiceBindingsResponse> invoke(ListServiceInstanceServiceBindingsRequest request) {
+            return this.serviceInstances.listServiceBindings(request);
         }
 
     }

--- a/cloudfoundry-client-spring/src/test/resources/v2/service_instances/GET_{id}_service_bindings_response.json
+++ b/cloudfoundry-client-spring/src/test/resources/v2/service_instances/GET_{id}_service_bindings_response.json
@@ -1,0 +1,31 @@
+{
+  "total_results": 1,
+  "total_pages": 1,
+  "prev_url": null,
+  "next_url": null,
+  "resources": [
+    {
+      "metadata": {
+        "guid": "05f3ec3c-8d97-4bd8-bf86-e44cc835a154",
+        "url": "/v2/service_bindings/05f3ec3c-8d97-4bd8-bf86-e44cc835a154",
+        "created_at": "2015-07-27T22:43:09Z",
+        "updated_at": null
+      },
+      "entity": {
+        "app_guid": "8a50163b-a39d-4f44-aece-dc5a956da848",
+        "service_instance_guid": "a5a0567e-edbf-4da9-ae90-dce24af308a1",
+        "credentials": {
+          "creds-key-85": "creds-val-85"
+        },
+        "binding_options": {
+
+        },
+        "gateway_data": null,
+        "gateway_name": "",
+        "syslog_drain_url": null,
+        "app_url": "/v2/apps/8a50163b-a39d-4f44-aece-dc5a956da848",
+        "service_instance_url": "/v2/service_instances/a5a0567e-edbf-4da9-ae90-dce24af308a1"
+      }
+    }
+  ]
+}

--- a/cloudfoundry-client/src/main/java/org/cloudfoundry/client/v2/serviceinstances/ServiceInstances.java
+++ b/cloudfoundry-client/src/main/java/org/cloudfoundry/client/v2/serviceinstances/ServiceInstances.java
@@ -39,4 +39,12 @@ public interface ServiceInstances {
      */
     Mono<ListServiceInstancesResponse> list(ListServiceInstancesRequest request);
 
+    /**
+     * Makes the <a href="http://apidocs.cloudfoundry.org/214/service_instances/list_all_service_bindings_for_the_service_instance.html">List all Service Bindings for the Service Binding</a> request
+     *
+     * @param request the List Service Bindings request
+     * @return the response from the List Service Bindings request
+     */
+    Mono<ListServiceInstanceServiceBindingsResponse> listServiceBindings(ListServiceInstanceServiceBindingsRequest request);
+
 }

--- a/cloudfoundry-client/src/main/lombok/org/cloudfoundry/client/v2/serviceinstances/ListServiceInstanceServiceBindingsRequest.java
+++ b/cloudfoundry-client/src/main/lombok/org/cloudfoundry/client/v2/serviceinstances/ListServiceInstanceServiceBindingsRequest.java
@@ -1,0 +1,79 @@
+/*
+ * Copyright 2013-2016 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.cloudfoundry.client.v2.serviceinstances;
+
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import lombok.Builder;
+import lombok.Data;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.Singular;
+import lombok.ToString;
+import org.cloudfoundry.client.Validatable;
+import org.cloudfoundry.client.ValidationResult;
+import org.cloudfoundry.client.v2.InFilterParameter;
+import org.cloudfoundry.client.v2.PaginatedRequest;
+
+import java.util.List;
+
+/**
+ * The request payload for the List all Service Bindings for the Service Binding operation
+ */
+@Data
+@EqualsAndHashCode(callSuper = true)
+@ToString(callSuper = true)
+public final class ListServiceInstanceServiceBindingsRequest extends PaginatedRequest implements Validatable {
+
+    /**
+     * The id of the Service Instance
+     *
+     * @param id the id of the Service Instance
+     * @return the id of the Service Instance
+     */
+    @Getter(onMethod = @__(@JsonIgnore))
+    private final String id;
+
+    /**
+     * The ids of the applications
+     *
+     * @param applicationIds the ids of the applications to filter on
+     * @return the ids of the applications to filter on
+     */
+    @Getter(onMethod = @__(@InFilterParameter("app_guid")))
+    private final List<String> applicationIds;
+
+    @Builder
+    ListServiceInstanceServiceBindingsRequest(OrderDirection orderDirection, Integer page, Integer resultsPerPage,
+                                              @Singular List<String> applicationIds,
+                                              String id) {
+        super(orderDirection, page, resultsPerPage);
+        this.applicationIds = applicationIds;
+        this.id = id;
+    }
+
+    @Override
+    public ValidationResult isValid() {
+        ValidationResult.ValidationResultBuilder builder = ValidationResult.builder();
+
+        if (this.id == null) {
+            builder.message("id must be specified");
+        }
+
+        return builder.build();
+    }
+
+}

--- a/cloudfoundry-client/src/main/lombok/org/cloudfoundry/client/v2/serviceinstances/ListServiceInstanceServiceBindingsResponse.java
+++ b/cloudfoundry-client/src/main/lombok/org/cloudfoundry/client/v2/serviceinstances/ListServiceInstanceServiceBindingsResponse.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2013-2016 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.cloudfoundry.client.v2.serviceinstances;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.Builder;
+import lombok.Data;
+import lombok.EqualsAndHashCode;
+import lombok.Singular;
+import lombok.ToString;
+import org.cloudfoundry.client.v2.PaginatedResponse;
+import org.cloudfoundry.client.v2.servicebindings.ServiceBindingResource;
+
+import java.util.List;
+
+/**
+ * The response payload for the List all Service Bindings for the Service Instance operation
+ */
+@Data
+@EqualsAndHashCode(callSuper = true)
+@ToString(callSuper = true)
+public final class ListServiceInstanceServiceBindingsResponse extends PaginatedResponse<ServiceBindingResource> {
+
+    @Builder
+    ListServiceInstanceServiceBindingsResponse(@JsonProperty("next_url") String nextUrl,
+                                               @JsonProperty("prev_url") String previousUrl,
+                                               @JsonProperty("resources") @Singular List<ServiceBindingResource> resources,
+                                               @JsonProperty("total_pages") Integer totalPages,
+                                               @JsonProperty("total_results") Integer totalResults) {
+        super(nextUrl, previousUrl, resources, totalPages, totalResults);
+    }
+
+}

--- a/cloudfoundry-client/src/test/java/org/cloudfoundry/client/v2/serviceinstances/ListServiceInstanceServiceBindingsRequestTest.java
+++ b/cloudfoundry-client/src/test/java/org/cloudfoundry/client/v2/serviceinstances/ListServiceInstanceServiceBindingsRequestTest.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2013-2016 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.cloudfoundry.client.v2.serviceinstances;
+
+
+import org.cloudfoundry.client.ValidationResult;
+import org.junit.Test;
+
+import static org.cloudfoundry.client.ValidationResult.Status.INVALID;
+import static org.cloudfoundry.client.ValidationResult.Status.VALID;
+import static org.junit.Assert.assertEquals;
+
+public final class ListServiceInstanceServiceBindingsRequestTest {
+
+    @Test
+    public void isValid() {
+        ValidationResult result = ListServiceInstanceServiceBindingsRequest.builder()
+                .id("test-id")
+                .build()
+                .isValid();
+
+        assertEquals(VALID, result.getStatus());
+    }
+
+    @Test
+    public void isValidNoId() {
+        ValidationResult result = ListServiceInstanceServiceBindingsRequest.builder()
+                .build()
+                .isValid();
+
+        assertEquals(INVALID, result.getStatus());
+        assertEquals("id must be specified", result.getMessages().get(0));
+    }
+
+}


### PR DESCRIPTION
This change adds the API for List Service Binding for a Service Instance (GET /v2/service_instances/:guid/service_bindings) according to [this story](https://www.pivotaltracker.com/projects/816799/stories/101451540)