### PR TITLE
Bind a Service Instance To A Route

### DIFF
--- a/cloudfoundry-client-spring/src/main/lombok/org/cloudfoundry/client/spring/v2/serviceinstances/SpringServiceInstances.java
+++ b/cloudfoundry-client-spring/src/main/lombok/org/cloudfoundry/client/spring/v2/serviceinstances/SpringServiceInstances.java
@@ -20,6 +20,8 @@ import lombok.ToString;
 import org.cloudfoundry.client.spring.util.AbstractSpringOperations;
 import org.cloudfoundry.client.spring.util.QueryBuilder;
 import org.cloudfoundry.client.spring.v2.FilterBuilder;
+import org.cloudfoundry.client.v2.serviceinstances.BindServiceInstanceToRouteRequest;
+import org.cloudfoundry.client.v2.serviceinstances.BindServiceInstanceToRouteResponse;
 import org.cloudfoundry.client.v2.serviceinstances.CreateServiceInstanceRequest;
 import org.cloudfoundry.client.v2.serviceinstances.CreateServiceInstanceResponse;
 import org.cloudfoundry.client.v2.serviceinstances.DeleteServiceInstanceRequest;
@@ -55,6 +57,18 @@ public final class SpringServiceInstances extends AbstractSpringOperations imple
      */
     public SpringServiceInstances(RestOperations restOperations, URI root, ProcessorGroup<?> processorGroup) {
         super(restOperations, root, processorGroup);
+    }
+
+    @Override
+    public Mono<BindServiceInstanceToRouteResponse> bindToRoute(final BindServiceInstanceToRouteRequest request) {
+        return put(request, BindServiceInstanceToRouteResponse.class, new Consumer<UriComponentsBuilder>() {
+
+            @Override
+            public void accept(UriComponentsBuilder builder) {
+                builder.pathSegment("v2", "service_instances", request.getId(), "routes", request.getRouteId());
+            }
+
+        });
     }
 
     @Override

--- a/cloudfoundry-client-spring/src/test/java/org/cloudfoundry/client/spring/v2/serviceinstances/SpringServiceInstancesTest.java
+++ b/cloudfoundry-client-spring/src/test/java/org/cloudfoundry/client/spring/v2/serviceinstances/SpringServiceInstancesTest.java
@@ -20,6 +20,8 @@ import org.cloudfoundry.client.spring.AbstractApiTest;
 import org.cloudfoundry.client.v2.Resource;
 import org.cloudfoundry.client.v2.servicebindings.ServiceBindingEntity;
 import org.cloudfoundry.client.v2.servicebindings.ServiceBindingResource;
+import org.cloudfoundry.client.v2.serviceinstances.BindServiceInstanceToRouteRequest;
+import org.cloudfoundry.client.v2.serviceinstances.BindServiceInstanceToRouteResponse;
 import org.cloudfoundry.client.v2.serviceinstances.CreateServiceInstanceRequest;
 import org.cloudfoundry.client.v2.serviceinstances.CreateServiceInstanceResponse;
 import org.cloudfoundry.client.v2.serviceinstances.DeleteServiceInstanceRequest;
@@ -46,6 +48,58 @@ import static org.springframework.http.HttpStatus.NO_CONTENT;
 import static org.springframework.http.HttpStatus.OK;
 
 public final class SpringServiceInstancesTest {
+
+    public static final class BindToRoute extends AbstractApiTest<BindServiceInstanceToRouteRequest, BindServiceInstanceToRouteResponse> {
+
+        private final SpringServiceInstances serviceInstances = new SpringServiceInstances(this.restTemplate, this.root, PROCESSOR_GROUP);
+
+        @Override
+        protected BindServiceInstanceToRouteRequest getInvalidRequest() {
+            return BindServiceInstanceToRouteRequest.builder().build();
+        }
+
+        @Override
+        protected RequestContext getRequestContext() {
+            return new RequestContext()
+                    .method(PUT).path("v2/service_instances/test-id/routes/route-id")
+                    .status(CREATED)
+                    .responsePayload("v2/service_instances/PUT_{id}_routes_response.json");
+        }
+
+        @Override
+        protected BindServiceInstanceToRouteResponse getResponse() {
+            return BindServiceInstanceToRouteResponse.builder()
+                    .metadata(Resource.Metadata.builder()
+                            .createdAt("2015-12-22T18:27:58Z")
+                            .id("e7e5b08e-c530-4c1c-b420-fa0b09b3770d")
+                            .url("/v2/service_instances/e7e5b08e-c530-4c1c-b420-fa0b09b3770d")
+                            .build())
+                    .entity(ServiceInstanceEntity.builder()
+                            .name("name-160")
+                            .credential("creds-key-89", "creds-val-89")
+                            .servicePlanId("957307f5-6811-4eba-8667-ffee5a704a4a")
+                            .spaceId("36b01ada-ef02-4ff5-9f78-cd9e704211d2")
+                            .type("managed_service_instance")
+                            .spaceUrl("/v2/spaces/36b01ada-ef02-4ff5-9f78-cd9e704211d2")
+                            .servicePlanUrl("/v2/service_plans/957307f5-6811-4eba-8667-ffee5a704a4a")
+                            .serviceBindingsUrl("/v2/service_instances/e7e5b08e-c530-4c1c-b420-fa0b09b3770d/service_bindings")
+                            .serviceKeysUrl("/v2/service_instances/e7e5b08e-c530-4c1c-b420-fa0b09b3770d/service_keys")
+                            .routesUrl("/v2/service_instances/e7e5b08e-c530-4c1c-b420-fa0b09b3770d/routes")
+                            .build())
+                    .build();
+        }
+
+        @Override
+        protected BindServiceInstanceToRouteRequest getValidRequest() throws Exception {
+            return BindServiceInstanceToRouteRequest.builder().id("test-id").routeId("route-id").build();
+        }
+
+        @Override
+        protected Mono<BindServiceInstanceToRouteResponse> invoke(BindServiceInstanceToRouteRequest request) {
+            return this.serviceInstances.bindToRoute(request);
+        }
+
+    }
 
     public static final class Create extends AbstractApiTest<CreateServiceInstanceRequest, CreateServiceInstanceResponse> {
 

--- a/cloudfoundry-client-spring/src/test/resources/v2/service_instances/PUT_{id}_routes_response.json
+++ b/cloudfoundry-client-spring/src/test/resources/v2/service_instances/PUT_{id}_routes_response.json
@@ -1,0 +1,28 @@
+{
+  "metadata": {
+    "guid": "e7e5b08e-c530-4c1c-b420-fa0b09b3770d",
+    "url": "/v2/service_instances/e7e5b08e-c530-4c1c-b420-fa0b09b3770d",
+    "created_at": "2015-12-22T18:27:58Z",
+    "updated_at": null
+  },
+  "entity": {
+    "name": "name-160",
+    "credentials": {
+      "creds-key-89": "creds-val-89"
+    },
+    "service_plan_guid": "957307f5-6811-4eba-8667-ffee5a704a4a",
+    "space_guid": "36b01ada-ef02-4ff5-9f78-cd9e704211d2",
+    "gateway_data": null,
+    "dashboard_url": null,
+    "type": "managed_service_instance",
+    "last_operation": null,
+    "tags": [
+
+    ],
+    "space_url": "/v2/spaces/36b01ada-ef02-4ff5-9f78-cd9e704211d2",
+    "service_plan_url": "/v2/service_plans/957307f5-6811-4eba-8667-ffee5a704a4a",
+    "service_bindings_url": "/v2/service_instances/e7e5b08e-c530-4c1c-b420-fa0b09b3770d/service_bindings",
+    "service_keys_url": "/v2/service_instances/e7e5b08e-c530-4c1c-b420-fa0b09b3770d/service_keys",
+    "routes_url": "/v2/service_instances/e7e5b08e-c530-4c1c-b420-fa0b09b3770d/routes"
+  }
+}

--- a/cloudfoundry-client/src/main/java/org/cloudfoundry/client/v2/serviceinstances/ServiceInstances.java
+++ b/cloudfoundry-client/src/main/java/org/cloudfoundry/client/v2/serviceinstances/ServiceInstances.java
@@ -24,6 +24,14 @@ import reactor.core.publisher.Mono;
 public interface ServiceInstances {
 
     /**
+     * Makes the <a href="http://apidocs.cloudfoundry.org/227/service_instances/binding_a_service_instance_to_a_route_%28experimental%29.html">Bind Service Instance To a Route (experimental)</a> request
+     *
+     * @param request the Bind Service Instance To Route request
+     * @return the response from the Bind Service Instance To Route request
+     */
+    Mono<BindServiceInstanceToRouteResponse> bindToRoute(BindServiceInstanceToRouteRequest request);
+
+    /**
      * Makes the <a href="http://apidocs.cloudfoundry.org/214/service_instances/creating_a_service_instance.html">Create Service Instance</a> request
      *
      * @param request the Create Service Instance request

--- a/cloudfoundry-client/src/main/lombok/org/cloudfoundry/client/v2/serviceinstances/BindServiceInstanceToRouteRequest.java
+++ b/cloudfoundry-client/src/main/lombok/org/cloudfoundry/client/v2/serviceinstances/BindServiceInstanceToRouteRequest.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright 2013-2016 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.cloudfoundry.client.v2.serviceinstances;
+
+
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import lombok.Builder;
+import lombok.Getter;
+import org.cloudfoundry.client.Validatable;
+import org.cloudfoundry.client.ValidationResult;
+
+/**
+ * The request payload to Bind Service Instance To a Route
+ */
+public final class BindServiceInstanceToRouteRequest implements Validatable {
+
+    /**
+     * The id
+     *
+     * @param id the id
+     * @return the id
+     */
+    @Getter(onMethod = @__(@JsonIgnore))
+    private final String id;
+
+    /**
+     * The route id
+     *
+     * @param routeId the route id
+     * @return the route id
+     */
+    @Getter(onMethod = @__(@JsonIgnore))
+    private final String routeId;
+
+    @Builder
+    BindServiceInstanceToRouteRequest(String id, String routeId) {
+        this.id = id;
+        this.routeId = routeId;
+    }
+
+    @Override
+    public ValidationResult isValid() {
+        ValidationResult.ValidationResultBuilder builder = ValidationResult.builder();
+
+        if (this.id == null) {
+            builder.message("id must be specified");
+        }
+
+        if (this.routeId == null) {
+            builder.message("route id must be specified");
+        }
+
+        return builder.build();
+    }
+
+}

--- a/cloudfoundry-client/src/main/lombok/org/cloudfoundry/client/v2/serviceinstances/BindServiceInstanceToRouteResponse.java
+++ b/cloudfoundry-client/src/main/lombok/org/cloudfoundry/client/v2/serviceinstances/BindServiceInstanceToRouteResponse.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2013-2016 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.cloudfoundry.client.v2.serviceinstances;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.Builder;
+import lombok.Data;
+import lombok.EqualsAndHashCode;
+import lombok.ToString;
+import org.cloudfoundry.client.v2.Resource;
+
+/**
+ * The response payload for the the Bind Service Instance To Route request.
+ */
+@Data
+@EqualsAndHashCode(callSuper = true)
+@ToString(callSuper = true)
+public final class BindServiceInstanceToRouteResponse extends Resource<ServiceInstanceEntity> {
+
+    @Builder
+    BindServiceInstanceToRouteResponse(@JsonProperty("entity") ServiceInstanceEntity entity,
+                                       @JsonProperty("metadata") Metadata metadata) {
+        super(entity, metadata);
+    }
+
+}

--- a/cloudfoundry-client/src/test/java/org/cloudfoundry/client/v2/serviceinstances/BindServiceInstanceToRouteRequestTest.java
+++ b/cloudfoundry-client/src/test/java/org/cloudfoundry/client/v2/serviceinstances/BindServiceInstanceToRouteRequestTest.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright 2013-2016 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.cloudfoundry.client.v2.serviceinstances;
+
+import org.cloudfoundry.client.ValidationResult;
+import org.junit.Test;
+
+import static org.cloudfoundry.client.ValidationResult.Status.INVALID;
+import static org.cloudfoundry.client.ValidationResult.Status.VALID;
+import static org.junit.Assert.assertEquals;
+
+
+public final class BindServiceInstanceToRouteRequestTest {
+
+    @Test
+    public void isNotValidNoId() {
+        ValidationResult result = BindServiceInstanceToRouteRequest.builder()
+                .routeId("route-id")
+                .build()
+                .isValid();
+
+        assertEquals(INVALID, result.getStatus());
+        assertEquals("id must be specified", result.getMessages().get(0));
+    }
+
+    @Test
+    public void isNotValidNoRouteId() {
+        ValidationResult result = BindServiceInstanceToRouteRequest.builder()
+                .id("service-instance-id")
+                .build()
+                .isValid();
+
+        assertEquals(INVALID, result.getStatus());
+        assertEquals("route id must be specified", result.getMessages().get(0));
+    }
+
+
+    @Test
+    public void isValid() {
+        ValidationResult result = BindServiceInstanceToRouteRequest.builder()
+                .id("service-instance-id")
+                .routeId("route-id")
+                .build()
+                .isValid();
+
+        assertEquals(VALID, result.getStatus());
+    }
+}


### PR DESCRIPTION
This change adds the API for Bind a Service Instance To a Route (```PUT /v2/service_instances/:service_instance_guid/routes/:route_guid```)
We know that it is experimental, but @gberche-orange  mentionned me that we may need it in autosleep development.