### PR TITLE
List Service Plan Visibility

### DIFF
--- a/cloudfoundry-client-spring/src/main/lombok/org/cloudfoundry/client/spring/v2/serviceplanvisibilities/SpringServicePlanVisibilities.java
+++ b/cloudfoundry-client-spring/src/main/lombok/org/cloudfoundry/client/spring/v2/serviceplanvisibilities/SpringServicePlanVisibilities.java
@@ -19,9 +19,12 @@ package org.cloudfoundry.client.spring.v2.serviceplanvisibilities;
 
 import org.cloudfoundry.client.spring.util.AbstractSpringOperations;
 import org.cloudfoundry.client.spring.util.QueryBuilder;
+import org.cloudfoundry.client.spring.v2.FilterBuilder;
 import org.cloudfoundry.client.v2.serviceplanvisibilities.CreateServicePlanVisibilityRequest;
 import org.cloudfoundry.client.v2.serviceplanvisibilities.CreateServicePlanVisibilityResponse;
 import org.cloudfoundry.client.v2.serviceplanvisibilities.DeleteServicePlanVisibilityRequest;
+import org.cloudfoundry.client.v2.serviceplanvisibilities.ListServicePlanVisibilitiesRequest;
+import org.cloudfoundry.client.v2.serviceplanvisibilities.ListServicePlanVisibilitiesResponse;
 import org.cloudfoundry.client.v2.serviceplanvisibilities.ServicePlanVisibilities;
 import org.springframework.web.client.RestOperations;
 import org.springframework.web.util.UriComponentsBuilder;
@@ -65,4 +68,18 @@ public final class SpringServicePlanVisibilities extends AbstractSpringOperation
         });
     }
 
+    @Override
+    public Mono<ListServicePlanVisibilitiesResponse> list(final ListServicePlanVisibilitiesRequest request) {
+        return get(request, ListServicePlanVisibilitiesResponse.class, new Consumer<UriComponentsBuilder>() {
+
+            @Override
+            public void accept(UriComponentsBuilder builder) {
+                builder.pathSegment("v2", "service_plan_visibilities");
+                FilterBuilder.augment(builder, request);
+                QueryBuilder.augment(builder, request);
+            }
+
+        });
+    }
+    
 }

--- a/cloudfoundry-client-spring/src/test/java/org/cloudfoundry/client/spring/v2/serviceplanvisibilities/SpringServicePlanVisibilitiesTest.java
+++ b/cloudfoundry-client-spring/src/test/java/org/cloudfoundry/client/spring/v2/serviceplanvisibilities/SpringServicePlanVisibilitiesTest.java
@@ -21,14 +21,19 @@ import org.cloudfoundry.client.v2.Resource;
 import org.cloudfoundry.client.v2.serviceplanvisibilities.CreateServicePlanVisibilityRequest;
 import org.cloudfoundry.client.v2.serviceplanvisibilities.CreateServicePlanVisibilityResponse;
 import org.cloudfoundry.client.v2.serviceplanvisibilities.DeleteServicePlanVisibilityRequest;
+import org.cloudfoundry.client.v2.serviceplanvisibilities.ListServicePlanVisibilitiesRequest;
+import org.cloudfoundry.client.v2.serviceplanvisibilities.ListServicePlanVisibilitiesResponse;
 import org.cloudfoundry.client.v2.serviceplanvisibilities.ServicePlanVisibilities;
 import org.cloudfoundry.client.v2.serviceplanvisibilities.ServicePlanVisibilityEntity;
+import org.cloudfoundry.client.v2.serviceplanvisibilities.ServicePlanVisibilityResource;
 import org.reactivestreams.Publisher;
 
 import static org.springframework.http.HttpMethod.DELETE;
+import static org.springframework.http.HttpMethod.GET;
 import static org.springframework.http.HttpMethod.POST;
 import static org.springframework.http.HttpStatus.CREATED;
 import static org.springframework.http.HttpStatus.NO_CONTENT;
+import static org.springframework.http.HttpStatus.OK;
 
 
 public final class SpringServicePlanVisibilitiesTest {
@@ -114,6 +119,58 @@ public final class SpringServicePlanVisibilitiesTest {
         @Override
         protected Publisher<Void> invoke(DeleteServicePlanVisibilityRequest request) {
             return this.servicePlanVisibilities.delete(request);
+        }
+    }
+
+    public static final class List extends AbstractApiTest<ListServicePlanVisibilitiesRequest, ListServicePlanVisibilitiesResponse> {
+
+        private final ServicePlanVisibilities servicePlanVisibilities = new SpringServicePlanVisibilities(this.restTemplate, this.root, PROCESSOR_GROUP);
+
+        @Override
+        protected ListServicePlanVisibilitiesRequest getInvalidRequest() {
+            return null;
+        }
+
+        @Override
+        protected RequestContext getRequestContext() {
+            return new RequestContext()
+                    .method(GET).path("/v2/service_plan_visibilities?q=organization_guid%20IN%20test-organization-id&page=-1")
+                    .status(OK)
+                    .responsePayload("v2/service_plan_visibilities/GET_response.json");
+        }
+
+        @Override
+        protected ListServicePlanVisibilitiesResponse getResponse() {
+            return ListServicePlanVisibilitiesResponse.builder()
+                    .totalPages(1)
+                    .totalResults(1)
+                    .resource(ServicePlanVisibilityResource.builder()
+                            .metadata(Resource.Metadata.builder()
+                                    .id("3d5c0584-fbf0-4d75-b68e-226e77496f69")
+                                    .url("/v2/service_plan_visibilities/3d5c0584-fbf0-4d75-b68e-226e77496f69")
+                                    .createdAt("2015-07-27T22:43:28Z")
+                                    .build())
+                            .entity(ServicePlanVisibilityEntity.builder()
+                                    .organizationId("1dbe25db-6a8c-43e7-a941-cc483bb45570")
+                                    .organizationUrl("/v2/organizations/1dbe25db-6a8c-43e7-a941-cc483bb45570")
+                                    .servicePlanId("69cab29d-826c-48bf-b435-b43013f9c11b")
+                                    .servicePlanUrl("/v2/service_plans/69cab29d-826c-48bf-b435-b43013f9c11b")
+                                    .build())
+                            .build())
+                    .build();
+        }
+
+        @Override
+        protected ListServicePlanVisibilitiesRequest getValidRequest() throws Exception {
+            return ListServicePlanVisibilitiesRequest.builder()
+                    .organizationId("test-organization-id")
+                    .page(-1)
+                    .build();
+        }
+
+        @Override
+        protected Publisher<ListServicePlanVisibilitiesResponse> invoke(ListServicePlanVisibilitiesRequest request) {
+            return this.servicePlanVisibilities.list(request);
         }
     }
 

--- a/cloudfoundry-client-spring/src/test/resources/v2/service_plan_visibilities/GET_response.json
+++ b/cloudfoundry-client-spring/src/test/resources/v2/service_plan_visibilities/GET_response.json
@@ -1,0 +1,22 @@
+{
+  "total_results": 1,
+  "total_pages": 1,
+  "prev_url": null,
+  "next_url": null,
+  "resources": [
+    {
+      "metadata": {
+        "guid": "3d5c0584-fbf0-4d75-b68e-226e77496f69",
+        "url": "/v2/service_plan_visibilities/3d5c0584-fbf0-4d75-b68e-226e77496f69",
+        "created_at": "2015-07-27T22:43:28Z",
+        "updated_at": null
+      },
+      "entity": {
+        "service_plan_guid": "69cab29d-826c-48bf-b435-b43013f9c11b",
+        "organization_guid": "1dbe25db-6a8c-43e7-a941-cc483bb45570",
+        "service_plan_url": "/v2/service_plans/69cab29d-826c-48bf-b435-b43013f9c11b",
+        "organization_url": "/v2/organizations/1dbe25db-6a8c-43e7-a941-cc483bb45570"
+      }
+    }
+  ]
+}

--- a/cloudfoundry-client/src/main/java/org/cloudfoundry/client/v2/serviceplanvisibilities/ServicePlanVisibilities.java
+++ b/cloudfoundry-client/src/main/java/org/cloudfoundry/client/v2/serviceplanvisibilities/ServicePlanVisibilities.java
@@ -39,4 +39,12 @@ public interface ServicePlanVisibilities {
      */
     Mono<Void> delete(DeleteServicePlanVisibilityRequest request);
 
+    /**
+     * Makes the <a href="http://apidocs.cloudfoundry.org/214/service_bindings/list_all_service_bindings.html">List all Service Plan Visibilities</a> request
+     *
+     * @param request the List Service Plan Visibilities request
+     * @return the response from the List Service Plan Visibilities request
+     */
+    Mono<ListServicePlanVisibilitiesResponse> list(ListServicePlanVisibilitiesRequest request);
+
 }

--- a/cloudfoundry-client/src/main/lombok/org/cloudfoundry/client/v2/serviceplanvisibilities/ListServicePlanVisibilitiesRequest.java
+++ b/cloudfoundry-client/src/main/lombok/org/cloudfoundry/client/v2/serviceplanvisibilities/ListServicePlanVisibilitiesRequest.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright 2013-2016 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.cloudfoundry.client.v2.serviceplanvisibilities;
+
+import lombok.Builder;
+import lombok.Data;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.Singular;
+import lombok.ToString;
+import org.cloudfoundry.client.Validatable;
+import org.cloudfoundry.client.ValidationResult;
+import org.cloudfoundry.client.v2.InFilterParameter;
+import org.cloudfoundry.client.v2.PaginatedRequest;
+
+import java.util.List;
+
+/**
+ * The request payload for the List all Service Service Plan Visibilities operation
+ */
+@Data
+@EqualsAndHashCode(callSuper = true)
+@ToString(callSuper = true)
+public final class ListServicePlanVisibilitiesRequest extends PaginatedRequest implements Validatable {
+
+    /**
+     * The organization ids
+     *
+     * @param organizationIds the organization ids
+     * @return the organization ids
+     */
+    @Getter(onMethod = @__(@InFilterParameter("organization_guid")))
+    private final List<String> organizationIds;
+
+    /**
+     * The service plan ids
+     *
+     * @param servicePlanIds the service plan ids
+     * @return the service plan ids
+     */
+    @Getter(onMethod = @__(@InFilterParameter("service_plan_guid")))
+    private final List<String> servicePlanIds;
+
+    @Builder
+    ListServicePlanVisibilitiesRequest(OrderDirection orderDirection, Integer page, Integer resultsPerPage,
+                                       @Singular List<String> organizationIds,
+                                       @Singular List<String> servicePlanIds) {
+        super(orderDirection, page, resultsPerPage);
+        this.organizationIds = organizationIds;
+        this.servicePlanIds = servicePlanIds;
+    }
+
+    @Override
+    public ValidationResult isValid() {
+        return ValidationResult.builder().build();
+    }
+
+}

--- a/cloudfoundry-client/src/main/lombok/org/cloudfoundry/client/v2/serviceplanvisibilities/ListServicePlanVisibilitiesResponse.java
+++ b/cloudfoundry-client/src/main/lombok/org/cloudfoundry/client/v2/serviceplanvisibilities/ListServicePlanVisibilitiesResponse.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2013-2016 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.cloudfoundry.client.v2.serviceplanvisibilities;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.Builder;
+import lombok.Data;
+import lombok.EqualsAndHashCode;
+import lombok.Singular;
+import lombok.ToString;
+import org.cloudfoundry.client.v2.PaginatedResponse;
+
+import java.util.List;
+
+/**
+ * The response payload for the List all Service Service Plan Visibilities
+ */
+@Data
+@EqualsAndHashCode(callSuper = true)
+@ToString(callSuper = true)
+public final class ListServicePlanVisibilitiesResponse extends PaginatedResponse<ServicePlanVisibilityResource> {
+
+    @Builder
+    ListServicePlanVisibilitiesResponse(@JsonProperty("next_url") String nextUrl,
+                                        @JsonProperty("prev_url") String previousUrl,
+                                        @JsonProperty("resources") @Singular List<ServicePlanVisibilityResource> resources,
+                                        @JsonProperty("total_pages") Integer totalPages,
+                                        @JsonProperty("total_results") Integer totalResults) {
+        super(nextUrl, previousUrl, resources, totalPages, totalResults);
+    }
+
+}

--- a/cloudfoundry-client/src/main/lombok/org/cloudfoundry/client/v2/serviceplanvisibilities/ServicePlanVisibilityResource.java
+++ b/cloudfoundry-client/src/main/lombok/org/cloudfoundry/client/v2/serviceplanvisibilities/ServicePlanVisibilityResource.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2013-2016 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.cloudfoundry.client.v2.serviceplanvisibilities;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.Builder;
+import lombok.Data;
+import lombok.EqualsAndHashCode;
+import lombok.ToString;
+import org.cloudfoundry.client.v2.Resource;
+
+/**
+ * Service Plan Visibility in responses
+ */
+@Data
+@EqualsAndHashCode(callSuper = true)
+@ToString(callSuper = true)
+public final class ServicePlanVisibilityResource extends Resource<ServicePlanVisibilityEntity> {
+
+    @Builder
+    ServicePlanVisibilityResource(@JsonProperty("entity") ServicePlanVisibilityEntity entity,
+                                  @JsonProperty("metadata") Metadata metadata) {
+        super(entity, metadata);
+    }
+
+}

--- a/cloudfoundry-client/src/test/java/org/cloudfoundry/client/v2/serviceplanvisibilities/ListServicePlanVisibilitiesRequestTest.java
+++ b/cloudfoundry-client/src/test/java/org/cloudfoundry/client/v2/serviceplanvisibilities/ListServicePlanVisibilitiesRequestTest.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2013-2016 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.cloudfoundry.client.v2.serviceplanvisibilities;
+
+import org.junit.Test;
+
+import static org.cloudfoundry.client.ValidationResult.Status.VALID;
+import static org.junit.Assert.assertEquals;
+
+public final class ListServicePlanVisibilitiesRequestTest {
+
+    @Test
+    public void isValid() {
+        assertEquals(VALID, ListServicePlanVisibilitiesRequest.builder().build().isValid().getStatus());
+    }
+    
+}


### PR DESCRIPTION
This change adds the api to list service plan visibility (```GET /v2/service_plan_visibilities```)
See [this story](https://www.pivotaltracker.com/projects/816799/stories/101451566)