### PR TITLE
Delete Service Plan

### DIFF
--- a/cloudfoundry-client-spring/src/main/lombok/org/cloudfoundry/client/spring/v2/serviceplans/SpringServicePlans.java
+++ b/cloudfoundry-client-spring/src/main/lombok/org/cloudfoundry/client/spring/v2/serviceplans/SpringServicePlans.java
@@ -21,6 +21,7 @@ import lombok.ToString;
 import org.cloudfoundry.client.spring.util.AbstractSpringOperations;
 import org.cloudfoundry.client.spring.util.QueryBuilder;
 import org.cloudfoundry.client.spring.v2.FilterBuilder;
+import org.cloudfoundry.client.v2.serviceplans.DeleteServicePlanRequest;
 import org.cloudfoundry.client.v2.serviceplans.GetServicePlanRequest;
 import org.cloudfoundry.client.v2.serviceplans.GetServicePlanResponse;
 import org.cloudfoundry.client.v2.serviceplans.ListServicePlanServiceInstancesRequest;
@@ -49,6 +50,17 @@ public final class SpringServicePlans extends AbstractSpringOperations implement
      */
     public SpringServicePlans(RestOperations restOperations, java.net.URI root, ProcessorGroup<?> processorGroup) {
         super(restOperations, root, processorGroup);
+    }
+
+    @Override
+    public Mono<Void> delete(final DeleteServicePlanRequest request) {
+        return delete(request, new Consumer<UriComponentsBuilder>() {
+            @Override
+            public void accept(UriComponentsBuilder builder) {
+                builder.pathSegment("v2", "service_plans", request.getServicePlanId());
+                QueryBuilder.augment(builder, request);
+            }
+        });
     }
 
     @Override

--- a/cloudfoundry-client-spring/src/test/java/org/cloudfoundry/client/spring/v2/serviceplans/SpringServicePlansTest.java
+++ b/cloudfoundry-client-spring/src/test/java/org/cloudfoundry/client/spring/v2/serviceplans/SpringServicePlansTest.java
@@ -17,9 +17,11 @@
 package org.cloudfoundry.client.spring.v2.serviceplans;
 
 import org.cloudfoundry.client.spring.AbstractApiTest;
+import org.cloudfoundry.client.spring.AbstractRestTest;
 import org.cloudfoundry.client.v2.Resource;
 import org.cloudfoundry.client.v2.serviceinstances.ServiceInstanceEntity;
 import org.cloudfoundry.client.v2.serviceinstances.ServiceInstanceResource;
+import org.cloudfoundry.client.v2.serviceplans.DeleteServicePlanRequest;
 import org.cloudfoundry.client.v2.serviceplans.GetServicePlanRequest;
 import org.cloudfoundry.client.v2.serviceplans.GetServicePlanResponse;
 import org.cloudfoundry.client.v2.serviceplans.ListServicePlanServiceInstancesRequest;
@@ -31,11 +33,50 @@ import org.cloudfoundry.client.v2.serviceplans.ServicePlanResource;
 import org.reactivestreams.Publisher;
 import reactor.core.publisher.Mono;
 
+import static org.springframework.http.HttpMethod.DELETE;
 import static org.springframework.http.HttpMethod.GET;
+import static org.springframework.http.HttpStatus.NO_CONTENT;
 import static org.springframework.http.HttpStatus.OK;
 
 
 public final class SpringServicePlansTest {
+
+    public static final class Delete extends AbstractApiTest<DeleteServicePlanRequest, Void> {
+
+        private final SpringServicePlans servicePlans = new SpringServicePlans(this.restTemplate, this.root, PROCESSOR_GROUP);
+
+        @Override
+        protected DeleteServicePlanRequest getInvalidRequest() {
+            return DeleteServicePlanRequest.builder().build();
+        }
+
+        @Override
+        protected RequestContext getRequestContext() {
+            return new RequestContext()
+                    .method(DELETE)
+                    .path("v2/service_plans/test-service-plan-id?async=true")
+                    .status(NO_CONTENT);
+        }
+
+        @Override
+        protected Void getResponse() {
+            return null;
+        }
+
+        @Override
+        protected DeleteServicePlanRequest getValidRequest() throws Exception {
+            return DeleteServicePlanRequest.builder()
+                    .async(true)
+                    .servicePlanId("test-service-plan-id")
+                    .build();
+
+        }
+
+        @Override
+        protected Publisher<Void> invoke(DeleteServicePlanRequest request) {
+            return this.servicePlans.delete(request);
+        }
+    }
 
     public static final class Get extends AbstractApiTest<GetServicePlanRequest, GetServicePlanResponse> {
 

--- a/cloudfoundry-client/src/main/java/org/cloudfoundry/client/v2/serviceplans/ServicePlans.java
+++ b/cloudfoundry-client/src/main/java/org/cloudfoundry/client/v2/serviceplans/ServicePlans.java
@@ -22,6 +22,14 @@ import reactor.core.publisher.Mono;
 public interface ServicePlans {
 
     /**
+     * Makes the <a href="http://apidocs.cloudfoundry.org/214/service_plans/delete_a_particular_service_plans.html">Delete the Service Plan</a> request
+     *
+     * @param request the Delete Service Plan request
+     * @return the response from the Delete Service Plan request
+     */
+    Mono<Void> delete(DeleteServicePlanRequest request);
+
+    /**
      * Makes the <a href="http://apidocs.cloudfoundry.org/214/service_plans/retrieve_a_particular_service_plan.html">Retrieve a Particular Service Plan</a> request
      *
      * @param request the Get Service Plan request

--- a/cloudfoundry-client/src/main/lombok/org/cloudfoundry/client/v2/serviceplans/DeleteServicePlanRequest.java
+++ b/cloudfoundry-client/src/main/lombok/org/cloudfoundry/client/v2/serviceplans/DeleteServicePlanRequest.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright 2013-2016 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.cloudfoundry.client.v2.serviceplans;
+
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import lombok.Builder;
+import lombok.Getter;
+import org.cloudfoundry.client.QueryParameter;
+import org.cloudfoundry.client.Validatable;
+import org.cloudfoundry.client.ValidationResult;
+
+/**
+ * The request payload for the Delete Service Plan request.
+ */
+public class DeleteServicePlanRequest implements Validatable {
+
+    /**
+     * The async
+     *
+     * @param async the async
+     * @return the async
+     */
+    @Getter(onMethod = @__(@QueryParameter("async")))
+    private final Boolean async;
+
+    /**
+     * The service plan id
+     *
+     * @param servicePlanId the service plan id
+     * @return the service plan id
+     */
+    @Getter(onMethod = @__(@JsonIgnore))
+    private final String servicePlanId;
+
+    @Builder
+    DeleteServicePlanRequest(Boolean async, String servicePlanId) {
+        this.async = async;
+        this.servicePlanId = servicePlanId;
+    }
+
+    @Override
+    public ValidationResult isValid() {
+        ValidationResult.ValidationResultBuilder builder = ValidationResult.builder();
+
+        if (this.servicePlanId == null) {
+            builder.message("service plan id must be specified");
+        }
+
+        return builder.build();
+    }
+
+}

--- a/cloudfoundry-client/src/test/java/org/cloudfoundry/client/v2/serviceplans/DeleteServicePlanRequestTest.java
+++ b/cloudfoundry-client/src/test/java/org/cloudfoundry/client/v2/serviceplans/DeleteServicePlanRequestTest.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2013-2016 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.cloudfoundry.client.v2.serviceplans;
+
+import org.cloudfoundry.client.ValidationResult;
+import org.junit.Test;
+
+import static org.cloudfoundry.client.ValidationResult.Status.INVALID;
+import static org.cloudfoundry.client.ValidationResult.Status.VALID;
+import static org.junit.Assert.assertEquals;
+
+
+public final class DeleteServicePlanRequestTest {
+
+    @Test
+    public void isValid() {
+        ValidationResult result = DeleteServicePlanRequest.builder()
+                .async(true)
+                .servicePlanId("test-id")
+                .build()
+                .isValid();
+
+        assertEquals(VALID, result.getStatus());
+    }
+
+    @Test
+    public void isValidNoId() {
+        ValidationResult result = DeleteServicePlanRequest.builder()
+                .async(true)
+                .build()
+                .isValid();
+
+        assertEquals(INVALID, result.getStatus());
+        assertEquals("service plan id must be specified", result.getMessages().get(0));
+    }
+
+}


### PR DESCRIPTION
This change adds the api to delete a service plan (```DELETE /v2/service_plans/:guid```)
See [this story](https://www.pivotaltracker.com/projects/816799/stories/101451572)