### PR TITLE
Delete Service Broker

### DIFF
--- a/cloudfoundry-client-spring/src/main/lombok/org/cloudfoundry/client/spring/v2/servicebrokers/SpringServiceBrokers.java
+++ b/cloudfoundry-client-spring/src/main/lombok/org/cloudfoundry/client/spring/v2/servicebrokers/SpringServiceBrokers.java
@@ -20,6 +20,7 @@ import lombok.ToString;
 import org.cloudfoundry.client.spring.util.AbstractSpringOperations;
 import org.cloudfoundry.client.v2.servicebrokers.CreateServiceBrokerRequest;
 import org.cloudfoundry.client.v2.servicebrokers.CreateServiceBrokerResponse;
+import org.cloudfoundry.client.v2.servicebrokers.DeleteServiceBrokerRequest;
 import org.cloudfoundry.client.v2.servicebrokers.ServiceBrokers;
 import org.springframework.web.client.RestOperations;
 import org.springframework.web.util.UriComponentsBuilder;
@@ -55,6 +56,17 @@ public final class SpringServiceBrokers extends AbstractSpringOperations impleme
                 builder.pathSegment("v2", "service_brokers");
             }
 
+        });
+    }
+
+    @Override
+    public Mono<Void> delete(final DeleteServiceBrokerRequest request) {
+        return delete(request, new Consumer<UriComponentsBuilder>() {
+
+            @Override
+            public void accept(UriComponentsBuilder builder) {
+                builder.pathSegment("v2", "service_brokers", request.getId());
+            }
         });
     }
 

--- a/cloudfoundry-client-spring/src/test/java/org/cloudfoundry/client/spring/v2/servicebrokers/SpringServiceBrokersTest.java
+++ b/cloudfoundry-client-spring/src/test/java/org/cloudfoundry/client/spring/v2/servicebrokers/SpringServiceBrokersTest.java
@@ -20,11 +20,14 @@ import org.cloudfoundry.client.spring.AbstractApiTest;
 import org.cloudfoundry.client.v2.Resource;
 import org.cloudfoundry.client.v2.servicebrokers.CreateServiceBrokerRequest;
 import org.cloudfoundry.client.v2.servicebrokers.CreateServiceBrokerResponse;
+import org.cloudfoundry.client.v2.servicebrokers.DeleteServiceBrokerRequest;
 import org.cloudfoundry.client.v2.servicebrokers.ServiceBrokerEntity;
 import reactor.Mono;
 
+import static org.springframework.http.HttpMethod.DELETE;
 import static org.springframework.http.HttpMethod.POST;
 import static org.springframework.http.HttpStatus.CREATED;
+import static org.springframework.http.HttpStatus.NO_CONTENT;
 
 public final class SpringServiceBrokersTest {
 
@@ -78,6 +81,38 @@ public final class SpringServiceBrokersTest {
             return this.serviceBrokers.create(request);
         }
 
+    }
+
+    public static final class Delete extends AbstractApiTest<DeleteServiceBrokerRequest, Void> {
+
+        private final SpringServiceBrokers serviceBrokers = new SpringServiceBrokers(this.restTemplate, this.root, PROCESSOR_GROUP);
+
+        @Override
+        protected DeleteServiceBrokerRequest getInvalidRequest() {
+            return DeleteServiceBrokerRequest.builder().build();
+        }
+
+        @Override
+        protected RequestContext getRequestContext() {
+            return new RequestContext()
+                    .method(DELETE).path("/v2/service_brokers/test-id")
+                    .status(NO_CONTENT);
+        }
+
+        @Override
+        protected Void getResponse() {
+            return null;
+        }
+
+        @Override
+        protected DeleteServiceBrokerRequest getValidRequest() throws Exception {
+            return DeleteServiceBrokerRequest.builder().id("test-id").build();
+        }
+
+        @Override
+        protected Mono<Void> invoke(DeleteServiceBrokerRequest request) {
+            return this.serviceBrokers.delete(request);
+        }
     }
 
 }

--- a/cloudfoundry-client/src/main/java/org/cloudfoundry/client/v2/servicebrokers/ServiceBrokers.java
+++ b/cloudfoundry-client/src/main/java/org/cloudfoundry/client/v2/servicebrokers/ServiceBrokers.java
@@ -31,4 +31,12 @@ public interface ServiceBrokers {
      */
     Mono<CreateServiceBrokerResponse> create(CreateServiceBrokerRequest request);
 
+    /**
+     * Makes the <a href="http://apidocs.cloudfoundry.org/214/service_brokers/delete_a_particular_service_broker.html">Delete the Service Broker</a> request
+     *
+     * @param request the Delete Service Broker request
+     * @return the response from the Delete Service Broker request
+     */
+    Mono<Void> delete(DeleteServiceBrokerRequest request);
+
 }

--- a/cloudfoundry-client/src/main/lombok/org/cloudfoundry/client/v2/servicebrokers/DeleteServiceBrokerRequest.java
+++ b/cloudfoundry-client/src/main/lombok/org/cloudfoundry/client/v2/servicebrokers/DeleteServiceBrokerRequest.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright 2013-2016 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.cloudfoundry.client.v2.servicebrokers;
+
+
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import lombok.Builder;
+import lombok.Getter;
+import org.cloudfoundry.client.Validatable;
+import org.cloudfoundry.client.ValidationResult;
+
+public final class DeleteServiceBrokerRequest implements Validatable {
+
+    /**
+     * The id
+     *
+     * @param id the id
+     * @return the id
+     */
+    @Getter(onMethod = @__(@JsonIgnore))
+    private final String id;
+
+    @Builder
+    DeleteServiceBrokerRequest(String id) {
+        this.id = id;
+    }
+
+    @Override
+    public ValidationResult isValid() {
+        ValidationResult.ValidationResultBuilder builder = ValidationResult.builder();
+
+        if (this.id == null) {
+            builder.message("id must be specified");
+        }
+
+        return builder.build();
+    }
+
+}

--- a/cloudfoundry-client/src/test/java/org/cloudfoundry/client/v2/servicebrokers/DeleteServiceBrokerRequestTest.java
+++ b/cloudfoundry-client/src/test/java/org/cloudfoundry/client/v2/servicebrokers/DeleteServiceBrokerRequestTest.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2013-2016 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.cloudfoundry.client.v2.servicebrokers;
+
+import org.cloudfoundry.client.ValidationResult;
+import org.junit.Test;
+
+import static org.cloudfoundry.client.ValidationResult.Status.INVALID;
+import static org.cloudfoundry.client.ValidationResult.Status.VALID;
+import static org.junit.Assert.assertEquals;
+
+
+public final class DeleteServiceBrokerRequestTest {
+
+    @Test
+    public void isValid() {
+        ValidationResult result = DeleteServiceBrokerRequest.builder()
+                .id("test-id")
+                .build()
+                .isValid();
+
+        assertEquals(VALID, result.getStatus());
+    }
+
+    @Test
+    public void isValidNoId() {
+        ValidationResult result = DeleteServiceBrokerRequest.builder()
+                .build()
+                .isValid();
+
+        assertEquals(INVALID, result.getStatus());
+        assertEquals("id must be specified", result.getMessages().get(0));
+    }
+
+}


### PR DESCRIPTION
This change adds the API for Delete Service Broker (DELETE /v2/service_brokers)
According to [this story](#101451528)