### PR TITLE
Migrate Service Instances

### DIFF
--- a/cloudfoundry-client-spring/src/main/lombok/org/cloudfoundry/client/spring/v2/serviceplans/SpringServicePlans.java
+++ b/cloudfoundry-client-spring/src/main/lombok/org/cloudfoundry/client/spring/v2/serviceplans/SpringServicePlans.java
@@ -29,6 +29,8 @@ import org.cloudfoundry.client.v2.serviceplans.ListServicePlanServiceInstancesRe
 import org.cloudfoundry.client.v2.serviceplans.ListServicePlanServiceInstancesResponse;
 import org.cloudfoundry.client.v2.serviceplans.ListServicePlansRequest;
 import org.cloudfoundry.client.v2.serviceplans.ListServicePlansResponse;
+import org.cloudfoundry.client.v2.serviceplans.MigrateServiceInstancesRequest;
+import org.cloudfoundry.client.v2.serviceplans.MigrateServiceInstancesResponse;
 import org.cloudfoundry.client.v2.serviceplans.ServicePlans;
 import org.springframework.web.client.RestOperations;
 import org.springframework.web.util.UriComponentsBuilder;
@@ -104,4 +106,15 @@ public final class SpringServicePlans extends AbstractSpringOperations implement
         });
     }
 
+    @Override
+    public Mono<MigrateServiceInstancesResponse> migrateServiceInstances(final MigrateServiceInstancesRequest request) {
+        return put(request, MigrateServiceInstancesResponse.class, new Consumer<UriComponentsBuilder>() {
+
+            @Override
+            public void accept(UriComponentsBuilder builder) {
+                builder.pathSegment("v2", "service_plans", request.getCurrentServicePlanId(), "service_instances");
+            }
+
+        });
+    }
 }

--- a/cloudfoundry-client-spring/src/test/java/org/cloudfoundry/client/spring/v2/serviceplans/SpringServicePlansTest.java
+++ b/cloudfoundry-client-spring/src/test/java/org/cloudfoundry/client/spring/v2/serviceplans/SpringServicePlansTest.java
@@ -29,12 +29,16 @@ import org.cloudfoundry.client.v2.serviceplans.ListServicePlanServiceInstancesRe
 import org.cloudfoundry.client.v2.serviceplans.ListServicePlanServiceInstancesResponse;
 import org.cloudfoundry.client.v2.serviceplans.ListServicePlansRequest;
 import org.cloudfoundry.client.v2.serviceplans.ListServicePlansResponse;
+import org.cloudfoundry.client.v2.serviceplans.MigrateServiceInstancesRequest;
+import org.cloudfoundry.client.v2.serviceplans.MigrateServiceInstancesResponse;
 import org.cloudfoundry.client.v2.serviceplans.ServicePlanEntity;
 import org.cloudfoundry.client.v2.serviceplans.ServicePlanResource;
+import org.reactivestreams.Publisher;
 import reactor.core.publisher.Mono;
 
 import static org.springframework.http.HttpMethod.DELETE;
 import static org.springframework.http.HttpMethod.GET;
+import static org.springframework.http.HttpMethod.PUT;
 import static org.springframework.http.HttpStatus.ACCEPTED;
 import static org.springframework.http.HttpStatus.NO_CONTENT;
 import static org.springframework.http.HttpStatus.OK;
@@ -294,6 +298,47 @@ public final class SpringServicePlansTest {
         @Override
         protected Mono<ListServicePlanServiceInstancesResponse> invoke(ListServicePlanServiceInstancesRequest request) {
             return this.servicePlans.listServiceInstances(request);
+        }
+
+    }
+
+    public static final class MigrateServiceInstances extends AbstractApiTest<MigrateServiceInstancesRequest, MigrateServiceInstancesResponse> {
+
+        private final SpringServicePlans servicePlans = new SpringServicePlans(this.restTemplate, this.root, PROCESSOR_GROUP);
+
+        @Override
+        protected MigrateServiceInstancesRequest getInvalidRequest() {
+            return MigrateServiceInstancesRequest.builder().build();
+        }
+
+        @Override
+        protected RequestContext getRequestContext() {
+            return new RequestContext()
+                .method(PUT)
+                .path("v2/service_plans/ed66be44-0c9d-40f9-93b9-4e9c062a345c/service_instances")
+                .requestPayload("v2/service_plans/PUT_{id}_service_instances_request.json")
+                .status(OK)
+                .responsePayload("v2/service_plans/PUT_{id}_service_instances_response.json");
+        }
+
+        @Override
+        protected MigrateServiceInstancesResponse getResponse() {
+            return MigrateServiceInstancesResponse.builder()
+                .resourcesChanged(1)
+                .build();
+        }
+
+        @Override
+        protected MigrateServiceInstancesRequest getValidRequest() throws Exception {
+            return MigrateServiceInstancesRequest.builder()
+                .currentServicePlanId("ed66be44-0c9d-40f9-93b9-4e9c062a345c")
+                .destinationServicePlanId("8234565b-70d1-41cc-ac11-783694c35d15")
+                .build();
+        }
+
+        @Override
+        protected Publisher<MigrateServiceInstancesResponse> invoke(MigrateServiceInstancesRequest request) {
+            return this.servicePlans.migrateServiceInstances(request);
         }
 
     }

--- a/cloudfoundry-client-spring/src/test/resources/v2/service_plans/PUT_{id}_service_instances_request.json
+++ b/cloudfoundry-client-spring/src/test/resources/v2/service_plans/PUT_{id}_service_instances_request.json
@@ -1,0 +1,3 @@
+{
+  "service_plan_guid": "8234565b-70d1-41cc-ac11-783694c35d15"
+}

--- a/cloudfoundry-client-spring/src/test/resources/v2/service_plans/PUT_{id}_service_instances_response.json
+++ b/cloudfoundry-client-spring/src/test/resources/v2/service_plans/PUT_{id}_service_instances_response.json
@@ -1,0 +1,3 @@
+{
+  "changed_count": 1
+}

--- a/cloudfoundry-client/src/main/java/org/cloudfoundry/client/v2/serviceplans/ServicePlans.java
+++ b/cloudfoundry-client/src/main/java/org/cloudfoundry/client/v2/serviceplans/ServicePlans.java
@@ -53,4 +53,13 @@ public interface ServicePlans {
      */
     Mono<ListServicePlanServiceInstancesResponse> listServiceInstances(ListServicePlanServiceInstancesRequest request);
 
+    /**
+     * Makes the <a href="http://apidocs.cloudfoundry.org/214/service_instances/migrate_service_instances_from_one_service_plan_to_another_service_plan_%28experimental%29.html">Migrate Service
+     * Instances from one Service Plan to the other</a> request
+     *
+     * @param request the Migrate Service Instance request
+     * @return the response from the Migrate Service Instance request
+     */
+    Mono<MigrateServiceInstancesResponse> migrateServiceInstances(MigrateServiceInstancesRequest request);
+
 }

--- a/cloudfoundry-client/src/main/lombok/org/cloudfoundry/client/v2/serviceplans/MigrateServiceInstancesRequest.java
+++ b/cloudfoundry-client/src/main/lombok/org/cloudfoundry/client/v2/serviceplans/MigrateServiceInstancesRequest.java
@@ -1,0 +1,73 @@
+/*
+ * Copyright 2013-2016 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.cloudfoundry.client.v2.serviceplans;
+
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.Builder;
+import lombok.Data;
+import lombok.Getter;
+import org.cloudfoundry.client.Validatable;
+import org.cloudfoundry.client.ValidationResult;
+
+/**
+ * The request payload for the Migrate Service Instances operation
+ */
+@Data
+public class MigrateServiceInstancesRequest implements Validatable {
+
+    /**
+     * The current service plan id
+     *
+     * @param currentServicePlanId the current service plan id
+     * @return the current service plan id
+     */
+    @Getter(onMethod = @__(@JsonIgnore))
+    private final String currentServicePlanId;
+
+    /**
+     * The destination service plan id
+     *
+     * @param destinationServicePlanId the destination service plan id
+     * @return the destination service plan id
+     */
+    @Getter(onMethod = @__(@JsonProperty("service_plan_guid")))
+    private final String destinationServicePlanId;
+
+    @Builder
+    MigrateServiceInstancesRequest(String currentServicePlanId,
+                                   String destinationServicePlanId) {
+        this.currentServicePlanId = currentServicePlanId;
+        this.destinationServicePlanId = destinationServicePlanId;
+    }
+
+    @Override
+    public ValidationResult isValid() {
+        ValidationResult.ValidationResultBuilder builder = ValidationResult.builder();
+
+        if (this.currentServicePlanId == null) {
+            builder.message("current service plan id must be specified");
+        }
+
+        if (this.destinationServicePlanId == null) {
+            builder.message("destination service plan id must be specified");
+        }
+
+        return builder.build();
+    }
+
+}

--- a/cloudfoundry-client/src/main/lombok/org/cloudfoundry/client/v2/serviceplans/MigrateServiceInstancesResponse.java
+++ b/cloudfoundry-client/src/main/lombok/org/cloudfoundry/client/v2/serviceplans/MigrateServiceInstancesResponse.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2013-2016 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.cloudfoundry.client.v2.serviceplans;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.Builder;
+import lombok.Data;
+import lombok.EqualsAndHashCode;
+import lombok.ToString;
+
+/**
+ * The resource response payload for the Migrate Service Instances Response
+ */
+@Data
+@EqualsAndHashCode
+@ToString(callSuper = true)
+public final class MigrateServiceInstancesResponse {
+
+    /**
+     * The number of resources changed
+     *
+     * @param resourcesChanged the number of resources changed
+     * @return the number of resources changed
+     */
+    private final Integer resourcesChanged;
+
+    @Builder
+    MigrateServiceInstancesResponse(@JsonProperty("changed_count") Integer resourcesChanged) {
+        this.resourcesChanged = resourcesChanged;
+    }
+
+}

--- a/cloudfoundry-client/src/test/java/org/cloudfoundry/client/v2/serviceplans/MigrateServiceInstancesRequestTest.java
+++ b/cloudfoundry-client/src/test/java/org/cloudfoundry/client/v2/serviceplans/MigrateServiceInstancesRequestTest.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright 2013-2016 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.cloudfoundry.client.v2.serviceplans;
+
+import org.cloudfoundry.client.ValidationResult;
+import org.junit.Test;
+
+import static org.cloudfoundry.client.ValidationResult.Status.INVALID;
+import static org.cloudfoundry.client.ValidationResult.Status.VALID;
+import static org.junit.Assert.assertEquals;
+
+public final class MigrateServiceInstancesRequestTest {
+
+    @Test
+    public void isNotValidNoCurrentServicePlanId() {
+        ValidationResult result = MigrateServiceInstancesRequest.builder()
+            .destinationServicePlanId("destination-service-plan-id")
+            .build()
+            .isValid();
+
+        assertEquals(INVALID, result.getStatus());
+        assertEquals("current service plan id must be specified", result.getMessages().get(0));
+    }
+
+    @Test
+    public void isNotValidNoDestinationServicePlanId() {
+        ValidationResult result = MigrateServiceInstancesRequest.builder()
+            .currentServicePlanId("current-service-plan-id")
+            .build()
+            .isValid();
+
+        assertEquals(INVALID, result.getStatus());
+        assertEquals("destination service plan id must be specified", result.getMessages().get(0));
+    }
+
+    @Test
+    public void isValid() {
+        ValidationResult result = MigrateServiceInstancesRequest.builder()
+            .currentServicePlanId("current-service-plan-id")
+            .destinationServicePlanId("destination-service-plan-id")
+            .build()
+            .isValid();
+
+        assertEquals(VALID, result.getStatus());
+    }
+
+}


### PR DESCRIPTION
This change adds the api to migrate service plans from one plan to the other (```PUT /v2/service_plans/:service_plan_guid/service_instances```)
See [this story](https://www.pivotaltracker.com/projects/816799/stories/101451544)