### PR TITLE
Update Service Plan Visibility

### DIFF
--- a/cloudfoundry-client-spring/src/main/lombok/org/cloudfoundry/client/spring/v2/serviceplanvisibilities/SpringServicePlanVisibilities.java
+++ b/cloudfoundry-client-spring/src/main/lombok/org/cloudfoundry/client/spring/v2/serviceplanvisibilities/SpringServicePlanVisibilities.java
@@ -28,6 +28,8 @@ import org.cloudfoundry.client.v2.serviceplanvisibilities.GetServicePlanVisibili
 import org.cloudfoundry.client.v2.serviceplanvisibilities.ListServicePlanVisibilitiesRequest;
 import org.cloudfoundry.client.v2.serviceplanvisibilities.ListServicePlanVisibilitiesResponse;
 import org.cloudfoundry.client.v2.serviceplanvisibilities.ServicePlanVisibilities;
+import org.cloudfoundry.client.v2.serviceplanvisibilities.UpdateServicePlanVisibilityRequest;
+import org.cloudfoundry.client.v2.serviceplanvisibilities.UpdateServicePlanVisibilityResponse;
 import org.springframework.web.client.RestOperations;
 import org.springframework.web.util.UriComponentsBuilder;
 import reactor.core.publisher.Mono;
@@ -55,13 +57,13 @@ public final class SpringServicePlanVisibilities extends AbstractSpringOperation
             public void accept(UriComponentsBuilder builder) {
                 builder.pathSegment("v2", "service_plan_visibilities");
             }
-
         });
     }
 
     @Override
     public Mono<Void> delete(final DeleteServicePlanVisibilityRequest request) {
         return delete(request, Void.class, new Consumer<UriComponentsBuilder>() {
+
             @Override
             public void accept(UriComponentsBuilder builder) {
                 builder.pathSegment("v2", "service_plan_visibilities", request.getServicePlanVisibilityId());
@@ -73,6 +75,7 @@ public final class SpringServicePlanVisibilities extends AbstractSpringOperation
     @Override
     public Mono<GetServicePlanVisibilityResponse> get(final GetServicePlanVisibilityRequest request) {
         return get(request, GetServicePlanVisibilityResponse.class, new Consumer<UriComponentsBuilder>() {
+
             @Override
             public void accept(UriComponentsBuilder builder) {
                 builder.pathSegment("v2", "service_plan_visibilities", request.getServicePlanVisibilityId());
@@ -90,7 +93,17 @@ public final class SpringServicePlanVisibilities extends AbstractSpringOperation
                 FilterBuilder.augment(builder, request);
                 QueryBuilder.augment(builder, request);
             }
+        });
+    }
 
+    @Override
+    public Mono<UpdateServicePlanVisibilityResponse> update(final UpdateServicePlanVisibilityRequest request) {
+        return put(request, UpdateServicePlanVisibilityResponse.class, new Consumer<UriComponentsBuilder>() {
+
+            @Override
+            public void accept(UriComponentsBuilder builder) {
+                builder.pathSegment("v2", "service_plan_visibilities", request.getServicePlanVisibilityId());
+            }
         });
     }
 

--- a/cloudfoundry-client-spring/src/test/java/org/cloudfoundry/client/spring/v2/serviceplanvisibilities/SpringServicePlanVisibilitiesTest.java
+++ b/cloudfoundry-client-spring/src/test/java/org/cloudfoundry/client/spring/v2/serviceplanvisibilities/SpringServicePlanVisibilitiesTest.java
@@ -28,11 +28,14 @@ import org.cloudfoundry.client.v2.serviceplanvisibilities.ListServicePlanVisibil
 import org.cloudfoundry.client.v2.serviceplanvisibilities.ServicePlanVisibilities;
 import org.cloudfoundry.client.v2.serviceplanvisibilities.ServicePlanVisibilityEntity;
 import org.cloudfoundry.client.v2.serviceplanvisibilities.ServicePlanVisibilityResource;
+import org.cloudfoundry.client.v2.serviceplanvisibilities.UpdateServicePlanVisibilityRequest;
+import org.cloudfoundry.client.v2.serviceplanvisibilities.UpdateServicePlanVisibilityResponse;
 import org.reactivestreams.Publisher;
 
 import static org.springframework.http.HttpMethod.DELETE;
 import static org.springframework.http.HttpMethod.GET;
 import static org.springframework.http.HttpMethod.POST;
+import static org.springframework.http.HttpMethod.PUT;
 import static org.springframework.http.HttpStatus.CREATED;
 import static org.springframework.http.HttpStatus.NO_CONTENT;
 import static org.springframework.http.HttpStatus.OK;
@@ -222,5 +225,57 @@ public final class SpringServicePlanVisibilitiesTest {
             return this.servicePlanVisibilities.list(request);
         }
     }
+
+    public static final class Update extends AbstractApiTest<UpdateServicePlanVisibilityRequest, UpdateServicePlanVisibilityResponse> {
+
+        private final ServicePlanVisibilities servicePlanVisibilities = new SpringServicePlanVisibilities(this.restTemplate, this.root, PROCESSOR_GROUP);
+
+        @Override
+        protected UpdateServicePlanVisibilityRequest getInvalidRequest() {
+            return UpdateServicePlanVisibilityRequest.builder().build();
+        }
+
+        @Override
+        protected RequestContext getRequestContext() {
+            return new RequestContext()
+                .method(PUT).path("v2/service_plan_visibilities/test-service-plan-visibility-id")
+                .requestPayload("v2/service_plan_visibilities/PUT_{id}_request.json")
+                .status(CREATED)
+                .responsePayload("v2/service_plan_visibilities/PUT_{id}_response.json");
+        }
+
+        @Override
+        protected UpdateServicePlanVisibilityResponse getResponse() {
+            return UpdateServicePlanVisibilityResponse.builder()
+                .metadata(Resource.Metadata.builder()
+                    .createdAt("2015-07-27T22:43:28Z")
+                    .id("5f1514f9-66ee-4799-9de2-69f2ec3cb5f1")
+                    .updatedAt("2015-07-27T22:43:28Z")
+                    .url("/v2/service_plan_visibilities/5f1514f9-66ee-4799-9de2-69f2ec3cb5f1")
+                    .build())
+                .entity(ServicePlanVisibilityEntity.builder()
+                    .organizationId("e4d0b68b-9e73-4253-b03f-2bfda6cd814b")
+                    .organizationUrl("/v2/organizations/e4d0b68b-9e73-4253-b03f-2bfda6cd814b")
+                    .servicePlanId("7288464d-3866-436a-915c-2bada4725e7e")
+                    .servicePlanUrl("/v2/service_plans/7288464d-3866-436a-915c-2bada4725e7e")
+                    .build())
+                .build();
+        }
+
+        @Override
+        protected UpdateServicePlanVisibilityRequest getValidRequest() throws Exception {
+            return UpdateServicePlanVisibilityRequest.builder()
+                .organizationId("e4d0b68b-9e73-4253-b03f-2bfda6cd814b")
+                .servicePlanId("7288464d-3866-436a-915c-2bada4725e7e")
+                .servicePlanVisibilityId("test-service-plan-visibility-id")
+                .build();
+        }
+
+        @Override
+        protected Publisher<UpdateServicePlanVisibilityResponse> invoke(UpdateServicePlanVisibilityRequest request) {
+            return this.servicePlanVisibilities.update(request);
+        }
+    }
+
 
 }

--- a/cloudfoundry-client-spring/src/test/resources/v2/service_plan_visibilities/PUT_{id}_request.json
+++ b/cloudfoundry-client-spring/src/test/resources/v2/service_plan_visibilities/PUT_{id}_request.json
@@ -1,0 +1,4 @@
+{
+  "service_plan_guid": "7288464d-3866-436a-915c-2bada4725e7e",
+  "organization_guid": "e4d0b68b-9e73-4253-b03f-2bfda6cd814b"
+}

--- a/cloudfoundry-client-spring/src/test/resources/v2/service_plan_visibilities/PUT_{id}_response.json
+++ b/cloudfoundry-client-spring/src/test/resources/v2/service_plan_visibilities/PUT_{id}_response.json
@@ -1,0 +1,14 @@
+{
+  "metadata": {
+    "guid": "5f1514f9-66ee-4799-9de2-69f2ec3cb5f1",
+    "url": "/v2/service_plan_visibilities/5f1514f9-66ee-4799-9de2-69f2ec3cb5f1",
+    "created_at": "2015-07-27T22:43:28Z",
+    "updated_at": "2015-07-27T22:43:28Z"
+  },
+  "entity": {
+    "service_plan_guid": "7288464d-3866-436a-915c-2bada4725e7e",
+    "organization_guid": "e4d0b68b-9e73-4253-b03f-2bfda6cd814b",
+    "service_plan_url": "/v2/service_plans/7288464d-3866-436a-915c-2bada4725e7e",
+    "organization_url": "/v2/organizations/e4d0b68b-9e73-4253-b03f-2bfda6cd814b"
+  }
+}

--- a/cloudfoundry-client/src/main/java/org/cloudfoundry/client/v2/serviceplanvisibilities/ServicePlanVisibilities.java
+++ b/cloudfoundry-client/src/main/java/org/cloudfoundry/client/v2/serviceplanvisibilities/ServicePlanVisibilities.java
@@ -55,4 +55,12 @@ public interface ServicePlanVisibilities {
      */
     Mono<ListServicePlanVisibilitiesResponse> list(ListServicePlanVisibilitiesRequest request);
 
+    /**
+     * Makes the <a href="http://apidocs.cloudfoundry.org/214/service_plan_visibilities/updating_a_service_plan_visibility.html">Update Service Plan Visibility</a> request
+     *
+     * @param request the Update Service Plan Visibility request
+     * @return the response from the Update Service Plan Visibility request
+     */
+    Mono<UpdateServicePlanVisibilityResponse> update(UpdateServicePlanVisibilityRequest request);
+
 }

--- a/cloudfoundry-client/src/main/lombok/org/cloudfoundry/client/v2/serviceplanvisibilities/UpdateServicePlanVisibilityRequest.java
+++ b/cloudfoundry-client/src/main/lombok/org/cloudfoundry/client/v2/serviceplanvisibilities/UpdateServicePlanVisibilityRequest.java
@@ -1,0 +1,86 @@
+/*
+ * Copyright 2013-2016 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.cloudfoundry.client.v2.serviceplanvisibilities;
+
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.Builder;
+import lombok.Getter;
+import org.cloudfoundry.client.Validatable;
+import org.cloudfoundry.client.ValidationResult;
+
+/**
+ * The request payload for the Update Service Plan Visibility
+ */
+public final class UpdateServicePlanVisibilityRequest implements Validatable {
+
+    /**
+     * The organization id
+     *
+     * @param organizationId the organization id
+     * @return the organization id
+     */
+    @Getter(onMethod = @__(@JsonProperty("organization_guid")))
+    private final String organizationId;
+
+    /**
+     * The service plan id
+     *
+     * @param servicePlanId the service plan id
+     * @return the service plan id
+     */
+    @Getter(onMethod = @__(@JsonProperty("service_plan_guid")))
+    private final String servicePlanId;
+
+    /**
+     * The service plan visibility id
+     *
+     * @param servicePlanVisibilityId the service plan visibility id
+     * @return the service plan visibility id
+     */
+    @Getter(onMethod = @__(@JsonIgnore))
+    private final String servicePlanVisibilityId;
+
+    @Builder
+    UpdateServicePlanVisibilityRequest(String organizationId,
+                                       String servicePlanId,
+                                       String servicePlanVisibilityId) {
+        this.organizationId = organizationId;
+        this.servicePlanId = servicePlanId;
+        this.servicePlanVisibilityId = servicePlanVisibilityId;
+    }
+
+    @Override
+    public ValidationResult isValid() {
+        ValidationResult.ValidationResultBuilder builder = ValidationResult.builder();
+
+        if (this.organizationId == null) {
+            builder.message("organization id must be specified");
+        }
+
+        if (this.servicePlanId == null) {
+            builder.message("service plan id must be specified");
+        }
+
+        if (this.servicePlanVisibilityId == null) {
+            builder.message("service plan visibility id must be specified");
+        }
+
+        return builder.build();
+    }
+
+}

--- a/cloudfoundry-client/src/main/lombok/org/cloudfoundry/client/v2/serviceplanvisibilities/UpdateServicePlanVisibilityResponse.java
+++ b/cloudfoundry-client/src/main/lombok/org/cloudfoundry/client/v2/serviceplanvisibilities/UpdateServicePlanVisibilityResponse.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2013-2016 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.cloudfoundry.client.v2.serviceplanvisibilities;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.Builder;
+import lombok.Data;
+import lombok.EqualsAndHashCode;
+import lombok.ToString;
+import org.cloudfoundry.client.v2.Resource;
+
+/**
+ * The response payload for the the Update Service Plan Visibility request.
+ */
+@Data
+@EqualsAndHashCode(callSuper = true)
+@ToString(callSuper = true)
+public final class UpdateServicePlanVisibilityResponse extends Resource<ServicePlanVisibilityEntity> {
+
+
+    @Builder
+    UpdateServicePlanVisibilityResponse(@JsonProperty("entity") ServicePlanVisibilityEntity entity,
+                                        @JsonProperty("metadata") Metadata metadata) {
+        super(entity, metadata);
+    }
+
+}

--- a/cloudfoundry-client/src/test/java/org/cloudfoundry/client/v2/serviceplanvisibilities/UpdateServicePlanVisibilityRequestTest.java
+++ b/cloudfoundry-client/src/test/java/org/cloudfoundry/client/v2/serviceplanvisibilities/UpdateServicePlanVisibilityRequestTest.java
@@ -1,0 +1,75 @@
+/*
+ * Copyright 2013-2016 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.cloudfoundry.client.v2.serviceplanvisibilities;
+
+import org.cloudfoundry.client.ValidationResult;
+import org.junit.Test;
+
+import static org.cloudfoundry.client.ValidationResult.Status.INVALID;
+import static org.cloudfoundry.client.ValidationResult.Status.VALID;
+import static org.junit.Assert.assertEquals;
+
+
+public final class UpdateServicePlanVisibilityRequestTest {
+
+    @Test
+    public void isNotValidNoId() {
+        ValidationResult result = GetServicePlanVisibilityRequest.builder()
+            .build()
+            .isValid();
+
+        assertEquals(INVALID, result.getStatus());
+        assertEquals("service plan visibility id must be specified", result.getMessages().get(0));
+    }
+
+    @Test
+    public void isNotValidNoOrganizationId() {
+        ValidationResult result = UpdateServicePlanVisibilityRequest.builder()
+            .servicePlanId("service-plan-id")
+            .servicePlanVisibilityId("test-service-plan-visibility-id")
+            .build()
+            .isValid();
+
+        assertEquals(INVALID, result.getStatus());
+        assertEquals("organization id must be specified", result.getMessages().get(0));
+    }
+
+    @Test
+    public void isNotValidNoServicePlanId() {
+        ValidationResult result = UpdateServicePlanVisibilityRequest.builder()
+            .organizationId("organization-id")
+            .servicePlanVisibilityId("test-service-plan-visibility-id")
+            .build()
+            .isValid();
+
+        assertEquals(INVALID, result.getStatus());
+        assertEquals("service plan id must be specified", result.getMessages().get(0));
+    }
+
+    @Test
+    public void isValid() {
+        ValidationResult result = UpdateServicePlanVisibilityRequest.builder()
+            .organizationId("organization-id")
+            .servicePlanId("service-plan-id")
+            .servicePlanVisibilityId("test-service-plan-visibility-id")
+            .build()
+            .isValid();
+
+        assertEquals(VALID, result.getStatus());
+    }
+
+}


### PR DESCRIPTION
This change adds the api to update a service plan visibility (```PUT /v2/service_plan_visibilities/:guid```)
See [this story](https://www.pivotaltracker.com/projects/816799/stories/101451570)