### PR TITLE
List Service Plans

### DIFF
--- a/cloudfoundry-client-spring/src/main/lombok/org/cloudfoundry/client/spring/v2/services/SpringServices.java
+++ b/cloudfoundry-client-spring/src/main/lombok/org/cloudfoundry/client/spring/v2/services/SpringServices.java
@@ -24,6 +24,8 @@ import org.cloudfoundry.client.v2.services.DeleteServiceRequest;
 import org.cloudfoundry.client.v2.services.DeleteServiceResponse;
 import org.cloudfoundry.client.v2.services.GetServiceRequest;
 import org.cloudfoundry.client.v2.services.GetServiceResponse;
+import org.cloudfoundry.client.v2.services.ListServiceServicePlansRequest;
+import org.cloudfoundry.client.v2.services.ListServiceServicePlansResponse;
 import org.cloudfoundry.client.v2.services.ListServicesRequest;
 import org.cloudfoundry.client.v2.services.ListServicesResponse;
 import org.cloudfoundry.client.v2.services.Services;
@@ -92,4 +94,17 @@ public final class SpringServices extends AbstractSpringOperations implements Se
         });
     }
 
+    @Override
+    public Mono<ListServiceServicePlansResponse> listServicePlans(final ListServiceServicePlansRequest request) {
+        return get(request, ListServiceServicePlansResponse.class, new Consumer<UriComponentsBuilder>() {
+
+            @Override
+            public void accept(UriComponentsBuilder builder) {
+                builder.pathSegment("v2", "services", request.getServiceId(), "service_plans");
+                FilterBuilder.augment(builder, request);
+                QueryBuilder.augment(builder, request);
+            }
+
+        });
+    }
 }

--- a/cloudfoundry-client-spring/src/test/java/org/cloudfoundry/client/spring/v2/services/SpringServicesTest.java
+++ b/cloudfoundry-client-spring/src/test/java/org/cloudfoundry/client/spring/v2/services/SpringServicesTest.java
@@ -19,10 +19,14 @@ package org.cloudfoundry.client.spring.v2.services;
 import org.cloudfoundry.client.spring.AbstractApiTest;
 import org.cloudfoundry.client.v2.Resource;
 import org.cloudfoundry.client.v2.job.JobEntity;
+import org.cloudfoundry.client.v2.serviceplans.ServicePlanEntity;
+import org.cloudfoundry.client.v2.serviceplans.ServicePlanResource;
 import org.cloudfoundry.client.v2.services.DeleteServiceRequest;
 import org.cloudfoundry.client.v2.services.DeleteServiceResponse;
 import org.cloudfoundry.client.v2.services.GetServiceRequest;
 import org.cloudfoundry.client.v2.services.GetServiceResponse;
+import org.cloudfoundry.client.v2.services.ListServiceServicePlansRequest;
+import org.cloudfoundry.client.v2.services.ListServiceServicePlansResponse;
 import org.cloudfoundry.client.v2.services.ListServicesRequest;
 import org.cloudfoundry.client.v2.services.ListServicesResponse;
 import org.cloudfoundry.client.v2.services.ServiceEntity;
@@ -229,6 +233,63 @@ public final class SpringServicesTest {
             return this.services.list(request);
         }
 
+    }
+
+    public static final class ListServicePlans extends AbstractApiTest<ListServiceServicePlansRequest, ListServiceServicePlansResponse> {
+
+        private final SpringServices services = new SpringServices(this.restTemplate, this.root, PROCESSOR_GROUP);
+
+        @Override
+        protected ListServiceServicePlansRequest getInvalidRequest() {
+            return ListServiceServicePlansRequest.builder().build();
+        }
+
+        @Override
+        protected RequestContext getRequestContext() {
+            return new RequestContext()
+                .method(GET).path("/v2/services/f1b0edbe-fac4-4512-9071-8b26045413bb/service_plans?page=-1")
+                .status(OK)
+                .responsePayload("v2/services/GET_{id}_service_plans_response.json");
+        }
+
+        @Override
+        protected ListServiceServicePlansResponse getResponse() {
+            return ListServiceServicePlansResponse.builder()
+                .totalResults(1)
+                .totalPages(1)
+                .resource(ServicePlanResource.builder()
+                    .metadata(Resource.Metadata.builder()
+                        .createdAt("2015-07-27T22:43:35Z")
+                        .id("51067400-d79f-4ca5-9400-1f36f5dd09e7")
+                        .url("/v2/service_plans/51067400-d79f-4ca5-9400-1f36f5dd09e7")
+                        .build())
+                    .entity(ServicePlanEntity.builder()
+                        .name("name-2409")
+                        .free(false)
+                        .description("desc-218")
+                        .serviceId("f1b0edbe-fac4-4512-9071-8b26045413bb")
+                        .uniqueId("48fb5a34-1c14-4da5-944e-a14fa1ba5325")
+                        .visible(true)
+                        .active(true)
+                        .serviceUrl("/v2/services/f1b0edbe-fac4-4512-9071-8b26045413bb")
+                        .serviceInstancesUrl("/v2/service_plans/51067400-d79f-4ca5-9400-1f36f5dd09e7/service_instances")
+                        .build())
+                    .build())
+                .build();
+        }
+
+        @Override
+        protected ListServiceServicePlansRequest getValidRequest() throws Exception {
+            return ListServiceServicePlansRequest.builder()
+                .serviceId("f1b0edbe-fac4-4512-9071-8b26045413bb")
+                .page(-1)
+                .build();
+        }
+
+        @Override
+        protected Mono<ListServiceServicePlansResponse> invoke(ListServiceServicePlansRequest request) {
+            return this.services.listServicePlans(request);
+        }
     }
 
 }

--- a/cloudfoundry-client-spring/src/test/resources/v2/services/GET_{id}_service_plans_response.json
+++ b/cloudfoundry-client-spring/src/test/resources/v2/services/GET_{id}_service_plans_response.json
@@ -1,0 +1,28 @@
+{
+  "total_results": 1,
+  "total_pages": 1,
+  "prev_url": null,
+  "next_url": null,
+  "resources": [
+    {
+      "metadata": {
+        "guid": "51067400-d79f-4ca5-9400-1f36f5dd09e7",
+        "url": "/v2/service_plans/51067400-d79f-4ca5-9400-1f36f5dd09e7",
+        "created_at": "2015-07-27T22:43:35Z",
+        "updated_at": null
+      },
+      "entity": {
+        "name": "name-2409",
+        "free": false,
+        "description": "desc-218",
+        "service_guid": "f1b0edbe-fac4-4512-9071-8b26045413bb",
+        "extra": null,
+        "unique_id": "48fb5a34-1c14-4da5-944e-a14fa1ba5325",
+        "public": true,
+        "active": true,
+        "service_url": "/v2/services/f1b0edbe-fac4-4512-9071-8b26045413bb",
+        "service_instances_url": "/v2/service_plans/51067400-d79f-4ca5-9400-1f36f5dd09e7/service_instances"
+      }
+    }
+  ]
+}

--- a/cloudfoundry-client/src/main/java/org/cloudfoundry/client/v2/services/Services.java
+++ b/cloudfoundry-client/src/main/java/org/cloudfoundry/client/v2/services/Services.java
@@ -47,4 +47,12 @@ public interface Services {
      */
     Mono<ListServicesResponse> list(ListServicesRequest request);
 
+    /**
+     * Makes the <a href="http://apidocs.cloudfoundry.org/214/services/list_all_service_plans_for_the_service.html">List all Service Plans for the Service</a> request
+     *
+     * @param request the List Service Plans request
+     * @return the response from the List Service Plans request
+     */
+    Mono<ListServiceServicePlansResponse> listServicePlans(ListServiceServicePlansRequest request);
+
 }

--- a/cloudfoundry-client/src/main/lombok/org/cloudfoundry/client/v2/services/ListServiceServicePlansRequest.java
+++ b/cloudfoundry-client/src/main/lombok/org/cloudfoundry/client/v2/services/ListServiceServicePlansRequest.java
@@ -14,8 +14,9 @@
  * limitations under the License.
  */
 
-package org.cloudfoundry.client.v2.serviceplans;
+package org.cloudfoundry.client.v2.services;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import lombok.Builder;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
@@ -30,12 +31,12 @@ import org.cloudfoundry.client.v2.PaginatedRequest;
 import java.util.List;
 
 /**
- * The request payload for the List Service Plans operation
+ * The request payload for the List all Service Plans for the Service operation
  */
 @Data
 @EqualsAndHashCode(callSuper = true)
 @ToString(callSuper = true)
-public final class ListServicePlansRequest extends PaginatedRequest implements Validatable {
+public final class ListServiceServicePlansRequest extends PaginatedRequest implements Validatable {
 
     /**
      * The active flag
@@ -56,13 +57,13 @@ public final class ListServicePlansRequest extends PaginatedRequest implements V
     private final List<String> serviceBrokerIds;
 
     /**
-     * The service ids
+     * The service id
      *
-     * @param serviceIds the service ids
-     * @return the service ids
+     * @param serviceId the service id
+     * @return the service id
      */
-    @Getter(onMethod = @__(@InFilterParameter("service_guid")))
-    private final List<String> serviceIds;
+    @Getter(onMethod = @__(@JsonIgnore))
+    private final String serviceId;
 
     /**
      * The service instance ids
@@ -74,21 +75,27 @@ public final class ListServicePlansRequest extends PaginatedRequest implements V
     private final List<String> serviceInstanceIds;
 
     @Builder
-    ListServicePlansRequest(OrderDirection orderDirection, Integer page, Integer resultsPerPage,
-                            Boolean active,
-                            @Singular List<String> serviceBrokerIds,
-                            @Singular List<String> serviceIds,
-                            @Singular List<String> serviceInstanceIds) {
+    ListServiceServicePlansRequest(OrderDirection orderDirection, Integer page, Integer resultsPerPage,
+                                   Boolean active,
+                                   @Singular List<String> serviceBrokerIds,
+                                   String serviceId,
+                                   @Singular List<String> serviceInstanceIds) {
         super(orderDirection, page, resultsPerPage);
         this.active = active;
         this.serviceBrokerIds = serviceBrokerIds;
-        this.serviceIds = serviceIds;
+        this.serviceId = serviceId;
         this.serviceInstanceIds = serviceInstanceIds;
     }
 
     @Override
     public ValidationResult isValid() {
-        return ValidationResult.builder().build();
+        ValidationResult.ValidationResultBuilder builder = ValidationResult.builder();
+
+        if (this.serviceId == null) {
+            builder.message("service id must be specified");
+        }
+
+        return builder.build();
     }
 
 }

--- a/cloudfoundry-client/src/main/lombok/org/cloudfoundry/client/v2/services/ListServiceServicePlansResponse.java
+++ b/cloudfoundry-client/src/main/lombok/org/cloudfoundry/client/v2/services/ListServiceServicePlansResponse.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2013-2016 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.cloudfoundry.client.v2.services;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.Builder;
+import lombok.Data;
+import lombok.EqualsAndHashCode;
+import lombok.Singular;
+import lombok.ToString;
+import org.cloudfoundry.client.v2.PaginatedResponse;
+import org.cloudfoundry.client.v2.serviceplans.ServicePlanResource;
+
+import java.util.List;
+
+/**
+ * The response payload for the List all Service Plans for the Service operation
+ */
+@Data
+@EqualsAndHashCode(callSuper = true)
+@ToString(callSuper = true)
+public final class ListServiceServicePlansResponse extends PaginatedResponse<ServicePlanResource> {
+
+    @Builder
+    ListServiceServicePlansResponse(@JsonProperty("next_url") String nextUrl,
+                                    @JsonProperty("prev_url") String previousUrl,
+                                    @JsonProperty("resources") @Singular List<ServicePlanResource> resources,
+                                    @JsonProperty("total_pages") Integer totalPages,
+                                    @JsonProperty("total_results") Integer totalResults) {
+        super(nextUrl, previousUrl, resources, totalPages, totalResults);
+    }
+
+}

--- a/cloudfoundry-client/src/test/java/org/cloudfoundry/client/v2/services/ListServiceServicePlansRequestTest.java
+++ b/cloudfoundry-client/src/test/java/org/cloudfoundry/client/v2/services/ListServiceServicePlansRequestTest.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2013-2016 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.cloudfoundry.client.v2.services;
+
+import org.cloudfoundry.client.ValidationResult;
+import org.junit.Test;
+
+import static org.cloudfoundry.client.ValidationResult.Status.INVALID;
+import static org.cloudfoundry.client.ValidationResult.Status.VALID;
+import static org.junit.Assert.assertEquals;
+
+public final class ListServiceServicePlansRequestTest {
+
+    @Test
+    public void isValid() {
+        ValidationResult result = ListServiceServicePlansRequest.builder()
+            .serviceId("test-service-id")
+            .build()
+            .isValid();
+
+        assertEquals(VALID, result.getStatus());
+    }
+
+    @Test
+    public void isValidNoId() {
+        ValidationResult result = ListServiceServicePlansRequest.builder()
+            .build()
+            .isValid();
+
+        assertEquals(INVALID, result.getStatus());
+        assertEquals("service id must be specified", result.getMessages().get(0));
+    }
+
+}


### PR DESCRIPTION
This change adds the api to list service plans for a service (```GET /v2/services/:guid/service_plans```)
See [this story](https://www.pivotaltracker.com/projects/816799/stories/101452052)
@nebhale : I assumed [the documentation](http://apidocs.cloudfoundry.org/214/services/list_all_service_plans_for_the_service.html) was wrong about the ```service_guid``` filter parameter. Since the aim of the service is getting service plan for a given service, filtering by service seems to be incorrect...And it helped me because having a ```@Singular``` ```serviceIds``` would have be a mess with the ```serviceId``` attribute :smiley: 