### PR TITLE
Get Service Plan Visibility

### DIFF
--- a/cloudfoundry-client-spring/src/main/lombok/org/cloudfoundry/client/spring/v2/serviceplanvisibilities/SpringServicePlanVisibilities.java
+++ b/cloudfoundry-client-spring/src/main/lombok/org/cloudfoundry/client/spring/v2/serviceplanvisibilities/SpringServicePlanVisibilities.java
@@ -23,6 +23,8 @@ import org.cloudfoundry.client.spring.v2.FilterBuilder;
 import org.cloudfoundry.client.v2.serviceplanvisibilities.CreateServicePlanVisibilityRequest;
 import org.cloudfoundry.client.v2.serviceplanvisibilities.CreateServicePlanVisibilityResponse;
 import org.cloudfoundry.client.v2.serviceplanvisibilities.DeleteServicePlanVisibilityRequest;
+import org.cloudfoundry.client.v2.serviceplanvisibilities.GetServicePlanVisibilityRequest;
+import org.cloudfoundry.client.v2.serviceplanvisibilities.GetServicePlanVisibilityResponse;
 import org.cloudfoundry.client.v2.serviceplanvisibilities.ListServicePlanVisibilitiesRequest;
 import org.cloudfoundry.client.v2.serviceplanvisibilities.ListServicePlanVisibilitiesResponse;
 import org.cloudfoundry.client.v2.serviceplanvisibilities.ServicePlanVisibilities;
@@ -64,6 +66,16 @@ public final class SpringServicePlanVisibilities extends AbstractSpringOperation
             public void accept(UriComponentsBuilder builder) {
                 builder.pathSegment("v2", "service_plan_visibilities", request.getServicePlanVisibilityId());
                 QueryBuilder.augment(builder, request);
+            }
+        });
+    }
+
+    @Override
+    public Mono<GetServicePlanVisibilityResponse> get(final GetServicePlanVisibilityRequest request) {
+        return get(request, GetServicePlanVisibilityResponse.class, new Consumer<UriComponentsBuilder>() {
+            @Override
+            public void accept(UriComponentsBuilder builder) {
+                builder.pathSegment("v2", "service_plan_visibilities", request.getServicePlanVisibilityId());
             }
         });
     }

--- a/cloudfoundry-client-spring/src/test/java/org/cloudfoundry/client/spring/v2/serviceplanvisibilities/SpringServicePlanVisibilitiesTest.java
+++ b/cloudfoundry-client-spring/src/test/java/org/cloudfoundry/client/spring/v2/serviceplanvisibilities/SpringServicePlanVisibilitiesTest.java
@@ -21,6 +21,8 @@ import org.cloudfoundry.client.v2.Resource;
 import org.cloudfoundry.client.v2.serviceplanvisibilities.CreateServicePlanVisibilityRequest;
 import org.cloudfoundry.client.v2.serviceplanvisibilities.CreateServicePlanVisibilityResponse;
 import org.cloudfoundry.client.v2.serviceplanvisibilities.DeleteServicePlanVisibilityRequest;
+import org.cloudfoundry.client.v2.serviceplanvisibilities.GetServicePlanVisibilityRequest;
+import org.cloudfoundry.client.v2.serviceplanvisibilities.GetServicePlanVisibilityResponse;
 import org.cloudfoundry.client.v2.serviceplanvisibilities.ListServicePlanVisibilitiesRequest;
 import org.cloudfoundry.client.v2.serviceplanvisibilities.ListServicePlanVisibilitiesResponse;
 import org.cloudfoundry.client.v2.serviceplanvisibilities.ServicePlanVisibilities;
@@ -119,6 +121,53 @@ public final class SpringServicePlanVisibilitiesTest {
         @Override
         protected Publisher<Void> invoke(DeleteServicePlanVisibilityRequest request) {
             return this.servicePlanVisibilities.delete(request);
+        }
+    }
+
+    public static final class Get extends AbstractApiTest<GetServicePlanVisibilityRequest, GetServicePlanVisibilityResponse> {
+
+        private final ServicePlanVisibilities servicePlanVisibilities = new SpringServicePlanVisibilities(this.restTemplate, this.root, PROCESSOR_GROUP);
+
+        @Override
+        protected GetServicePlanVisibilityRequest getInvalidRequest() {
+            return GetServicePlanVisibilityRequest.builder().build();
+        }
+
+        @Override
+        protected RequestContext getRequestContext() {
+            return new RequestContext()
+                .method(GET).path("/v2/service_plan_visibilities/test-service-plan-visibility-id")
+                .status(OK)
+                .responsePayload("v2/service_plan_visibilities/GET_{id}_response.json");
+        }
+
+        @Override
+        protected GetServicePlanVisibilityResponse getResponse() {
+            return GetServicePlanVisibilityResponse.builder()
+                .metadata(Resource.Metadata.builder()
+                    .createdAt("2015-07-27T22:43:28Z")
+                    .id("18365c25-898b-4365-911d-6f6a09154297")
+                    .url("/v2/service_plan_visibilities/18365c25-898b-4365-911d-6f6a09154297")
+                    .build())
+                .entity(ServicePlanVisibilityEntity.builder()
+                    .organizationId("a1cc950b-ed5b-41eb-8eee-d9a8f85aa1ea")
+                    .organizationUrl("/v2/organizations/a1cc950b-ed5b-41eb-8eee-d9a8f85aa1ea")
+                    .servicePlanId("ea1ba716-e720-4aef-8a90-439924bb53d0")
+                    .servicePlanUrl("/v2/service_plans/ea1ba716-e720-4aef-8a90-439924bb53d0")
+                    .build())
+                .build();
+        }
+
+        @Override
+        protected GetServicePlanVisibilityRequest getValidRequest() throws Exception {
+            return GetServicePlanVisibilityRequest.builder()
+                .servicePlanVisibilityId("test-service-plan-visibility-id")
+                .build();
+        }
+
+        @Override
+        protected Publisher<GetServicePlanVisibilityResponse> invoke(GetServicePlanVisibilityRequest request) {
+            return this.servicePlanVisibilities.get(request);
         }
     }
 

--- a/cloudfoundry-client-spring/src/test/resources/v2/service_plan_visibilities/GET_{id}_response.json
+++ b/cloudfoundry-client-spring/src/test/resources/v2/service_plan_visibilities/GET_{id}_response.json
@@ -1,0 +1,14 @@
+{
+  "metadata": {
+    "guid": "18365c25-898b-4365-911d-6f6a09154297",
+    "url": "/v2/service_plan_visibilities/18365c25-898b-4365-911d-6f6a09154297",
+    "created_at": "2015-07-27T22:43:28Z",
+    "updated_at": null
+  },
+  "entity": {
+    "service_plan_guid": "ea1ba716-e720-4aef-8a90-439924bb53d0",
+    "organization_guid": "a1cc950b-ed5b-41eb-8eee-d9a8f85aa1ea",
+    "service_plan_url": "/v2/service_plans/ea1ba716-e720-4aef-8a90-439924bb53d0",
+    "organization_url": "/v2/organizations/a1cc950b-ed5b-41eb-8eee-d9a8f85aa1ea"
+  }
+}

--- a/cloudfoundry-client/src/main/java/org/cloudfoundry/client/v2/serviceplanvisibilities/ServicePlanVisibilities.java
+++ b/cloudfoundry-client/src/main/java/org/cloudfoundry/client/v2/serviceplanvisibilities/ServicePlanVisibilities.java
@@ -40,6 +40,14 @@ public interface ServicePlanVisibilities {
     Mono<Void> delete(DeleteServicePlanVisibilityRequest request);
 
     /**
+     * Makes the <a href="http://apidocs.cloudfoundry.org/214/service_plan_visibilities/retrieve_a_particular_service_plan_visibility.html">Retrieve a Particular Service Plan Visibility</a> request
+     *
+     * @param request the Get Service Plan Visibility request
+     * @return the response from the Get Service Plan Visibility request
+     */
+    Mono<GetServicePlanVisibilityResponse> get(GetServicePlanVisibilityRequest request);
+
+    /**
      * Makes the <a href="http://apidocs.cloudfoundry.org/214/service_bindings/list_all_service_bindings.html">List all Service Plan Visibilities</a> request
      *
      * @param request the List Service Plan Visibilities request

--- a/cloudfoundry-client/src/main/lombok/org/cloudfoundry/client/v2/serviceplanvisibilities/GetServicePlanVisibilityRequest.java
+++ b/cloudfoundry-client/src/main/lombok/org/cloudfoundry/client/v2/serviceplanvisibilities/GetServicePlanVisibilityRequest.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright 2013-2016 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.cloudfoundry.client.v2.serviceplanvisibilities;
+
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import lombok.Builder;
+import lombok.Data;
+import lombok.Getter;
+import org.cloudfoundry.client.Validatable;
+import org.cloudfoundry.client.ValidationResult;
+
+/**
+ * The request payload for the Get Service Plan Visibility operation
+ */
+@Data
+public final class GetServicePlanVisibilityRequest implements Validatable {
+
+    /**
+     * The service plan visibility id
+     *
+     * @param servicePlanVisibilityId the service plan visibility id
+     * @return the service plan visibility id
+     */
+    @Getter(onMethod = @__(@JsonIgnore))
+    private final String servicePlanVisibilityId;
+
+    @Builder
+    GetServicePlanVisibilityRequest(String servicePlanVisibilityId) {
+        this.servicePlanVisibilityId = servicePlanVisibilityId;
+    }
+
+    @Override
+    public ValidationResult isValid() {
+        ValidationResult.ValidationResultBuilder builder = ValidationResult.builder();
+
+        if (this.servicePlanVisibilityId == null) {
+            builder.message("service plan visibility id must be specified");
+        }
+
+        return builder.build();
+    }
+}

--- a/cloudfoundry-client/src/main/lombok/org/cloudfoundry/client/v2/serviceplanvisibilities/GetServicePlanVisibilityResponse.java
+++ b/cloudfoundry-client/src/main/lombok/org/cloudfoundry/client/v2/serviceplanvisibilities/GetServicePlanVisibilityResponse.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2013-2016 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.cloudfoundry.client.v2.serviceplanvisibilities;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.Builder;
+import lombok.Data;
+import lombok.EqualsAndHashCode;
+import lombok.ToString;
+import org.cloudfoundry.client.v2.Resource;
+
+/**
+ * The response payload for the Get Service Plan Visibility operation
+ */
+@Data
+@EqualsAndHashCode(callSuper = true)
+@ToString(callSuper = true)
+public final class GetServicePlanVisibilityResponse extends Resource<ServicePlanVisibilityEntity> {
+
+    @Builder
+    GetServicePlanVisibilityResponse(@JsonProperty("entity") ServicePlanVisibilityEntity entity,
+                                     @JsonProperty("metadata") Metadata metadata) {
+        super(entity, metadata);
+    }
+
+}

--- a/cloudfoundry-client/src/test/java/org/cloudfoundry/client/v2/serviceplanvisibilities/GetServicePlanVisibilityRequestTest.java
+++ b/cloudfoundry-client/src/test/java/org/cloudfoundry/client/v2/serviceplanvisibilities/GetServicePlanVisibilityRequestTest.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2013-2016 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.cloudfoundry.client.v2.serviceplanvisibilities;
+
+import org.cloudfoundry.client.ValidationResult;
+import org.junit.Test;
+
+import static org.cloudfoundry.client.ValidationResult.Status.INVALID;
+import static org.cloudfoundry.client.ValidationResult.Status.VALID;
+import static org.junit.Assert.assertEquals;
+
+public final class GetServicePlanVisibilityRequestTest {
+
+    @Test
+    public void isValid() {
+        ValidationResult result = GetServicePlanVisibilityRequest.builder()
+            .servicePlanVisibilityId("test-service-plan-visibility-id")
+            .build()
+            .isValid();
+
+        assertEquals(VALID, result.getStatus());
+    }
+
+    @Test
+    public void isValidNoId() {
+        ValidationResult result = GetServicePlanVisibilityRequest.builder()
+            .build()
+            .isValid();
+
+        assertEquals(INVALID, result.getStatus());
+        assertEquals("service plan visibility id must be specified", result.getMessages().get(0));
+    }
+}


### PR DESCRIPTION
This change adds the api to retrieve a particular service plan visibility (```GET /v2/service_plan_visibilities/:guid```)
See [this story](https://www.pivotaltracker.com/projects/816799/stories/101451568)