### PR TITLE
Get permissions on a Service Instance

### DIFF
--- a/cloudfoundry-client-spring/src/main/lombok/org/cloudfoundry/client/spring/v2/serviceinstances/SpringServiceInstances.java
+++ b/cloudfoundry-client-spring/src/main/lombok/org/cloudfoundry/client/spring/v2/serviceinstances/SpringServiceInstances.java
@@ -25,6 +25,8 @@ import org.cloudfoundry.client.v2.serviceinstances.BindServiceInstanceToRouteRes
 import org.cloudfoundry.client.v2.serviceinstances.CreateServiceInstanceRequest;
 import org.cloudfoundry.client.v2.serviceinstances.CreateServiceInstanceResponse;
 import org.cloudfoundry.client.v2.serviceinstances.DeleteServiceInstanceRequest;
+import org.cloudfoundry.client.v2.serviceinstances.GetServiceInstancePermissionsRequest;
+import org.cloudfoundry.client.v2.serviceinstances.GetServiceInstancePermissionsResponse;
 import org.cloudfoundry.client.v2.serviceinstances.GetServiceInstanceRequest;
 import org.cloudfoundry.client.v2.serviceinstances.GetServiceInstanceResponse;
 import org.cloudfoundry.client.v2.serviceinstances.ListServiceInstanceServiceBindingsRequest;
@@ -103,6 +105,18 @@ public final class SpringServiceInstances extends AbstractSpringOperations imple
             @Override
             public void accept(UriComponentsBuilder builder) {
                 builder.pathSegment("v2", "service_instances", request.getServiceInstanceId());
+            }
+
+        });
+    }
+
+    @Override
+    public Mono<GetServiceInstancePermissionsResponse> getPermissions(final GetServiceInstancePermissionsRequest request) {
+        return get(request, GetServiceInstancePermissionsResponse.class, new Consumer<UriComponentsBuilder>() {
+
+            @Override
+            public void accept(UriComponentsBuilder builder) {
+                builder.pathSegment("v2", "service_instances", request.getServiceInstanceId(), "permissions");
             }
 
         });

--- a/cloudfoundry-client-spring/src/test/java/org/cloudfoundry/client/spring/v2/serviceinstances/SpringServiceInstancesTest.java
+++ b/cloudfoundry-client-spring/src/test/java/org/cloudfoundry/client/spring/v2/serviceinstances/SpringServiceInstancesTest.java
@@ -25,6 +25,8 @@ import org.cloudfoundry.client.v2.serviceinstances.BindServiceInstanceToRouteRes
 import org.cloudfoundry.client.v2.serviceinstances.CreateServiceInstanceRequest;
 import org.cloudfoundry.client.v2.serviceinstances.CreateServiceInstanceResponse;
 import org.cloudfoundry.client.v2.serviceinstances.DeleteServiceInstanceRequest;
+import org.cloudfoundry.client.v2.serviceinstances.GetServiceInstancePermissionsRequest;
+import org.cloudfoundry.client.v2.serviceinstances.GetServiceInstancePermissionsResponse;
 import org.cloudfoundry.client.v2.serviceinstances.GetServiceInstanceRequest;
 import org.cloudfoundry.client.v2.serviceinstances.GetServiceInstanceResponse;
 import org.cloudfoundry.client.v2.serviceinstances.LastOperation;
@@ -36,6 +38,7 @@ import org.cloudfoundry.client.v2.serviceinstances.ServiceInstanceEntity;
 import org.cloudfoundry.client.v2.serviceinstances.ServiceInstanceResource;
 import org.cloudfoundry.client.v2.serviceinstances.UpdateServiceInstanceRequest;
 import org.cloudfoundry.client.v2.serviceinstances.UpdateServiceInstanceResponse;
+import org.reactivestreams.Publisher;
 import reactor.core.publisher.Mono;
 
 import static org.cloudfoundry.client.v2.Resource.Metadata;
@@ -277,6 +280,45 @@ public final class SpringServiceInstancesTest {
         }
 
     }
+
+    public static final class GetPermissions extends AbstractApiTest<GetServiceInstancePermissionsRequest, GetServiceInstancePermissionsResponse> {
+
+        private final SpringServiceInstances serviceInstances = new SpringServiceInstances(this.restTemplate, this.root, PROCESSOR_GROUP);
+
+        @Override
+        protected GetServiceInstancePermissionsRequest getInvalidRequest() {
+            return GetServiceInstancePermissionsRequest.builder().build();
+        }
+
+        @Override
+        protected RequestContext getRequestContext() {
+            return new RequestContext()
+                .method(GET).path("/v2/service_instances/test-service-instance-id/permissions")
+                .status(OK)
+                .responsePayload("v2/service_instances/GET_{id}_permissions_response.json");
+        }
+
+        @Override
+        protected GetServiceInstancePermissionsResponse getResponse() {
+            return GetServiceInstancePermissionsResponse.builder()
+                .manage(true)
+                .build();
+        }
+
+        @Override
+        protected GetServiceInstancePermissionsRequest getValidRequest() throws Exception {
+            return GetServiceInstancePermissionsRequest.builder()
+                .serviceInstanceId("test-service-instance-id")
+                .build();
+        }
+
+        @Override
+        protected Publisher<GetServiceInstancePermissionsResponse> invoke(GetServiceInstancePermissionsRequest request) {
+            return this.serviceInstances.getPermissions(request);
+        }
+        
+    }
+
 
     public static final class List extends AbstractApiTest<ListServiceInstancesRequest, ListServiceInstancesResponse> {
 

--- a/cloudfoundry-client-spring/src/test/resources/v2/service_instances/GET_{id}_permissions_response.json
+++ b/cloudfoundry-client-spring/src/test/resources/v2/service_instances/GET_{id}_permissions_response.json
@@ -1,0 +1,3 @@
+{
+  "manage": true
+}

--- a/cloudfoundry-client/src/main/java/org/cloudfoundry/client/v2/serviceinstances/ServiceInstances.java
+++ b/cloudfoundry-client/src/main/java/org/cloudfoundry/client/v2/serviceinstances/ServiceInstances.java
@@ -57,6 +57,14 @@ public interface ServiceInstances {
     Mono<GetServiceInstanceResponse> get(GetServiceInstanceRequest request);
 
     /**
+     * Makes the <a href="http://apidocs.cloudfoundry.org/214/service_instances/retrieving_permissions_on_a_service_instance.html">Retrieving permissions on a Service Instance</a> request
+     *
+     * @param request the Get Permissions request
+     * @return the response from the Get Permissions request
+     */
+    Mono<GetServiceInstancePermissionsResponse> getPermissions(GetServiceInstancePermissionsRequest request);
+
+    /**
      * Makes the <a href="http://apidocs.cloudfoundry.org/214/service_instances/list_all_service_instances.html">List Service Instances</a> request
      *
      * @param request the List Service Instances request

--- a/cloudfoundry-client/src/main/lombok/org/cloudfoundry/client/v2/serviceinstances/GetServiceInstancePermissionsRequest.java
+++ b/cloudfoundry-client/src/main/lombok/org/cloudfoundry/client/v2/serviceinstances/GetServiceInstancePermissionsRequest.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright 2013-2016 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.cloudfoundry.client.v2.serviceinstances;
+
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import lombok.Builder;
+import lombok.Data;
+import lombok.Getter;
+import org.cloudfoundry.client.Validatable;
+import org.cloudfoundry.client.ValidationResult;
+
+/**
+ * The request payload for the Get Permissions operation
+ */
+@Data
+public final class GetServiceInstancePermissionsRequest implements Validatable {
+
+    /**
+     * The service instance id
+     *
+     * @param serviceInstanceId the service instance id
+     * @return the service instance id
+     */
+    @Getter(onMethod = @__(@JsonIgnore))
+    private final String serviceInstanceId;
+
+    @Builder
+    GetServiceInstancePermissionsRequest(String serviceInstanceId) {
+        this.serviceInstanceId = serviceInstanceId;
+    }
+
+    @Override
+    public ValidationResult isValid() {
+        ValidationResult.ValidationResultBuilder builder = ValidationResult.builder();
+
+        if (this.serviceInstanceId == null) {
+            builder.message("service instance id must be specified");
+        }
+
+        return builder.build();
+    }
+
+}

--- a/cloudfoundry-client/src/main/lombok/org/cloudfoundry/client/v2/serviceinstances/GetServiceInstancePermissionsResponse.java
+++ b/cloudfoundry-client/src/main/lombok/org/cloudfoundry/client/v2/serviceinstances/GetServiceInstancePermissionsResponse.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2013-2016 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.cloudfoundry.client.v2.serviceinstances;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.Builder;
+import lombok.Data;
+import lombok.EqualsAndHashCode;
+import lombok.ToString;
+
+/**
+ * The resource response payload for the Get Permissions Response
+ */
+@Data
+@EqualsAndHashCode
+@ToString(callSuper = true)
+public final class GetServiceInstancePermissionsResponse {
+
+    /**
+     * The manage flag
+     *
+     * @param manage the manage flag
+     * @return the manage flag
+     */
+    private final Boolean manage;
+
+    @Builder
+    GetServiceInstancePermissionsResponse(@JsonProperty("manage") Boolean manage) {
+        this.manage = manage;
+    }
+    
+}

--- a/cloudfoundry-client/src/test/java/org/cloudfoundry/client/v2/serviceinstances/GetServiceInstancePermissionsRequestTest.java
+++ b/cloudfoundry-client/src/test/java/org/cloudfoundry/client/v2/serviceinstances/GetServiceInstancePermissionsRequestTest.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2013-2016 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.cloudfoundry.client.v2.serviceinstances;
+
+import org.cloudfoundry.client.ValidationResult;
+import org.junit.Test;
+
+import static org.cloudfoundry.client.ValidationResult.Status.INVALID;
+import static org.cloudfoundry.client.ValidationResult.Status.VALID;
+import static org.junit.Assert.assertEquals;
+
+
+public final class GetServiceInstancePermissionsRequestTest {
+
+    @Test
+    public void isValid() {
+        ValidationResult result = GetServiceInstancePermissionsRequest.builder()
+            .serviceInstanceId("test-service-instance-id")
+            .build()
+            .isValid();
+
+        assertEquals(VALID, result.getStatus());
+    }
+
+    @Test
+    public void isValidNoId() {
+        ValidationResult result = GetServiceInstancePermissionsRequest.builder()
+            .build()
+            .isValid();
+
+        assertEquals(INVALID, result.getStatus());
+        assertEquals("service instance id must be specified", result.getMessages().get(0));
+    }
+
+}


### PR DESCRIPTION
This change adds the api to get the permissions on a service instance (```GET /v2/service_instances/:guid/permissions```)
See [this story](https://www.pivotaltracker.com/projects/816799/stories/101451548)