### PR TITLE
List Service Instance for a Service Plan

### DIFF
--- a/cloudfoundry-client-spring/src/main/lombok/org/cloudfoundry/client/spring/SpringCloudFoundryClient.java
+++ b/cloudfoundry-client-spring/src/main/lombok/org/cloudfoundry/client/spring/SpringCloudFoundryClient.java
@@ -37,6 +37,7 @@ import org.cloudfoundry.client.spring.v2.routes.SpringRoutes;
 import org.cloudfoundry.client.spring.v2.servicebindings.SpringServiceBindings;
 import org.cloudfoundry.client.spring.v2.servicebrokers.SpringServiceBrokers;
 import org.cloudfoundry.client.spring.v2.serviceinstances.SpringServiceInstances;
+import org.cloudfoundry.client.spring.v2.serviceplans.SpringServicePlans;
 import org.cloudfoundry.client.spring.v2.shareddomains.SpringSharedDomains;
 import org.cloudfoundry.client.spring.v2.spacequotadefinitions.SpringSpaceQuotaDefinitions;
 import org.cloudfoundry.client.spring.v2.spaces.SpringSpaces;
@@ -55,6 +56,7 @@ import org.cloudfoundry.client.v2.routes.Routes;
 import org.cloudfoundry.client.v2.servicebindings.ServiceBindings;
 import org.cloudfoundry.client.v2.servicebrokers.ServiceBrokers;
 import org.cloudfoundry.client.v2.serviceinstances.ServiceInstances;
+import org.cloudfoundry.client.v2.serviceplans.ServicePlans;
 import org.cloudfoundry.client.v2.shareddomains.SharedDomains;
 import org.cloudfoundry.client.v2.spacequotadefinitions.SpaceQuotaDefinitions;
 import org.cloudfoundry.client.v2.spaces.Spaces;
@@ -129,6 +131,8 @@ public final class SpringCloudFoundryClient implements CloudFoundryClient {
 
     private final ServiceInstances serviceInstances;
 
+    private final ServicePlans servicePlans;
+
     private final SharedDomains sharedDomains;
 
     private final SpaceQuotaDefinitions spaceQuotaDefinitions;
@@ -191,6 +195,7 @@ public final class SpringCloudFoundryClient implements CloudFoundryClient {
         this.serviceBindings = new SpringServiceBindings(this.restOperations, root, this.processorGroup);
         this.serviceBrokers = new SpringServiceBrokers(this.restOperations, root, this.processorGroup);
         this.serviceInstances = new SpringServiceInstances(this.restOperations, root, this.processorGroup);
+        this.servicePlans = new SpringServicePlans(this.restOperations, root, this.processorGroup);
         this.spaceQuotaDefinitions = new SpringSpaceQuotaDefinitions(this.restOperations, root, this.processorGroup);
         this.spaces = new SpringSpaces(this.restOperations, root, this.processorGroup);
         this.stacks = new SpringStacks(this.restOperations, root, this.processorGroup);
@@ -216,6 +221,7 @@ public final class SpringCloudFoundryClient implements CloudFoundryClient {
         this.serviceBindings = new SpringServiceBindings(this.restOperations, root, this.processorGroup);
         this.serviceBrokers = new SpringServiceBrokers(this.restOperations, root, this.processorGroup);
         this.serviceInstances = new SpringServiceInstances(this.restOperations, root, this.processorGroup);
+        this.servicePlans = new SpringServicePlans(this.restOperations, root, this.processorGroup);
         this.spaceQuotaDefinitions = new SpringSpaceQuotaDefinitions(this.restOperations, root, this.processorGroup);
         this.spaces = new SpringSpaces(this.restOperations, root, this.processorGroup);
         this.stacks = new SpringStacks(this.restOperations, root, this.processorGroup);
@@ -280,6 +286,11 @@ public final class SpringCloudFoundryClient implements CloudFoundryClient {
     @Override
     public ServiceBrokers serviceBrokers() {
         return this.serviceBrokers;
+    }
+
+    @Override
+    public ServicePlans servicePlans() {
+        return this.servicePlans;
     }
 
     @Override

--- a/cloudfoundry-client-spring/src/main/lombok/org/cloudfoundry/client/spring/v2/serviceplans/SpringServicePlans.java
+++ b/cloudfoundry-client-spring/src/main/lombok/org/cloudfoundry/client/spring/v2/serviceplans/SpringServicePlans.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright 2013-2016 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.cloudfoundry.client.spring.v2.serviceplans;
+
+
+import lombok.ToString;
+import org.cloudfoundry.client.spring.util.AbstractSpringOperations;
+import org.cloudfoundry.client.spring.util.QueryBuilder;
+import org.cloudfoundry.client.spring.v2.FilterBuilder;
+import org.cloudfoundry.client.v2.serviceplans.ListServicePlanServiceInstancesRequest;
+import org.cloudfoundry.client.v2.serviceplans.ListServicePlanServiceInstancesResponse;
+import org.cloudfoundry.client.v2.serviceplans.ServicePlans;
+import org.springframework.web.client.RestOperations;
+import org.springframework.web.util.UriComponentsBuilder;
+import reactor.core.publisher.Mono;
+import reactor.core.publisher.ProcessorGroup;
+import reactor.fn.Consumer;
+
+/**
+ * The Spring-based implementation of {@link ServicePlans}
+ */
+@ToString(callSuper = true)
+public final class SpringServicePlans extends AbstractSpringOperations implements ServicePlans {
+
+    /**
+     * Creates an instance
+     *
+     * @param restOperations the {@link RestOperations } to use to communicate with the server
+     * @param root           the root URI of the server.  Typically something like {@code https://api.run.pivotal.io}.
+     * @param processorGroup The group to use when making requests
+     */
+    public SpringServicePlans(RestOperations restOperations, java.net.URI root, ProcessorGroup<?> processorGroup) {
+        super(restOperations, root, processorGroup);
+    }
+
+    @Override
+    public Mono<ListServicePlanServiceInstancesResponse> listServiceInstances(final ListServicePlanServiceInstancesRequest request) {
+        return get(request, ListServicePlanServiceInstancesResponse.class, new Consumer<UriComponentsBuilder>() {
+
+            @Override
+            public void accept(UriComponentsBuilder builder) {
+                builder.pathSegment("v2", "service_plans", request.getId(), "service_instances");
+                FilterBuilder.augment(builder, request);
+                QueryBuilder.augment(builder, request);
+            }
+
+        });
+    }
+
+}

--- a/cloudfoundry-client-spring/src/test/java/org/cloudfoundry/client/spring/SpringCloudFoundryClientTest.java
+++ b/cloudfoundry-client-spring/src/test/java/org/cloudfoundry/client/spring/SpringCloudFoundryClientTest.java
@@ -158,6 +158,11 @@ public final class SpringCloudFoundryClientTest extends AbstractRestTest {
     }
 
     @Test
+    public void servicePlans() {
+        assertNotNull(this.client.servicePlans());
+    }
+
+    @Test
     public void sharedDomains() {
         assertNotNull(this.client.sharedDomains());
     }

--- a/cloudfoundry-client-spring/src/test/java/org/cloudfoundry/client/spring/v2/serviceplans/SpringServicePlansTest.java
+++ b/cloudfoundry-client-spring/src/test/java/org/cloudfoundry/client/spring/v2/serviceplans/SpringServicePlansTest.java
@@ -1,0 +1,96 @@
+/*
+ * Copyright 2013-2016 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.cloudfoundry.client.spring.v2.serviceplans;
+
+import org.cloudfoundry.client.spring.AbstractApiTest;
+import org.cloudfoundry.client.v2.Resource;
+import org.cloudfoundry.client.v2.serviceinstances.ServiceInstanceEntity;
+import org.cloudfoundry.client.v2.serviceinstances.ServiceInstanceResource;
+import org.cloudfoundry.client.v2.serviceplans.ListServicePlanServiceInstancesRequest;
+import org.cloudfoundry.client.v2.serviceplans.ListServicePlanServiceInstancesResponse;
+import reactor.core.publisher.Mono;
+
+import static org.springframework.http.HttpMethod.GET;
+import static org.springframework.http.HttpStatus.OK;
+
+
+public final class SpringServicePlansTest {
+
+    public static final class ListServiceInstances
+            extends AbstractApiTest<ListServicePlanServiceInstancesRequest, ListServicePlanServiceInstancesResponse> {
+
+        private final SpringServicePlans servicePlans = new SpringServicePlans(this.restTemplate, this.root, PROCESSOR_GROUP);
+
+        @Override
+        protected ListServicePlanServiceInstancesRequest getInvalidRequest() {
+            return ListServicePlanServiceInstancesRequest.builder()
+                    .build();
+        }
+
+        @Override
+        protected RequestContext getRequestContext() {
+            return new RequestContext()
+                    .method(GET)
+                    .path("v2/service_plans/test-id/service_instances?q=space_guid%20IN%20test-space-id&page=-1")
+                    .status(OK)
+                    .responsePayload("v2/service_plans/GET_{id}_service_instances_response.json");
+        }
+
+        @Override
+        protected ListServicePlanServiceInstancesResponse getResponse() {
+            return ListServicePlanServiceInstancesResponse.builder()
+                    .totalResults(1)
+                    .totalPages(1)
+                    .resource(ServiceInstanceResource.builder()
+                            .metadata(Resource.Metadata.builder()
+                                    .createdAt("2015-07-27T22:43:16Z")
+                                    .id("b95c56b9-f81b-4d34-9a00-a1a1ddba5f2f")
+                                    .url("/v2/service_instances/b95c56b9-f81b-4d34-9a00-a1a1ddba5f2f")
+                                    .build())
+                            .entity(ServiceInstanceEntity.builder()
+                                    .name("name-457")
+                                    .credential("creds-key-268", "creds-val-268")
+                                    .servicePlanId("bb29926c-7482-4ae5-803c-ec99e95aa278")
+                                    .spaceId("cf5812f5-bf43-40cc-88d4-d50b76d7797d")
+                                    .type("managed_service_instance")
+                                    .spaceUrl("/v2/spaces/cf5812f5-bf43-40cc-88d4-d50b76d7797d")
+                                    .servicePlanUrl("/v2/service_plans/bb29926c-7482-4ae5-803c-ec99e95aa278")
+                                    .serviceBindingsUrl("/v2/service_instances/b95c56b9-f81b-4d34-9a00-a1a1ddba5f2f/service_bindings")
+                                    .serviceKeysUrl("/v2/service_instances/b95c56b9-f81b-4d34-9a00-a1a1ddba5f2f/service_keys")
+                                    .build())
+                            .build())
+                    .build();
+        }
+
+        @Override
+        protected ListServicePlanServiceInstancesRequest getValidRequest() throws Exception {
+            return ListServicePlanServiceInstancesRequest.builder()
+                    .id("test-id")
+                    .spaceId("test-space-id")
+                    .page(-1)
+                    .build();
+        }
+
+        @Override
+        protected Mono<ListServicePlanServiceInstancesResponse> invoke(ListServicePlanServiceInstancesRequest request) {
+            return this.servicePlans.listServiceInstances(request);
+        }
+
+    }
+
+
+}

--- a/cloudfoundry-client-spring/src/test/resources/v2/service_plans/GET_{id}_service_instances_response.json
+++ b/cloudfoundry-client-spring/src/test/resources/v2/service_plans/GET_{id}_service_instances_response.json
@@ -1,0 +1,35 @@
+{
+  "total_results": 1,
+  "total_pages": 1,
+  "prev_url": null,
+  "next_url": null,
+  "resources": [
+    {
+      "metadata": {
+        "guid": "b95c56b9-f81b-4d34-9a00-a1a1ddba5f2f",
+        "url": "/v2/service_instances/b95c56b9-f81b-4d34-9a00-a1a1ddba5f2f",
+        "created_at": "2015-07-27T22:43:16Z",
+        "updated_at": null
+      },
+      "entity": {
+        "name": "name-457",
+        "credentials": {
+          "creds-key-268": "creds-val-268"
+        },
+        "service_plan_guid": "bb29926c-7482-4ae5-803c-ec99e95aa278",
+        "space_guid": "cf5812f5-bf43-40cc-88d4-d50b76d7797d",
+        "gateway_data": null,
+        "dashboard_url": null,
+        "type": "managed_service_instance",
+        "last_operation": null,
+        "tags": [
+
+        ],
+        "space_url": "/v2/spaces/cf5812f5-bf43-40cc-88d4-d50b76d7797d",
+        "service_plan_url": "/v2/service_plans/bb29926c-7482-4ae5-803c-ec99e95aa278",
+        "service_bindings_url": "/v2/service_instances/b95c56b9-f81b-4d34-9a00-a1a1ddba5f2f/service_bindings",
+        "service_keys_url": "/v2/service_instances/b95c56b9-f81b-4d34-9a00-a1a1ddba5f2f/service_keys"
+      }
+    }
+  ]
+}

--- a/cloudfoundry-client/src/main/java/org/cloudfoundry/client/CloudFoundryClient.java
+++ b/cloudfoundry-client/src/main/java/org/cloudfoundry/client/CloudFoundryClient.java
@@ -26,6 +26,7 @@ import org.cloudfoundry.client.v2.routes.Routes;
 import org.cloudfoundry.client.v2.servicebindings.ServiceBindings;
 import org.cloudfoundry.client.v2.servicebrokers.ServiceBrokers;
 import org.cloudfoundry.client.v2.serviceinstances.ServiceInstances;
+import org.cloudfoundry.client.v2.serviceplans.ServicePlans;
 import org.cloudfoundry.client.v2.shareddomains.SharedDomains;
 import org.cloudfoundry.client.v2.spacequotadefinitions.SpaceQuotaDefinitions;
 import org.cloudfoundry.client.v2.spaces.Spaces;
@@ -135,6 +136,13 @@ public interface CloudFoundryClient {
      * @return the Cloud Foundry Service Instances Client API
      */
     ServiceInstances serviceInstances();
+
+    /**
+     * Main entry point to the Cloud Foundry Service Plans Client API
+     *
+     * @return the Cloud Foundry Service Plans Client API
+     */
+    ServicePlans servicePlans();
 
     /**
      * Main entry point to the Cloud Foundry Shared Domains Client API

--- a/cloudfoundry-client/src/main/java/org/cloudfoundry/client/v2/serviceplans/ServicePlans.java
+++ b/cloudfoundry-client/src/main/java/org/cloudfoundry/client/v2/serviceplans/ServicePlans.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2013-2016 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.cloudfoundry.client.v2.serviceplans;
+
+
+import reactor.core.publisher.Mono;
+
+public interface ServicePlans {
+
+    /**
+     * Makes the <a href="http://apidocs.cloudfoundry.org/214/service_plans/list_all_service_instances_for_the_service_plan.html">List all Service Instances for the Service Plan</a> request
+     *
+     * @param request the List Service Instances request
+     * @return the response from the List Service Instances request
+     */
+    Mono<ListServicePlanServiceInstancesResponse> listServiceInstances(ListServicePlanServiceInstancesRequest request);
+
+}

--- a/cloudfoundry-client/src/main/lombok/org/cloudfoundry/client/v2/serviceplans/ListServicePlanServiceInstancesRequest.java
+++ b/cloudfoundry-client/src/main/lombok/org/cloudfoundry/client/v2/serviceplans/ListServicePlanServiceInstancesRequest.java
@@ -1,0 +1,124 @@
+/*
+ * Copyright 2013-2016 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.cloudfoundry.client.v2.serviceplans;
+
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import lombok.Builder;
+import lombok.Data;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.Singular;
+import lombok.ToString;
+import org.cloudfoundry.client.Validatable;
+import org.cloudfoundry.client.ValidationResult;
+import org.cloudfoundry.client.v2.InFilterParameter;
+import org.cloudfoundry.client.v2.PaginatedRequest;
+
+import java.util.List;
+
+/**
+ * The request payload for the List all Service Instances for the Service Plan operation
+ */
+@Data
+@EqualsAndHashCode(callSuper = true)
+@ToString(callSuper = true)
+public final class ListServicePlanServiceInstancesRequest extends PaginatedRequest implements Validatable {
+
+    /**
+     * The gateway names
+     *
+     * @param gatewayNames the gateway names to filter on
+     * @return the gateway names to filter on
+     */
+    @Getter(onMethod = @__(@InFilterParameter("gateway_name")))
+    private final List<String> gatewayNames;
+
+    /**
+     * The id of the Service Plan
+     *
+     * @param id the id of the Service Plan
+     * @return the id of the Service Plan
+     */
+    @Getter(onMethod = @__(@JsonIgnore))
+    private final String id;
+
+    /**
+     * The names of the service instances
+     *
+     * @param names the names of the service instances to filter on
+     * @return the names of the service instances to filter on
+     */
+    @Getter(onMethod = @__(@InFilterParameter("names")))
+    private final List<String> names;
+
+    /**
+     * The service binding ids
+     *
+     * @param serviceBindingIds the service binding ids to filter on
+     * @return the service binding ids to filter on
+     */
+    @Getter(onMethod = @__(@InFilterParameter("service_binding_guid")))
+    private final List<String> serviceBindingIds;
+
+    /**
+     * The service key ids
+     *
+     * @param serviceKeyIds the service key ids to filter on
+     * @return the service key ids to filter on
+     */
+    @Getter(onMethod = @__(@InFilterParameter("service_key_guid")))
+    private final List<String> serviceKeyIds;
+
+    /**
+     * The space ids
+     *
+     * @param spaceIds the space ids to filter on
+     * @return the space ids to filter on
+     */
+    @Getter(onMethod = @__(@InFilterParameter("space_guid")))
+    private final List<String> spaceIds;
+
+    @Builder
+    ListServicePlanServiceInstancesRequest(OrderDirection orderDirection, Integer page, Integer resultsPerPage,
+                                           @Singular List<String> gatewayNames,
+                                           String id,
+                                           @Singular List<String> names,
+                                           @Singular List<String> serviceBindingIds,
+                                           @Singular List<String> serviceKeyIds,
+                                           @Singular List<String> spaceIds
+    ) {
+        super(orderDirection, page, resultsPerPage);
+        this.gatewayNames = gatewayNames;
+        this.id = id;
+        this.names = names;
+        this.serviceBindingIds = serviceBindingIds;
+        this.serviceKeyIds = serviceKeyIds;
+        this.spaceIds = spaceIds;
+    }
+
+    @Override
+    public ValidationResult isValid() {
+        ValidationResult.ValidationResultBuilder builder = ValidationResult.builder();
+
+        if (this.id == null) {
+            builder.message("id must be specified");
+        }
+
+        return builder.build();
+    }
+
+}

--- a/cloudfoundry-client/src/main/lombok/org/cloudfoundry/client/v2/serviceplans/ListServicePlanServiceInstancesResponse.java
+++ b/cloudfoundry-client/src/main/lombok/org/cloudfoundry/client/v2/serviceplans/ListServicePlanServiceInstancesResponse.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2013-2016 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.cloudfoundry.client.v2.serviceplans;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.Builder;
+import lombok.Data;
+import lombok.EqualsAndHashCode;
+import lombok.Singular;
+import lombok.ToString;
+import org.cloudfoundry.client.v2.PaginatedResponse;
+import org.cloudfoundry.client.v2.serviceinstances.ServiceInstanceResource;
+
+import java.util.List;
+
+/**
+ * The response payload for the List all Service Instances for the Service Plan operation
+ */
+@Data
+@EqualsAndHashCode(callSuper = true)
+@ToString(callSuper = true)
+public final class ListServicePlanServiceInstancesResponse extends PaginatedResponse<ServiceInstanceResource> {
+
+    @Builder
+    ListServicePlanServiceInstancesResponse(@JsonProperty("next_url") String nextUrl,
+                                            @JsonProperty("prev_url") String previousUrl,
+                                            @JsonProperty("resources") @Singular List<ServiceInstanceResource> resources,
+                                            @JsonProperty("total_pages") Integer totalPages,
+                                            @JsonProperty("total_results") Integer totalResults) {
+        super(nextUrl, previousUrl, resources, totalPages, totalResults);
+    }
+
+}

--- a/cloudfoundry-client/src/test/java/org/cloudfoundry/client/v2/serviceplans/ListServicePlanServiceInstancesRequestTest.java
+++ b/cloudfoundry-client/src/test/java/org/cloudfoundry/client/v2/serviceplans/ListServicePlanServiceInstancesRequestTest.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2013-2016 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.cloudfoundry.client.v2.serviceplans;
+
+import org.cloudfoundry.client.ValidationResult;
+import org.junit.Test;
+
+import static org.cloudfoundry.client.ValidationResult.Status.INVALID;
+import static org.cloudfoundry.client.ValidationResult.Status.VALID;
+import static org.junit.Assert.assertEquals;
+
+
+public final class ListServicePlanServiceInstancesRequestTest {
+
+    @Test
+    public void isValid() {
+        ValidationResult result = ListServicePlanServiceInstancesRequest.builder()
+                .id("test-id")
+                .build()
+                .isValid();
+
+        assertEquals(VALID, result.getStatus());
+    }
+
+    @Test
+    public void isValidNoId() {
+        ValidationResult result = ListServicePlanServiceInstancesRequest.builder()
+                .build()
+                .isValid();
+
+        assertEquals(INVALID, result.getStatus());
+        assertEquals("id must be specified", result.getMessages().get(0));
+    }
+
+}


### PR DESCRIPTION
- Init Service Plan API
- adds the API for List Service Instance for a Service Plan (GET /v2/service_plans/:guid/service_instances)
According to [this story](https://www.pivotaltracker.com/projects/816799/stories/101451574)
[#101451574]


_According to the documentation: _Valid filters: name, space_guid, service_plan_guid, service_binding_guid, gateway_name, organization_guid, service_key_guid_

- I willingly removed ```service_plan_guid``` filter because it is in the request...Did I miss something?
- Is ```organization_guid``` a valid filter (not an attribute of the service instance)?

See below 