### PR TITLE
Delete Service Plan Visibility

### DIFF
--- a/cloudfoundry-client-spring/src/main/lombok/org/cloudfoundry/client/spring/v2/serviceplanvisibilities/SpringServicePlanVisibilities.java
+++ b/cloudfoundry-client-spring/src/main/lombok/org/cloudfoundry/client/spring/v2/serviceplanvisibilities/SpringServicePlanVisibilities.java
@@ -18,8 +18,10 @@ package org.cloudfoundry.client.spring.v2.serviceplanvisibilities;
 
 
 import org.cloudfoundry.client.spring.util.AbstractSpringOperations;
+import org.cloudfoundry.client.spring.util.QueryBuilder;
 import org.cloudfoundry.client.v2.serviceplanvisibilities.CreateServicePlanVisibilityRequest;
 import org.cloudfoundry.client.v2.serviceplanvisibilities.CreateServicePlanVisibilityResponse;
+import org.cloudfoundry.client.v2.serviceplanvisibilities.DeleteServicePlanVisibilityRequest;
 import org.cloudfoundry.client.v2.serviceplanvisibilities.ServicePlanVisibilities;
 import org.springframework.web.client.RestOperations;
 import org.springframework.web.util.UriComponentsBuilder;
@@ -49,6 +51,17 @@ public final class SpringServicePlanVisibilities extends AbstractSpringOperation
                 builder.pathSegment("v2", "service_plan_visibilities");
             }
 
+        });
+    }
+
+    @Override
+    public Mono<Void> delete(final DeleteServicePlanVisibilityRequest request) {
+        return delete(request, new Consumer<UriComponentsBuilder>() {
+            @Override
+            public void accept(UriComponentsBuilder builder) {
+                builder.pathSegment("v2", "service_plan_visibilities", request.getServicePlanVisibilityId());
+                QueryBuilder.augment(builder, request);
+            }
         });
     }
 

--- a/cloudfoundry-client-spring/src/test/java/org/cloudfoundry/client/spring/v2/serviceplanvisibilities/SpringServicePlanVisibilitiesTest.java
+++ b/cloudfoundry-client-spring/src/test/java/org/cloudfoundry/client/spring/v2/serviceplanvisibilities/SpringServicePlanVisibilitiesTest.java
@@ -20,12 +20,15 @@ import org.cloudfoundry.client.spring.AbstractApiTest;
 import org.cloudfoundry.client.v2.Resource;
 import org.cloudfoundry.client.v2.serviceplanvisibilities.CreateServicePlanVisibilityRequest;
 import org.cloudfoundry.client.v2.serviceplanvisibilities.CreateServicePlanVisibilityResponse;
+import org.cloudfoundry.client.v2.serviceplanvisibilities.DeleteServicePlanVisibilityRequest;
 import org.cloudfoundry.client.v2.serviceplanvisibilities.ServicePlanVisibilities;
 import org.cloudfoundry.client.v2.serviceplanvisibilities.ServicePlanVisibilityEntity;
 import org.reactivestreams.Publisher;
 
+import static org.springframework.http.HttpMethod.DELETE;
 import static org.springframework.http.HttpMethod.POST;
 import static org.springframework.http.HttpStatus.CREATED;
+import static org.springframework.http.HttpStatus.NO_CONTENT;
 
 
 public final class SpringServicePlanVisibilitiesTest {
@@ -76,6 +79,41 @@ public final class SpringServicePlanVisibilitiesTest {
         @Override
         protected Publisher<CreateServicePlanVisibilityResponse> invoke(CreateServicePlanVisibilityRequest request) {
             return this.servicePlanVisibilities.create(request);
+        }
+    }
+
+    public static final class Delete extends AbstractApiTest<DeleteServicePlanVisibilityRequest, Void> {
+
+        private final ServicePlanVisibilities servicePlanVisibilities = new SpringServicePlanVisibilities(this.restTemplate, this.root, PROCESSOR_GROUP);
+
+        @Override
+        protected DeleteServicePlanVisibilityRequest getInvalidRequest() {
+            return DeleteServicePlanVisibilityRequest.builder().build();
+        }
+
+        @Override
+        protected RequestContext getRequestContext() {
+            return new RequestContext()
+                    .method(DELETE).path("/v2/service_plan_visibilities/test-service-plan-visibility-id?async=true")
+                    .status(NO_CONTENT);
+        }
+
+        @Override
+        protected Void getResponse() {
+            return null;
+        }
+
+        @Override
+        protected DeleteServicePlanVisibilityRequest getValidRequest() throws Exception {
+            return DeleteServicePlanVisibilityRequest.builder()
+                    .async(true)
+                    .servicePlanVisibilityId("test-service-plan-visibility-id")
+                    .build();
+        }
+
+        @Override
+        protected Publisher<Void> invoke(DeleteServicePlanVisibilityRequest request) {
+            return this.servicePlanVisibilities.delete(request);
         }
     }
 

--- a/cloudfoundry-client/src/main/java/org/cloudfoundry/client/v2/serviceplanvisibilities/ServicePlanVisibilities.java
+++ b/cloudfoundry-client/src/main/java/org/cloudfoundry/client/v2/serviceplanvisibilities/ServicePlanVisibilities.java
@@ -31,4 +31,12 @@ public interface ServicePlanVisibilities {
      */
     Mono<CreateServicePlanVisibilityResponse> create(CreateServicePlanVisibilityRequest request);
 
+    /**
+     * Makes the <a href="http://apidocs.cloudfoundry.org/214/service_plan_visibilities/delete_a_particular_service_plan_visibilities.html">Delete the Service Plan Visibility</a> request
+     *
+     * @param request the Delete Service Plan Visibility request
+     * @return the response from the Delete Service Plan Visibility request
+     */
+    Mono<Void> delete(DeleteServicePlanVisibilityRequest request);
+
 }

--- a/cloudfoundry-client/src/main/lombok/org/cloudfoundry/client/v2/serviceplanvisibilities/DeleteServicePlanVisibilityRequest.java
+++ b/cloudfoundry-client/src/main/lombok/org/cloudfoundry/client/v2/serviceplanvisibilities/DeleteServicePlanVisibilityRequest.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright 2013-2016 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.cloudfoundry.client.v2.serviceplanvisibilities;
+
+
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import lombok.Builder;
+import lombok.Getter;
+import org.cloudfoundry.client.QueryParameter;
+import org.cloudfoundry.client.Validatable;
+import org.cloudfoundry.client.ValidationResult;
+
+public final class DeleteServicePlanVisibilityRequest implements Validatable {
+
+    /**
+     * The async flag
+     *
+     * @param async  Will run the delete request in a background job. Recommended: 'true'.
+     * @return the async flag
+     */
+    @Getter(onMethod = @__(@QueryParameter("async")))
+    private final Boolean async;
+
+    /**
+     * The service plan visibility id
+     *
+     * @param servicePlanVisibilityId the service plan visibility id
+     * @return the service plan visibility id
+     */
+    @Getter(onMethod = @__(@JsonIgnore))
+    private final String servicePlanVisibilityId;
+
+    @Builder
+    DeleteServicePlanVisibilityRequest(Boolean async,
+                                       String servicePlanVisibilityId) {
+        this.async = async;
+        this.servicePlanVisibilityId = servicePlanVisibilityId;
+    }
+
+    @Override
+    public ValidationResult isValid() {
+        ValidationResult.ValidationResultBuilder builder = ValidationResult.builder();
+
+        if (this.servicePlanVisibilityId == null) {
+            builder.message("service plan visibility id must be specified");
+        }
+
+        return builder.build();
+    }
+
+}

--- a/cloudfoundry-client/src/test/java/org/cloudfoundry/client/v2/serviceplanvisibilities/DeleteServicePlanVisibilityRequestTest.java
+++ b/cloudfoundry-client/src/test/java/org/cloudfoundry/client/v2/serviceplanvisibilities/DeleteServicePlanVisibilityRequestTest.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2013-2016 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.cloudfoundry.client.v2.serviceplanvisibilities;
+
+import org.cloudfoundry.client.ValidationResult;
+import org.junit.Test;
+
+import static org.cloudfoundry.client.ValidationResult.Status.INVALID;
+import static org.cloudfoundry.client.ValidationResult.Status.VALID;
+import static org.junit.Assert.assertEquals;
+
+public final class DeleteServicePlanVisibilityRequestTest {
+
+    @Test
+    public void isValid() {
+        ValidationResult result = DeleteServicePlanVisibilityRequest.builder()
+                .servicePlanVisibilityId("test-service-plan-visibility-id")
+                .build()
+                .isValid();
+
+        assertEquals(VALID, result.getStatus());
+    }
+
+    @Test
+    public void isValidNoId() {
+        ValidationResult result = DeleteServicePlanVisibilityRequest.builder()
+                .build()
+                .isValid();
+
+        assertEquals(INVALID, result.getStatus());
+        assertEquals("service plan visibility id must be specified", result.getMessages().get(0));
+    }
+
+}


### PR DESCRIPTION
This change adds the api to delete a service plan visibility (```DELETE /v2/service_plan_visibilities/:guid```)
See [this story](https://www.pivotaltracker.com/projects/816799/stories/101451562)