### PR TITLE
Binding a Service Instance to a Route - Add parameters

### DIFF
--- a/cloudfoundry-client-spring/src/test/java/org/cloudfoundry/client/spring/v2/serviceinstances/SpringServiceInstancesTest.java
+++ b/cloudfoundry-client-spring/src/test/java/org/cloudfoundry/client/spring/v2/serviceinstances/SpringServiceInstancesTest.java
@@ -65,6 +65,7 @@ public final class SpringServiceInstancesTest {
         protected RequestContext getRequestContext() {
             return new RequestContext()
                 .method(PUT).path("v2/service_instances/test-service-instance-id/routes/route-id")
+                .requestPayload("v2/service_instances/PUT_{id}_routes_request.json")
                 .status(CREATED)
                 .responsePayload("v2/service_instances/PUT_{id}_routes_response.json");
         }
@@ -97,6 +98,7 @@ public final class SpringServiceInstancesTest {
             return BindServiceInstanceToRouteRequest.builder()
                 .serviceInstanceId("test-service-instance-id")
                 .routeId("route-id")
+                .parameter("the_service_broker", "wants this object")
                 .build();
         }
 

--- a/cloudfoundry-client-spring/src/test/resources/v2/service_instances/PUT_{id}_routes_request.json
+++ b/cloudfoundry-client-spring/src/test/resources/v2/service_instances/PUT_{id}_routes_request.json
@@ -1,0 +1,5 @@
+{
+  "parameters": {
+    "the_service_broker": "wants this object"
+  }
+}

--- a/cloudfoundry-client/src/main/java/org/cloudfoundry/client/v2/serviceinstances/ServiceInstances.java
+++ b/cloudfoundry-client/src/main/java/org/cloudfoundry/client/v2/serviceinstances/ServiceInstances.java
@@ -24,7 +24,7 @@ import reactor.core.publisher.Mono;
 public interface ServiceInstances {
 
     /**
-     * Makes the <a href="http://apidocs.cloudfoundry.org/227/service_instances/binding_a_service_instance_to_a_route_%28experimental%29.html">Bind Service Instance To a Route (experimental)</a>
+     * Makes the <a href="http://apidocs.cloudfoundry.org/230/service_instances/binding_a_service_instance_to_a_route_%28experimental%29.html">Bind Service Instance To a Route (experimental)</a>
      * request
      *
      * @param request the Bind Service Instance To Route request

--- a/cloudfoundry-client/src/main/lombok/org/cloudfoundry/client/v2/serviceinstances/BindServiceInstanceToRouteRequest.java
+++ b/cloudfoundry-client/src/main/lombok/org/cloudfoundry/client/v2/serviceinstances/BindServiceInstanceToRouteRequest.java
@@ -18,15 +18,30 @@ package org.cloudfoundry.client.v2.serviceinstances;
 
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.Builder;
 import lombok.Getter;
+import lombok.Singular;
 import org.cloudfoundry.client.Validatable;
 import org.cloudfoundry.client.ValidationResult;
+
+import java.util.Map;
+
+import static com.fasterxml.jackson.annotation.JsonInclude.Include.NON_EMPTY;
 
 /**
  * The request payload to Bind Service Instance To a Route
  */
 public final class BindServiceInstanceToRouteRequest implements Validatable {
+
+    /**
+     * Key/value pairs of all arbitrary parameters to pass along to the service broker
+     *
+     * @return the arbitrary parameters to pass along to the service broker
+     */
+    @Getter(onMethod = @__({@JsonProperty("parameters"), @JsonInclude(NON_EMPTY)}))
+    private final Map<String, Object> parameters;
 
     /**
      * The route id
@@ -47,7 +62,10 @@ public final class BindServiceInstanceToRouteRequest implements Validatable {
     private final String serviceInstanceId;
 
     @Builder
-    BindServiceInstanceToRouteRequest(String routeId, String serviceInstanceId) {
+    BindServiceInstanceToRouteRequest(@Singular Map<String, Object> parameters,
+                                      String routeId,
+                                      String serviceInstanceId) {
+        this.parameters = parameters;
         this.routeId = routeId;
         this.serviceInstanceId = serviceInstanceId;
     }


### PR DESCRIPTION
This change takes into account that Binding a Service Instance to a Route can  take arbitrary parameters See #393 