### PR TITLE
Create service plan visibility

### DIFF
--- a/cloudfoundry-client-spring/src/main/lombok/org/cloudfoundry/client/spring/SpringCloudFoundryClient.java
+++ b/cloudfoundry-client-spring/src/main/lombok/org/cloudfoundry/client/spring/SpringCloudFoundryClient.java
@@ -40,6 +40,7 @@ import org.cloudfoundry.client.spring.v2.servicebrokers.SpringServiceBrokers;
 import org.cloudfoundry.client.spring.v2.serviceinstances.SpringServiceInstances;
 import org.cloudfoundry.client.spring.v2.servicekeys.SpringServiceKeys;
 import org.cloudfoundry.client.spring.v2.serviceplans.SpringServicePlans;
+import org.cloudfoundry.client.spring.v2.serviceplanvisibilities.SpringServicePlanVisibilities;
 import org.cloudfoundry.client.spring.v2.shareddomains.SpringSharedDomains;
 import org.cloudfoundry.client.spring.v2.spacequotadefinitions.SpringSpaceQuotaDefinitions;
 import org.cloudfoundry.client.spring.v2.spaces.SpringSpaces;
@@ -61,6 +62,7 @@ import org.cloudfoundry.client.v2.servicebrokers.ServiceBrokers;
 import org.cloudfoundry.client.v2.serviceinstances.ServiceInstances;
 import org.cloudfoundry.client.v2.servicekeys.ServiceKeys;
 import org.cloudfoundry.client.v2.serviceplans.ServicePlans;
+import org.cloudfoundry.client.v2.serviceplanvisibilities.ServicePlanVisibilities;
 import org.cloudfoundry.client.v2.shareddomains.SharedDomains;
 import org.cloudfoundry.client.v2.spacequotadefinitions.SpaceQuotaDefinitions;
 import org.cloudfoundry.client.v2.spaces.Spaces;
@@ -138,6 +140,8 @@ public final class SpringCloudFoundryClient implements CloudFoundryClient {
 
     private final ServiceKeys serviceKeys;
 
+    private final ServicePlanVisibilities servicePlanVisibilities;
+
     private final ServicePlans servicePlans;
 
     private final SharedDomains sharedDomains;
@@ -204,6 +208,7 @@ public final class SpringCloudFoundryClient implements CloudFoundryClient {
         this.serviceBrokers = new SpringServiceBrokers(this.restOperations, root, this.processorGroup);
         this.serviceInstances = new SpringServiceInstances(this.restOperations, root, this.processorGroup);
         this.serviceKeys = new SpringServiceKeys(this.restOperations, root, this.processorGroup);
+        this.servicePlanVisibilities = new SpringServicePlanVisibilities(this.restOperations, root, this.processorGroup);
         this.servicePlans = new SpringServicePlans(this.restOperations, root, this.processorGroup);
         this.spaceQuotaDefinitions = new SpringSpaceQuotaDefinitions(this.restOperations, root, this.processorGroup);
         this.spaces = new SpringSpaces(this.restOperations, root, this.processorGroup);
@@ -231,6 +236,7 @@ public final class SpringCloudFoundryClient implements CloudFoundryClient {
         this.serviceBrokers = new SpringServiceBrokers(this.restOperations, root, this.processorGroup);
         this.serviceInstances = new SpringServiceInstances(this.restOperations, root, this.processorGroup);
         this.serviceKeys = new SpringServiceKeys(this.restOperations, root, this.processorGroup);
+        this.servicePlanVisibilities = new SpringServicePlanVisibilities(this.restOperations, root, this.processorGroup);
         this.servicePlans = new SpringServicePlans(this.restOperations, root, this.processorGroup);
         this.spaceQuotaDefinitions = new SpringSpaceQuotaDefinitions(this.restOperations, root, this.processorGroup);
         this.spaces = new SpringSpaces(this.restOperations, root, this.processorGroup);
@@ -311,6 +317,11 @@ public final class SpringCloudFoundryClient implements CloudFoundryClient {
     @Override
     public ServiceKeys serviceKeys() {
         return this.serviceKeys;
+    }
+
+    @Override
+    public ServicePlanVisibilities servicePlanVisibilities() {
+        return this.servicePlanVisibilities;
     }
 
     @Override

--- a/cloudfoundry-client-spring/src/main/lombok/org/cloudfoundry/client/spring/v2/serviceplanvisibilities/SpringServicePlanVisibilities.java
+++ b/cloudfoundry-client-spring/src/main/lombok/org/cloudfoundry/client/spring/v2/serviceplanvisibilities/SpringServicePlanVisibilities.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright 2013-2016 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.cloudfoundry.client.spring.v2.serviceplanvisibilities;
+
+
+import org.cloudfoundry.client.spring.util.AbstractSpringOperations;
+import org.cloudfoundry.client.v2.serviceplanvisibilities.CreateServicePlanVisibilityRequest;
+import org.cloudfoundry.client.v2.serviceplanvisibilities.CreateServicePlanVisibilityResponse;
+import org.cloudfoundry.client.v2.serviceplanvisibilities.ServicePlanVisibilities;
+import org.springframework.web.client.RestOperations;
+import org.springframework.web.util.UriComponentsBuilder;
+import reactor.core.publisher.Mono;
+import reactor.core.publisher.ProcessorGroup;
+import reactor.fn.Consumer;
+
+public final class SpringServicePlanVisibilities extends AbstractSpringOperations implements ServicePlanVisibilities {
+
+    /**
+     * Creates an instance
+     *
+     * @param restOperations the {@link RestOperations } to use to communicate with the server
+     * @param root           the root URI of the server.  Typically something like {@code https://api.run.pivotal.io}.
+     * @param processorGroup The group to use when making requests
+     */
+    public SpringServicePlanVisibilities(RestOperations restOperations, java.net.URI root, ProcessorGroup processorGroup) {
+        super(restOperations, root, processorGroup);
+    }
+
+    @Override
+    public Mono<CreateServicePlanVisibilityResponse> create(final CreateServicePlanVisibilityRequest request) {
+        return post(request, CreateServicePlanVisibilityResponse.class, new Consumer<UriComponentsBuilder>() {
+
+            @Override
+            public void accept(UriComponentsBuilder builder) {
+                builder.pathSegment("v2", "service_plan_visibilities");
+            }
+
+        });
+    }
+
+}

--- a/cloudfoundry-client-spring/src/test/java/org/cloudfoundry/client/spring/SpringCloudFoundryClientTest.java
+++ b/cloudfoundry-client-spring/src/test/java/org/cloudfoundry/client/spring/SpringCloudFoundryClientTest.java
@@ -163,6 +163,11 @@ public final class SpringCloudFoundryClientTest extends AbstractRestTest {
     }
 
     @Test
+    public void servicePlanVisibilities() {
+        assertNotNull(this.client.servicePlanVisibilities());
+    }
+
+    @Test
     public void servicePlans() {
         assertNotNull(this.client.servicePlans());
     }

--- a/cloudfoundry-client-spring/src/test/java/org/cloudfoundry/client/spring/v2/serviceplanvisibilities/SpringServicePlanVisibilitiesTest.java
+++ b/cloudfoundry-client-spring/src/test/java/org/cloudfoundry/client/spring/v2/serviceplanvisibilities/SpringServicePlanVisibilitiesTest.java
@@ -1,0 +1,82 @@
+/*
+ * Copyright 2013-2016 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.cloudfoundry.client.spring.v2.serviceplanvisibilities;
+
+import org.cloudfoundry.client.spring.AbstractApiTest;
+import org.cloudfoundry.client.v2.Resource;
+import org.cloudfoundry.client.v2.serviceplanvisibilities.CreateServicePlanVisibilityRequest;
+import org.cloudfoundry.client.v2.serviceplanvisibilities.CreateServicePlanVisibilityResponse;
+import org.cloudfoundry.client.v2.serviceplanvisibilities.ServicePlanVisibilities;
+import org.cloudfoundry.client.v2.serviceplanvisibilities.ServicePlanVisibilityEntity;
+import org.reactivestreams.Publisher;
+
+import static org.springframework.http.HttpMethod.POST;
+import static org.springframework.http.HttpStatus.CREATED;
+
+
+public final class SpringServicePlanVisibilitiesTest {
+
+    public static final class Create extends AbstractApiTest<CreateServicePlanVisibilityRequest, CreateServicePlanVisibilityResponse> {
+
+        private final ServicePlanVisibilities servicePlanVisibilities = new SpringServicePlanVisibilities(this.restTemplate, this.root, PROCESSOR_GROUP);
+
+        @Override
+        protected CreateServicePlanVisibilityRequest getInvalidRequest() {
+            return CreateServicePlanVisibilityRequest.builder().build();
+        }
+
+        @Override
+        protected RequestContext getRequestContext() {
+            return new RequestContext()
+                    .method(POST).path("v2/service_plan_visibilities")
+                    .requestPayload("v2/service_plan_visibilities/POST_request.json")
+                    .status(CREATED)
+                    .responsePayload("v2/service_plan_visibilities/POST_response.json");
+        }
+
+        @Override
+        protected CreateServicePlanVisibilityResponse getResponse() {
+            return CreateServicePlanVisibilityResponse.builder()
+                    .metadata(Resource.Metadata.builder()
+                            .createdAt("2015-07-27T22:43:28Z")
+                            .id("28a22749-25f4-44bd-a371-c37e2ee53175")
+                            .url("/v2/service_plan_visibilities/28a22749-25f4-44bd-a371-c37e2ee53175")
+                            .build())
+                    .entity(ServicePlanVisibilityEntity.builder()
+                            .organizationId("09be17a1-0cc6-4edb-955c-cf2a2ae85470")
+                            .organizationUrl("/v2/organizations/09be17a1-0cc6-4edb-955c-cf2a2ae85470")
+                            .servicePlanId("43f5496b-9117-404a-a637-eb38141b05af")
+                            .servicePlanUrl("/v2/service_plans/43f5496b-9117-404a-a637-eb38141b05af")
+                            .build())
+                    .build();
+        }
+
+        @Override
+        protected CreateServicePlanVisibilityRequest getValidRequest() throws Exception {
+            return CreateServicePlanVisibilityRequest.builder()
+                    .organizationId("09be17a1-0cc6-4edb-955c-cf2a2ae85470")
+                    .servicePlanId("43f5496b-9117-404a-a637-eb38141b05af")
+                    .build();
+        }
+
+        @Override
+        protected Publisher<CreateServicePlanVisibilityResponse> invoke(CreateServicePlanVisibilityRequest request) {
+            return this.servicePlanVisibilities.create(request);
+        }
+    }
+
+}

--- a/cloudfoundry-client-spring/src/test/resources/v2/service_plan_visibilities/POST_request.json
+++ b/cloudfoundry-client-spring/src/test/resources/v2/service_plan_visibilities/POST_request.json
@@ -1,0 +1,4 @@
+{
+  "service_plan_guid": "43f5496b-9117-404a-a637-eb38141b05af",
+  "organization_guid": "09be17a1-0cc6-4edb-955c-cf2a2ae85470"
+}

--- a/cloudfoundry-client-spring/src/test/resources/v2/service_plan_visibilities/POST_response.json
+++ b/cloudfoundry-client-spring/src/test/resources/v2/service_plan_visibilities/POST_response.json
@@ -1,0 +1,14 @@
+{
+  "metadata": {
+    "guid": "28a22749-25f4-44bd-a371-c37e2ee53175",
+    "url": "/v2/service_plan_visibilities/28a22749-25f4-44bd-a371-c37e2ee53175",
+    "created_at": "2015-07-27T22:43:28Z",
+    "updated_at": null
+  },
+  "entity": {
+    "service_plan_guid": "43f5496b-9117-404a-a637-eb38141b05af",
+    "organization_guid": "09be17a1-0cc6-4edb-955c-cf2a2ae85470",
+    "service_plan_url": "/v2/service_plans/43f5496b-9117-404a-a637-eb38141b05af",
+    "organization_url": "/v2/organizations/09be17a1-0cc6-4edb-955c-cf2a2ae85470"
+  }
+}

--- a/cloudfoundry-client/src/main/java/org/cloudfoundry/client/CloudFoundryClient.java
+++ b/cloudfoundry-client/src/main/java/org/cloudfoundry/client/CloudFoundryClient.java
@@ -29,6 +29,7 @@ import org.cloudfoundry.client.v2.servicebrokers.ServiceBrokers;
 import org.cloudfoundry.client.v2.serviceinstances.ServiceInstances;
 import org.cloudfoundry.client.v2.servicekeys.ServiceKeys;
 import org.cloudfoundry.client.v2.serviceplans.ServicePlans;
+import org.cloudfoundry.client.v2.serviceplanvisibilities.ServicePlanVisibilities;
 import org.cloudfoundry.client.v2.shareddomains.SharedDomains;
 import org.cloudfoundry.client.v2.spacequotadefinitions.SpaceQuotaDefinitions;
 import org.cloudfoundry.client.v2.spaces.Spaces;
@@ -152,6 +153,13 @@ public interface CloudFoundryClient {
      * @return the Cloud Foundry Service Keys Client API
      */
     ServiceKeys serviceKeys();
+
+    /**
+     * Main entry point to the Cloud Foundry Service Plan Visibilities Client API
+     *
+     * @return the Cloud Foundry Service Plan Visibilities Client API
+     */
+    ServicePlanVisibilities servicePlanVisibilities();
 
     /**
      * Main entry point to the Cloud Foundry Service Plans Client API

--- a/cloudfoundry-client/src/main/java/org/cloudfoundry/client/v2/serviceplanvisibilities/ServicePlanVisibilities.java
+++ b/cloudfoundry-client/src/main/java/org/cloudfoundry/client/v2/serviceplanvisibilities/ServicePlanVisibilities.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2013-2016 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.cloudfoundry.client.v2.serviceplanvisibilities;
+
+import reactor.core.publisher.Mono;
+
+/**
+ * Main entry point to the Cloud Foundry Service Plan Visibilities Client API
+ */
+public interface ServicePlanVisibilities {
+
+    /**
+     * Makes the <a href="http://apidocs.cloudfoundry.org/214/service_keys/create_a_service_key.html">Create Service Plan Visibility</a> request
+     *
+     * @param request the Create Service Plan Visibility request
+     * @return the response from the Create Service Plan Visibility request
+     */
+    Mono<CreateServicePlanVisibilityResponse> create(CreateServicePlanVisibilityRequest request);
+
+}

--- a/cloudfoundry-client/src/main/lombok/org/cloudfoundry/client/v2/serviceplanvisibilities/CreateServicePlanVisibilityRequest.java
+++ b/cloudfoundry-client/src/main/lombok/org/cloudfoundry/client/v2/serviceplanvisibilities/CreateServicePlanVisibilityRequest.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright 2013-2016 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.cloudfoundry.client.v2.serviceplanvisibilities;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.Builder;
+import lombok.Getter;
+import org.cloudfoundry.client.Validatable;
+import org.cloudfoundry.client.ValidationResult;
+
+/**
+ * The request payload for the Create Service Plan Visibility
+ */
+public final class CreateServicePlanVisibilityRequest implements Validatable {
+
+    /**
+     * The organization id
+     *
+     * @param organizationId the organization id
+     * @return the organization id
+     */
+    @Getter(onMethod = @__(@JsonProperty("organization_guid")))
+    private final String organizationId;
+
+    /**
+     * The service plan id
+     *
+     * @param servicePlanId the service plan id
+     * @return the service plan id
+     */
+    @Getter(onMethod = @__(@JsonProperty("service_plan_guid")))
+    private final String servicePlanId;
+
+    @Builder
+    CreateServicePlanVisibilityRequest(String organizationId,
+                                       String servicePlanId) {
+        this.organizationId = organizationId;
+        this.servicePlanId = servicePlanId;
+    }
+
+    @Override
+    public ValidationResult isValid() {
+        ValidationResult.ValidationResultBuilder builder = ValidationResult.builder();
+
+        if (this.organizationId == null) {
+            builder.message("organization id must be specified");
+        }
+
+        if (this.servicePlanId == null) {
+            builder.message("service plan id must be specified");
+        }
+
+        return builder.build();
+    }
+
+}

--- a/cloudfoundry-client/src/main/lombok/org/cloudfoundry/client/v2/serviceplanvisibilities/CreateServicePlanVisibilityResponse.java
+++ b/cloudfoundry-client/src/main/lombok/org/cloudfoundry/client/v2/serviceplanvisibilities/CreateServicePlanVisibilityResponse.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2013-2016 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.cloudfoundry.client.v2.serviceplanvisibilities;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.Builder;
+import lombok.Data;
+import lombok.EqualsAndHashCode;
+import lombok.ToString;
+import org.cloudfoundry.client.v2.Resource;
+
+/**
+ * The response payload for the the Create Service Plan Visibility request.
+ */
+@Data
+@EqualsAndHashCode(callSuper = true)
+@ToString(callSuper = true)
+public final class CreateServicePlanVisibilityResponse extends Resource<ServicePlanVisibilityEntity> {
+
+
+    @Builder
+    CreateServicePlanVisibilityResponse(@JsonProperty("entity") ServicePlanVisibilityEntity entity,
+                                        @JsonProperty("metadata") Metadata metadata) {
+        super(entity, metadata);
+    }
+
+}

--- a/cloudfoundry-client/src/main/lombok/org/cloudfoundry/client/v2/serviceplanvisibilities/ServicePlanVisibilityEntity.java
+++ b/cloudfoundry-client/src/main/lombok/org/cloudfoundry/client/v2/serviceplanvisibilities/ServicePlanVisibilityEntity.java
@@ -1,0 +1,73 @@
+/*
+ * Copyright 2013-2016 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.cloudfoundry.client.v2.serviceplanvisibilities;
+
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.Builder;
+import lombok.Data;
+
+/**
+ * The entity response payload for Service Plan Visibility
+ */
+@Data
+public final class ServicePlanVisibilityEntity {
+
+    /**
+     * The organization id
+     *
+     * @param organizationId the organization id
+     * @return the organization id
+     */
+    private final String organizationId;
+
+    /**
+     * The organization url
+     *
+     * @param spaceUrl the organization url
+     * @return the organization url
+     */
+    private final String organizationUrl;
+
+    /**
+     * The service plan id
+     *
+     * @param servicePlanId the service plan id
+     * @return the service plan id
+     */
+    private final String servicePlanId;
+
+    /**
+     * The service plan url
+     *
+     * @param servicePlanUrl the service plan url
+     * @return the service plan url
+     */
+    private final String servicePlanUrl;
+
+    @Builder
+    ServicePlanVisibilityEntity(@JsonProperty("organization_guid") String organizationId,
+                                @JsonProperty("organization_url") String organizationUrl,
+                                @JsonProperty("service_plan_guid") String servicePlanId,
+                                @JsonProperty("service_plan_url") String servicePlanUrl) {
+        this.organizationId = organizationId;
+        this.organizationUrl = organizationUrl;
+        this.servicePlanId = servicePlanId;
+        this.servicePlanUrl = servicePlanUrl;
+    }
+
+}

--- a/cloudfoundry-client/src/test/java/org/cloudfoundry/client/v2/serviceplanvisibilities/CreateServicePlanVisibilityRequestTest.java
+++ b/cloudfoundry-client/src/test/java/org/cloudfoundry/client/v2/serviceplanvisibilities/CreateServicePlanVisibilityRequestTest.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright 2013-2016 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.cloudfoundry.client.v2.serviceplanvisibilities;
+
+import org.cloudfoundry.client.ValidationResult;
+import org.junit.Test;
+
+import static org.cloudfoundry.client.ValidationResult.Status.INVALID;
+import static org.cloudfoundry.client.ValidationResult.Status.VALID;
+import static org.junit.Assert.assertEquals;
+
+
+public final class CreateServicePlanVisibilityRequestTest {
+
+    @Test
+    public void isNotValidNoOrganizationId() {
+        ValidationResult result = CreateServicePlanVisibilityRequest.builder()
+                .servicePlanId("service-plan-id")
+                .build()
+                .isValid();
+
+        assertEquals(INVALID, result.getStatus());
+        assertEquals("organization id must be specified", result.getMessages().get(0));
+    }
+
+    @Test
+    public void isNotValidNoServicePlanId() {
+        ValidationResult result = CreateServicePlanVisibilityRequest.builder()
+                .organizationId("organization-id")
+                .build()
+                .isValid();
+
+        assertEquals(INVALID, result.getStatus());
+        assertEquals("service plan id must be specified", result.getMessages().get(0));
+    }
+
+    @Test
+    public void isValid() {
+        ValidationResult result = CreateServicePlanVisibilityRequest.builder()
+                .organizationId("organization-id")
+                .servicePlanId("service-plan-id")
+                .build()
+                .isValid();
+
+        assertEquals(VALID, result.getStatus());
+    }
+
+}


### PR DESCRIPTION
this change adds the API to Create a Service Plan Visibility (```POST /v2/service_plan_visibilities```)
See [this story](https://www.pivotaltracker.com/projects/816799/stories/101451560)