### PR TITLE
Get Service Usage Events

### DIFF
--- a/cloudfoundry-client-spring/src/main/lombok/org/cloudfoundry/client/spring/SpringCloudFoundryClient.java
+++ b/cloudfoundry-client-spring/src/main/lombok/org/cloudfoundry/client/spring/SpringCloudFoundryClient.java
@@ -46,6 +46,7 @@ import org.cloudfoundry.client.spring.v2.servicekeys.SpringServiceKeys;
 import org.cloudfoundry.client.spring.v2.serviceplans.SpringServicePlans;
 import org.cloudfoundry.client.spring.v2.serviceplanvisibilities.SpringServicePlanVisibilities;
 import org.cloudfoundry.client.spring.v2.services.SpringServices;
+import org.cloudfoundry.client.spring.v2.serviceusageevents.SpringServiceUsageEvents;
 import org.cloudfoundry.client.spring.v2.shareddomains.SpringSharedDomains;
 import org.cloudfoundry.client.spring.v2.spacequotadefinitions.SpringSpaceQuotaDefinitions;
 import org.cloudfoundry.client.spring.v2.spaces.SpringSpaces;
@@ -73,6 +74,7 @@ import org.cloudfoundry.client.v2.servicekeys.ServiceKeys;
 import org.cloudfoundry.client.v2.serviceplans.ServicePlans;
 import org.cloudfoundry.client.v2.serviceplanvisibilities.ServicePlanVisibilities;
 import org.cloudfoundry.client.v2.services.Services;
+import org.cloudfoundry.client.v2.serviceusageevents.ServiceUsageEvents;
 import org.cloudfoundry.client.v2.shareddomains.SharedDomains;
 import org.cloudfoundry.client.v2.spacequotadefinitions.SpaceQuotaDefinitions;
 import org.cloudfoundry.client.v2.spaces.Spaces;
@@ -141,6 +143,8 @@ public final class SpringCloudFoundryClient implements CloudFoundryClient {
 
     private final ServicePlans servicePlans;
 
+    private final ServiceUsageEvents serviceUsageEvents;
+
     private final Services services;
 
     private final SharedDomains sharedDomains;
@@ -193,6 +197,7 @@ public final class SpringCloudFoundryClient implements CloudFoundryClient {
         this.serviceKeys = new SpringServiceKeys(restOperations, root, schedulerGroup);
         this.servicePlanVisibilities = new SpringServicePlanVisibilities(restOperations, root, schedulerGroup);
         this.servicePlans = new SpringServicePlans(restOperations, root, schedulerGroup);
+        this.serviceUsageEvents = new SpringServiceUsageEvents(restOperations, root, schedulerGroup);
         this.services = new SpringServices(restOperations, root, schedulerGroup);
         this.spaceQuotaDefinitions = new SpringSpaceQuotaDefinitions(restOperations, root, schedulerGroup);
         this.spaces = new SpringSpaces(restOperations, root, schedulerGroup);
@@ -316,6 +321,11 @@ public final class SpringCloudFoundryClient implements CloudFoundryClient {
     @Override
     public ServicePlans servicePlans() {
         return this.servicePlans;
+    }
+
+    @Override
+    public ServiceUsageEvents serviceUsageEvents() {
+        return this.serviceUsageEvents;
     }
 
     @Override

--- a/cloudfoundry-client-spring/src/main/lombok/org/cloudfoundry/client/spring/v2/serviceusageevents/SpringServiceUsageEvents.java
+++ b/cloudfoundry-client-spring/src/main/lombok/org/cloudfoundry/client/spring/v2/serviceusageevents/SpringServiceUsageEvents.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright 2013-2016 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.cloudfoundry.client.spring.v2.serviceusageevents;
+
+import org.cloudfoundry.client.spring.util.AbstractSpringOperations;
+import org.cloudfoundry.client.v2.serviceusageevents.GetServiceUsageEventsRequest;
+import org.cloudfoundry.client.v2.serviceusageevents.GetServiceUsageEventsResponse;
+import org.cloudfoundry.client.v2.serviceusageevents.ServiceUsageEvents;
+import org.springframework.web.client.RestOperations;
+import org.springframework.web.util.UriComponentsBuilder;
+import reactor.core.publisher.Mono;
+import reactor.core.publisher.SchedulerGroup;
+import reactor.fn.Consumer;
+
+import java.net.URI;
+
+/**
+ * Created by buce8373 on 15/02/2016.
+ */
+public final class SpringServiceUsageEvents extends AbstractSpringOperations implements ServiceUsageEvents {
+
+
+    /**
+     * Creates an instance
+     *
+     * @param restOperations the {@link RestOperations} to use to communicate with the server
+     * @param root           the root URI of the server.  Typically something like {@code https://api.run.pivotal.io}.
+     * @param schedulerGroup The group to use when making requests
+     */
+    public SpringServiceUsageEvents(RestOperations restOperations, URI root, SchedulerGroup schedulerGroup) {
+        super(restOperations, root, schedulerGroup);
+    }
+
+    @Override
+    public Mono<GetServiceUsageEventsResponse> get(final GetServiceUsageEventsRequest request) {
+        return get(request, GetServiceUsageEventsResponse.class, new Consumer<UriComponentsBuilder>() {
+
+            @Override
+            public void accept(UriComponentsBuilder builder) {
+                builder.pathSegment("v2", "service_usage_events", request.getServiceUsageEventsId());
+            }
+
+        });
+    }
+
+}

--- a/cloudfoundry-client-spring/src/test/java/org/cloudfoundry/client/spring/SpringCloudFoundryClientTest.java
+++ b/cloudfoundry-client-spring/src/test/java/org/cloudfoundry/client/spring/SpringCloudFoundryClientTest.java
@@ -138,6 +138,11 @@ public final class SpringCloudFoundryClientTest extends AbstractRestTest {
     }
 
     @Test
+    public void serviceUsageEvents() {
+        assertNotNull(this.client.serviceUsageEvents());
+    }
+
+    @Test
     public void services() {
         assertNotNull(this.client.services());
     }

--- a/cloudfoundry-client-spring/src/test/java/org/cloudfoundry/client/spring/v2/serviceusageevents/SpringServiceUsageEventsTest.java
+++ b/cloudfoundry-client-spring/src/test/java/org/cloudfoundry/client/spring/v2/serviceusageevents/SpringServiceUsageEventsTest.java
@@ -1,0 +1,85 @@
+/*
+ * Copyright 2013-2016 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.cloudfoundry.client.spring.v2.serviceusageevents;
+
+import org.cloudfoundry.client.spring.AbstractApiTest;
+import org.cloudfoundry.client.v2.Resource;
+import org.cloudfoundry.client.v2.serviceusageevents.GetServiceUsageEventsRequest;
+import org.cloudfoundry.client.v2.serviceusageevents.GetServiceUsageEventsResponse;
+import org.cloudfoundry.client.v2.serviceusageevents.ServiceUsageEventsEntity;
+import reactor.core.publisher.Mono;
+
+import static org.springframework.http.HttpMethod.GET;
+import static org.springframework.http.HttpStatus.OK;
+
+public final class SpringServiceUsageEventsTest {
+
+    public static final class Get extends AbstractApiTest<GetServiceUsageEventsRequest, GetServiceUsageEventsResponse> {
+
+        private final SpringServiceUsageEvents serviceUsageEvents = new SpringServiceUsageEvents(this.restTemplate, this.root, PROCESSOR_GROUP);
+
+        @Override
+        protected GetServiceUsageEventsRequest getInvalidRequest() {
+            return GetServiceUsageEventsRequest.builder().build();
+        }
+
+        @Override
+        protected RequestContext getRequestContext() {
+            return new RequestContext()
+                .method(GET).path("/v2/service_usage_events/9470627d-0488-4d9a-8564-f97571487893")
+                .status(OK)
+                .responsePayload("v2/service_usage_events/GET_{id}_response.json");
+        }
+
+        @Override
+        protected GetServiceUsageEventsResponse getResponse() {
+            return GetServiceUsageEventsResponse.builder()
+                .metadata(Resource.Metadata.builder()
+                    .createdAt("2015-07-27T22:43:30Z")
+                    .id("9470627d-0488-4d9a-8564-f97571487893")
+                    .url("/v2/service_usage_events/9470627d-0488-4d9a-8564-f97571487893")
+                    .build())
+                .entity(ServiceUsageEventsEntity.builder()
+                    .state("CREATED")
+                    .organizationId("guid-3f19bc03-d183-4189-bdeb-9f33468181da")
+                    .spaceId("guid-d565b0c4-3c38-41dd-a102-1c113c759fbf")
+                    .spaceName("name-2160")
+                    .serviceInstanceId("guid-4cef8892-46fc-4d70-a5d5-36385989f5df")
+                    .serviceInstanceName("name-2161")
+                    .serviceInstanceType("type-4")
+                    .servicePlanId("guid-f2a17886-488c-4066-9155-a1dbb64adadd")
+                    .servicePlanName("name-2162")
+                    .serviceId("guid-fdff7ee0-cc1b-4bdb-87d6-b0c3b47cb2b2")
+                    .serviceLabel("label-79")
+                    .build())
+                .build();
+        }
+
+        @Override
+        protected GetServiceUsageEventsRequest getValidRequest() throws Exception {
+            return GetServiceUsageEventsRequest.builder()
+                .serviceUsageEventsId("9470627d-0488-4d9a-8564-f97571487893")
+                .build();
+        }
+
+        @Override
+        protected Mono<GetServiceUsageEventsResponse> invoke(GetServiceUsageEventsRequest request) {
+            return this.serviceUsageEvents.get(request);
+        }
+    }
+
+}

--- a/cloudfoundry-client-spring/src/test/resources/v2/service_usage_events/GET_{id}_response.json
+++ b/cloudfoundry-client-spring/src/test/resources/v2/service_usage_events/GET_{id}_response.json
@@ -1,0 +1,20 @@
+{
+  "metadata": {
+    "guid": "9470627d-0488-4d9a-8564-f97571487893",
+    "url": "/v2/service_usage_events/9470627d-0488-4d9a-8564-f97571487893",
+    "created_at": "2015-07-27T22:43:30Z"
+  },
+  "entity": {
+    "state": "CREATED",
+    "org_guid": "guid-3f19bc03-d183-4189-bdeb-9f33468181da",
+    "space_guid": "guid-d565b0c4-3c38-41dd-a102-1c113c759fbf",
+    "space_name": "name-2160",
+    "service_instance_guid": "guid-4cef8892-46fc-4d70-a5d5-36385989f5df",
+    "service_instance_name": "name-2161",
+    "service_instance_type": "type-4",
+    "service_plan_guid": "guid-f2a17886-488c-4066-9155-a1dbb64adadd",
+    "service_plan_name": "name-2162",
+    "service_guid": "guid-fdff7ee0-cc1b-4bdb-87d6-b0c3b47cb2b2",
+    "service_label": "label-79"
+  }
+}

--- a/cloudfoundry-client/src/main/java/org/cloudfoundry/client/CloudFoundryClient.java
+++ b/cloudfoundry-client/src/main/java/org/cloudfoundry/client/CloudFoundryClient.java
@@ -33,6 +33,7 @@ import org.cloudfoundry.client.v2.servicekeys.ServiceKeys;
 import org.cloudfoundry.client.v2.serviceplans.ServicePlans;
 import org.cloudfoundry.client.v2.serviceplanvisibilities.ServicePlanVisibilities;
 import org.cloudfoundry.client.v2.services.Services;
+import org.cloudfoundry.client.v2.serviceusageevents.ServiceUsageEvents;
 import org.cloudfoundry.client.v2.shareddomains.SharedDomains;
 import org.cloudfoundry.client.v2.spacequotadefinitions.SpaceQuotaDefinitions;
 import org.cloudfoundry.client.v2.spaces.Spaces;
@@ -200,6 +201,13 @@ public interface CloudFoundryClient {
      * @return the Cloud Foundry Service Plans Client API
      */
     ServicePlans servicePlans();
+
+    /**
+     * Main entry point to the Cloud Foundry Service Usage Events Client API
+     *
+     * @return the Cloud Foundry Service Usage Events Client API
+     */
+    ServiceUsageEvents serviceUsageEvents();
 
     /**
      * Main entry point to the Cloud Foundry Services Client API

--- a/cloudfoundry-client/src/main/java/org/cloudfoundry/client/v2/serviceusageevents/ServiceUsageEvents.java
+++ b/cloudfoundry-client/src/main/java/org/cloudfoundry/client/v2/serviceusageevents/ServiceUsageEvents.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2013-2016 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.cloudfoundry.client.v2.serviceusageevents;
+
+
+import reactor.core.publisher.Mono;
+
+public interface ServiceUsageEvents {
+
+    /**
+     * Makes the <a href="http://apidocs.cloudfoundry.org/214/service_usage_events/retrieve_a_particular_service_usage_event.html">Retrieve a Particular Service Usage Events</a> request
+     *
+     * @param request the Get Service Usage Events
+     * @return the response from the Get Service Usage Events request
+     */
+    Mono<GetServiceUsageEventsResponse> get(GetServiceUsageEventsRequest request);
+
+}

--- a/cloudfoundry-client/src/main/lombok/org/cloudfoundry/client/v2/serviceusageevents/GetServiceUsageEventsRequest.java
+++ b/cloudfoundry-client/src/main/lombok/org/cloudfoundry/client/v2/serviceusageevents/GetServiceUsageEventsRequest.java
@@ -14,8 +14,7 @@
  * limitations under the License.
  */
 
-package org.cloudfoundry.client.v2.services;
-
+package org.cloudfoundry.client.v2.serviceusageevents;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import lombok.Builder;
@@ -25,34 +24,34 @@ import org.cloudfoundry.client.Validatable;
 import org.cloudfoundry.client.ValidationResult;
 
 /**
- * The request payload for the Get Service operation
+ * The request payload for the Get Service Usage Events operation
  */
 @Data
-public final class GetServiceRequest implements Validatable {
+public class GetServiceUsageEventsRequest implements Validatable {
 
     /**
-     * The service id
+     * The service usage events id
      *
-     * @param serviceId the service id
-     * @return the service id
+     * @param serviceUsageEventsId the service instance id
+     * @return the service usage events id
      */
     @Getter(onMethod = @__(@JsonIgnore))
-    private final String serviceId;
+    private final String serviceUsageEventsId;
 
     @Builder
-    GetServiceRequest(String serviceId) {
-        this.serviceId = serviceId;
+    GetServiceUsageEventsRequest(String serviceUsageEventsId) {
+        this.serviceUsageEventsId = serviceUsageEventsId;
     }
 
     @Override
     public ValidationResult isValid() {
         ValidationResult.ValidationResultBuilder builder = ValidationResult.builder();
 
-        if (this.serviceId == null) {
-            builder.message("service id must be specified");
+        if (this.serviceUsageEventsId == null) {
+            builder.message("service usage events id must be specified");
         }
 
         return builder.build();
     }
-
+    
 }

--- a/cloudfoundry-client/src/main/lombok/org/cloudfoundry/client/v2/serviceusageevents/GetServiceUsageEventsResponse.java
+++ b/cloudfoundry-client/src/main/lombok/org/cloudfoundry/client/v2/serviceusageevents/GetServiceUsageEventsResponse.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2013-2016 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.cloudfoundry.client.v2.serviceusageevents;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.Builder;
+import lombok.Data;
+import lombok.EqualsAndHashCode;
+import lombok.ToString;
+import org.cloudfoundry.client.v2.Resource;
+
+/**
+ * The resource response payload for the Get Service Usage Events Response
+ */
+@Data
+@EqualsAndHashCode(callSuper = true)
+@ToString(callSuper = true)
+public class GetServiceUsageEventsResponse extends Resource<ServiceUsageEventsEntity> {
+
+    @Builder
+    public GetServiceUsageEventsResponse(@JsonProperty("entity") ServiceUsageEventsEntity entity,
+                              @JsonProperty("metadata") Metadata metadata) {
+        super(entity, metadata);
+    }
+
+}

--- a/cloudfoundry-client/src/main/lombok/org/cloudfoundry/client/v2/serviceusageevents/ServiceUsageEventsEntity.java
+++ b/cloudfoundry-client/src/main/lombok/org/cloudfoundry/client/v2/serviceusageevents/ServiceUsageEventsEntity.java
@@ -1,0 +1,142 @@
+/*
+ * Copyright 2013-2016 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.cloudfoundry.client.v2.serviceusageevents;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.Builder;
+import lombok.Data;
+
+/**
+ * The entity response payload for Service Usage Events
+ */
+@Data
+public class ServiceUsageEventsEntity {
+
+    /**
+     * The organization id
+     *
+     * @param organizationId the organization id
+     * @return the organization id
+     */
+    private final String organizationId;
+
+    /**
+     * The service id
+     *
+     * @param serviceId the service id
+     * @return the service id
+     */
+    private final String serviceId;
+
+    /**
+     * The service instance id
+     *
+     * @param serviceInstanceId the service instance id
+     * @return the service instance id
+     */
+    private final String serviceInstanceId;
+
+    /**
+     * The service instance name
+     *
+     * @param serviceInstanceName the service instance name
+     * @return the service instance name
+     */
+    private final String serviceInstanceName;
+
+    /**
+     * The service instance type
+     *
+     * @param serviceInstanceType the service instance type
+     * @return the service instance type
+     */
+    private final String serviceInstanceType;
+
+    /**
+     * The service label
+     *
+     * @param serviceLabel the service label
+     * @return the service label
+     */
+    private final String serviceLabel;
+
+    /**
+     * The service plan id
+     *
+     * @param servicePlanId the service plan id
+     * @return the service plan id
+     */
+    private final String servicePlanId;
+
+    /**
+     * The service plan name
+     *
+     * @param servicePlanName the service plan name
+     * @return the service plan name
+     */
+    private final String servicePlanName;
+
+    /**
+     * The space id
+     *
+     * @param spaceId the space id
+     * @return the space id
+     */
+    private final String spaceId;
+
+    /**
+     * The space name
+     *
+     * @param spaceName the space name
+     * @return the space name
+     */
+    private final String spaceName;
+
+    /**
+     * The state
+     *
+     * @param state the state
+     * @return the state
+     */
+    private final String state;
+
+    @Builder
+    ServiceUsageEventsEntity(@JsonProperty("org_guid") String organizationId,
+                             @JsonProperty("service_guid") String serviceId,
+                             @JsonProperty("service_instance_guid") String serviceInstanceId,
+                             @JsonProperty("service_instance_name") String serviceInstanceName,
+                             @JsonProperty("service_instance_type") String serviceInstanceType,
+                             @JsonProperty("service_label") String serviceLabel,
+                             @JsonProperty("service_plan_guid") String servicePlanId,
+                             @JsonProperty("service_plan_name") String servicePlanName,
+                             @JsonProperty("space_guid") String spaceId,
+                             @JsonProperty("space_name") String spaceName,
+                             @JsonProperty("state") String state) {
+        this.organizationId = organizationId;
+        this.serviceId = serviceId;
+        this.serviceInstanceId = serviceInstanceId;
+        this.serviceInstanceName = serviceInstanceName;
+        this.serviceInstanceType = serviceInstanceType;
+        this.serviceLabel = serviceLabel;
+        this.servicePlanId = servicePlanId;
+        this.servicePlanName = servicePlanName;
+        this.spaceId = spaceId;
+        this.spaceName = spaceName;
+        this.state = state;
+    }
+
+}

--- a/cloudfoundry-client/src/test/java/org/cloudfoundry/client/v2/serviceusageevents/GetServiceUsageEventsRequestTest.java
+++ b/cloudfoundry-client/src/test/java/org/cloudfoundry/client/v2/serviceusageevents/GetServiceUsageEventsRequestTest.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2013-2016 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.cloudfoundry.client.v2.serviceusageevents;
+
+import org.cloudfoundry.client.ValidationResult;
+import org.junit.Test;
+
+import static org.cloudfoundry.client.ValidationResult.Status.INVALID;
+import static org.cloudfoundry.client.ValidationResult.Status.VALID;
+import static org.junit.Assert.assertEquals;
+
+public final class GetServiceUsageEventsRequestTest {
+
+    @Test
+    public void isValid() {
+        ValidationResult result = GetServiceUsageEventsRequest.builder()
+            .serviceUsageEventsId("test-service-usage-events-id")
+            .build()
+            .isValid();
+
+        assertEquals(VALID, result.getStatus());
+    }
+
+    @Test
+    public void isValidNoId() {
+        ValidationResult result = GetServiceUsageEventsRequest.builder()
+            .build()
+            .isValid();
+
+        assertEquals(INVALID, result.getStatus());
+        assertEquals("service usage events id must be specified", result.getMessages().get(0));
+    }
+    
+}


### PR DESCRIPTION
This change adds the API to get a Service Usage Events (```GET /v2/service_usage_events/:guid```)
See [this story](https://www.pivotaltracker.com/projects/816799/stories/101451584)