### PR TITLE
Delete Service Key

### DIFF
--- a/cloudfoundry-client-spring/src/main/lombok/org/cloudfoundry/client/spring/v2/servicekeys/SpringServiceKeys.java
+++ b/cloudfoundry-client-spring/src/main/lombok/org/cloudfoundry/client/spring/v2/servicekeys/SpringServiceKeys.java
@@ -21,6 +21,7 @@ import org.cloudfoundry.client.spring.util.AbstractSpringOperations;
 import org.cloudfoundry.client.v2.serviceinstances.ServiceInstances;
 import org.cloudfoundry.client.v2.servicekeys.CreateServiceKeyRequest;
 import org.cloudfoundry.client.v2.servicekeys.CreateServiceKeyResponse;
+import org.cloudfoundry.client.v2.servicekeys.DeleteServiceKeyRequest;
 import org.cloudfoundry.client.v2.servicekeys.ServiceKeys;
 import org.springframework.web.client.RestOperations;
 import org.springframework.web.util.UriComponentsBuilder;
@@ -59,4 +60,14 @@ public final class SpringServiceKeys extends AbstractSpringOperations implements
         });
     }
 
+    @Override
+    public Mono<Void> delete(final DeleteServiceKeyRequest request) {
+        return delete(request, new Consumer<UriComponentsBuilder>() {
+            @Override
+            public void accept(UriComponentsBuilder builder) {
+                builder.pathSegment("v2", "service_keys", request.getServiceKeyId());
+            }
+        });
+    }
+    
 }

--- a/cloudfoundry-client-spring/src/test/java/org/cloudfoundry/client/spring/v2/servicekeys/SpringServiceKeysTest.java
+++ b/cloudfoundry-client-spring/src/test/java/org/cloudfoundry/client/spring/v2/servicekeys/SpringServiceKeysTest.java
@@ -19,12 +19,15 @@ package org.cloudfoundry.client.spring.v2.servicekeys;
 import org.cloudfoundry.client.spring.AbstractApiTest;
 import org.cloudfoundry.client.v2.servicekeys.CreateServiceKeyRequest;
 import org.cloudfoundry.client.v2.servicekeys.CreateServiceKeyResponse;
+import org.cloudfoundry.client.v2.servicekeys.DeleteServiceKeyRequest;
 import org.cloudfoundry.client.v2.servicekeys.ServiceKeyEntity;
 import org.reactivestreams.Publisher;
 
 import static org.cloudfoundry.client.v2.Resource.Metadata;
+import static org.springframework.http.HttpMethod.DELETE;
 import static org.springframework.http.HttpMethod.POST;
 import static org.springframework.http.HttpStatus.CREATED;
+import static org.springframework.http.HttpStatus.NO_CONTENT;
 
 public final class SpringServiceKeysTest {
 
@@ -74,6 +77,40 @@ public final class SpringServiceKeysTest {
         @Override
         protected Publisher<CreateServiceKeyResponse> invoke(CreateServiceKeyRequest request) {
             return this.serviceKeys.create(request);
+        }
+    }
+
+    public static final class Delete extends AbstractApiTest<DeleteServiceKeyRequest, Void> {
+
+        private final SpringServiceKeys serviceKeys = new SpringServiceKeys(this.restTemplate, this.root, PROCESSOR_GROUP);
+
+        @Override
+        protected DeleteServiceKeyRequest getInvalidRequest() {
+            return DeleteServiceKeyRequest.builder().build();
+        }
+
+        @Override
+        protected RequestContext getRequestContext() {
+            return new RequestContext()
+                    .method(DELETE).path("/v2/service_keys/test-service-key-id")
+                    .status(NO_CONTENT);
+        }
+
+        @Override
+        protected Void getResponse() {
+            return null;
+        }
+
+        @Override
+        protected DeleteServiceKeyRequest getValidRequest() throws Exception {
+            return DeleteServiceKeyRequest.builder()
+                    .serviceKeyId("test-service-key-id")
+                    .build();
+        }
+
+        @Override
+        protected Publisher<Void> invoke(DeleteServiceKeyRequest request) {
+            return this.serviceKeys.delete(request);
         }
     }
 

--- a/cloudfoundry-client/src/main/java/org/cloudfoundry/client/v2/servicekeys/ServiceKeys.java
+++ b/cloudfoundry-client/src/main/java/org/cloudfoundry/client/v2/servicekeys/ServiceKeys.java
@@ -31,4 +31,12 @@ public interface ServiceKeys {
      */
     Mono<CreateServiceKeyResponse> create(CreateServiceKeyRequest request);
 
+    /**
+     * Makes the <a href="http://apidocs.cloudfoundry.org/214/service_keys/delete_a_particular_service_key.html">Delete the Service Key</a> request
+     *
+     * @param request the Delete Service Key request
+     * @return the response from the Delete Service Key request
+     */
+    Mono<Void> delete(DeleteServiceKeyRequest request);
+
 }

--- a/cloudfoundry-client/src/main/lombok/org/cloudfoundry/client/v2/servicekeys/DeleteServiceKeyRequest.java
+++ b/cloudfoundry-client/src/main/lombok/org/cloudfoundry/client/v2/servicekeys/DeleteServiceKeyRequest.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright 2013-2016 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.cloudfoundry.client.v2.servicekeys;
+
+
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import lombok.Builder;
+import lombok.Getter;
+import org.cloudfoundry.client.Validatable;
+import org.cloudfoundry.client.ValidationResult;
+
+public final class DeleteServiceKeyRequest implements Validatable {
+
+    /**
+     * The service key id
+     *
+     * @param serviceKeyId the service key id
+     * @return the service key id
+     */
+    @Getter(onMethod = @__(@JsonIgnore))
+    private final String serviceKeyId;
+
+    @Builder
+    DeleteServiceKeyRequest(String serviceKeyId) {
+        this.serviceKeyId = serviceKeyId;
+    }
+
+    @Override
+    public ValidationResult isValid() {
+        ValidationResult.ValidationResultBuilder builder = ValidationResult.builder();
+
+        if (this.serviceKeyId == null) {
+            builder.message("service key id must be specified");
+        }
+
+        return builder.build();
+    }
+
+}

--- a/cloudfoundry-client/src/test/java/org/cloudfoundry/client/v2/servicekeys/DeleteServiceKeyRequestTest.java
+++ b/cloudfoundry-client/src/test/java/org/cloudfoundry/client/v2/servicekeys/DeleteServiceKeyRequestTest.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2013-2016 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.cloudfoundry.client.v2.servicekeys;
+
+import org.cloudfoundry.client.ValidationResult;
+import org.junit.Test;
+
+import static org.cloudfoundry.client.ValidationResult.Status.INVALID;
+import static org.cloudfoundry.client.ValidationResult.Status.VALID;
+import static org.junit.Assert.assertEquals;
+
+public final class DeleteServiceKeyRequestTest {
+
+    @Test
+    public void isValid() {
+        ValidationResult result = DeleteServiceKeyRequest.builder()
+                .serviceKeyId("test-service-key-id")
+                .build()
+                .isValid();
+
+        assertEquals(VALID, result.getStatus());
+    }
+
+    @Test
+    public void isValidNoId() {
+        ValidationResult result = DeleteServiceKeyRequest.builder()
+                .build()
+                .isValid();
+
+        assertEquals(INVALID, result.getStatus());
+        assertEquals("service key id must be specified", result.getMessages().get(0));
+    }
+
+}


### PR DESCRIPTION
This change adds the api to delete a service key (```DELETE /v2/service_keys/:guid```)
According to [this story](https://www.pivotaltracker.com/projects/816799/stories/101451554)