### PR TITLE
Use a java.io.InputStream instead of java.io.File for application upload

### DIFF
--- a/cloudfoundry-client-spring/src/main/lombok/org/cloudfoundry/client/spring/v2/applications/SpringApplicationsV2.java
+++ b/cloudfoundry-client-spring/src/main/lombok/org/cloudfoundry/client/spring/v2/applications/SpringApplicationsV2.java
@@ -56,7 +56,7 @@ import org.cloudfoundry.client.v2.applications.UpdateApplicationResponse;
 import org.cloudfoundry.client.v2.applications.UploadApplicationRequest;
 import org.cloudfoundry.client.v2.applications.UploadApplicationResponse;
 import org.reactivestreams.Publisher;
-import org.springframework.core.io.FileSystemResource;
+import org.springframework.core.io.InputStreamResource;
 import org.springframework.util.LinkedMultiValueMap;
 import org.springframework.util.MultiValueMap;
 import org.springframework.web.client.RestOperations;
@@ -330,7 +330,7 @@ public final class SpringApplicationsV2 extends AbstractSpringOperations impleme
                         body.add("async", request.getAsync());
                     }
                     body.add("resources", request.getResources());
-                    body.add("application", new FileSystemResource(request.getApplication()));
+                    body.add("application", new InputStreamResource(request.getApplication()));
                     return body;
                 }
 

--- a/cloudfoundry-client-spring/src/test/java/org/cloudfoundry/client/spring/v2/applications/SpringApplicationsV2Test.java
+++ b/cloudfoundry-client-spring/src/test/java/org/cloudfoundry/client/spring/v2/applications/SpringApplicationsV2Test.java
@@ -1250,7 +1250,7 @@ public final class SpringApplicationsV2Test {
         @Override
         protected UploadApplicationRequest getValidRequest() throws Exception {
             return UploadApplicationRequest.builder()
-                .application(new ClassPathResource("v2/apps/application.zip").getFile())
+                .application(new ClassPathResource("v2/apps/application.zip").getInputStream())
                 .applicationId("test-application-id")
                 .resource(UploadApplicationRequest.Resource.builder()
                     .hash("b907173290db6a155949ab4dc9b2d019dea0c901")

--- a/cloudfoundry-client/src/main/lombok/org/cloudfoundry/client/v2/applications/UploadApplicationRequest.java
+++ b/cloudfoundry-client/src/main/lombok/org/cloudfoundry/client/v2/applications/UploadApplicationRequest.java
@@ -25,7 +25,7 @@ import lombok.Singular;
 import org.cloudfoundry.client.Validatable;
 import org.cloudfoundry.client.ValidationResult;
 
-import java.io.File;
+import java.io.InputStream;
 import java.util.List;
 
 /**
@@ -41,7 +41,7 @@ public final class UploadApplicationRequest implements Validatable {
      * @return the application bits file
      */
     @Getter(onMethod = @__(@JsonIgnore))
-    private final File application;
+    private final InputStream application;
 
     /**
      * The application id
@@ -71,7 +71,7 @@ public final class UploadApplicationRequest implements Validatable {
     private final List<Resource> resources;
 
     @Builder
-    UploadApplicationRequest(File application,
+    UploadApplicationRequest(InputStream application,
                              String applicationId,
                              Boolean async,
                              @Singular List<Resource> resources) {

--- a/cloudfoundry-client/src/test/java/org/cloudfoundry/client/v2/applications/UploadApplicationRequestTest.java
+++ b/cloudfoundry-client/src/test/java/org/cloudfoundry/client/v2/applications/UploadApplicationRequestTest.java
@@ -19,7 +19,8 @@ package org.cloudfoundry.client.v2.applications;
 import org.cloudfoundry.client.ValidationResult;
 import org.junit.Test;
 
-import java.io.File;
+import java.io.ByteArrayInputStream;
+import java.io.InputStream;
 
 import static org.cloudfoundry.client.ValidationResult.Status.INVALID;
 import static org.cloudfoundry.client.ValidationResult.Status.VALID;
@@ -27,10 +28,12 @@ import static org.junit.Assert.assertEquals;
 
 public final class UploadApplicationRequestTest {
 
+    private static final InputStream EMPTY_INPUT_STREAM = new ByteArrayInputStream(new byte[0]);
+
     @Test
     public void isValid() {
         ValidationResult result = UploadApplicationRequest.builder()
-            .application(new File("test-file"))
+            .application(EMPTY_INPUT_STREAM)
             .applicationId("test-application-id")
             .resource(UploadApplicationRequest.Resource.builder()
                 .hash("test-hash")
@@ -62,7 +65,7 @@ public final class UploadApplicationRequestTest {
     @Test
     public void isValidNoId() {
         ValidationResult result = UploadApplicationRequest.builder()
-            .application(new File("test-file"))
+            .application(EMPTY_INPUT_STREAM)
             .resource(UploadApplicationRequest.Resource.builder()
                 .hash("test-hash")
                 .path("test-path")
@@ -78,7 +81,7 @@ public final class UploadApplicationRequestTest {
     @Test
     public void isValidNoResourceHash() {
         ValidationResult result = UploadApplicationRequest.builder()
-            .application(new File("test-file"))
+            .application(EMPTY_INPUT_STREAM)
             .applicationId("test-application-id")
             .resource(UploadApplicationRequest.Resource.builder()
                 .path("test-path")
@@ -94,7 +97,7 @@ public final class UploadApplicationRequestTest {
     @Test
     public void isValidNoResourcePath() {
         ValidationResult result = UploadApplicationRequest.builder()
-            .application(new File("test-file"))
+            .application(EMPTY_INPUT_STREAM)
             .applicationId("test-application-id")
             .resource(UploadApplicationRequest.Resource.builder()
                 .hash("test-hash")
@@ -110,7 +113,7 @@ public final class UploadApplicationRequestTest {
     @Test
     public void isValidNoResourceSize() {
         ValidationResult result = UploadApplicationRequest.builder()
-            .application(new File("test-file"))
+            .application(EMPTY_INPUT_STREAM)
             .applicationId("test-application-id")
             .resource(UploadApplicationRequest.Resource.builder()
                 .hash("test-hash")
@@ -126,7 +129,7 @@ public final class UploadApplicationRequestTest {
     @Test
     public void isValidNoResources() {
         ValidationResult result = UploadApplicationRequest.builder()
-            .application(new File("test-file"))
+            .application(EMPTY_INPUT_STREAM)
             .applicationId("test-application-id")
             .build()
             .isValid();

--- a/integration-test/src/test/java/org/cloudfoundry/client/ApplicationsTest.java
+++ b/integration-test/src/test/java/org/cloudfoundry/client/ApplicationsTest.java
@@ -59,6 +59,8 @@ import reactor.rx.Stream;
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.File;
+import java.io.FileInputStream;
+import java.io.FileNotFoundException;
 import java.io.FileOutputStream;
 import java.io.IOException;
 import java.util.Map;
@@ -592,13 +594,17 @@ public final class ApplicationsTest extends AbstractIntegrationTest {
     }
 
     private Mono<String> uploadApplication(String applicationId) {
-        return this.cloudFoundryClient.applicationsV2()
-            .upload(UploadApplicationRequest.builder()
-                .application(new File("./src/test/resources/testApplication.zip"))
-                .async(false)
-                .applicationId(applicationId)
-                .build())
-            .map(response -> applicationId);
+        try {
+            return this.cloudFoundryClient.applicationsV2()
+                .upload(UploadApplicationRequest.builder()
+                    .application(new FileInputStream("./src/test/resources/testApplication.zip"))
+                    .async(false)
+                    .applicationId(applicationId)
+                    .build())
+                .map(response -> applicationId);
+        } catch (FileNotFoundException e) {
+            throw new RuntimeException(e);
+        }
     }
 
     private Mono<String> waitForStaging(String applicationId) {


### PR DESCRIPTION
File is too narrow scoped of an abstraction for providing application bits to be uploaded to Cloud Foundry. Using an InputStream is much more generic and allows for uploading applications that live off of the local filesystem.