### PR TITLE
Purge And Reseed Service Usage Events

### DIFF
--- a/cloudfoundry-client-spring/src/main/lombok/org/cloudfoundry/client/spring/v2/serviceusageevents/SpringServiceUsageEvents.java
+++ b/cloudfoundry-client-spring/src/main/lombok/org/cloudfoundry/client/spring/v2/serviceusageevents/SpringServiceUsageEvents.java
@@ -24,6 +24,7 @@ import org.cloudfoundry.client.v2.serviceusageevents.GetServiceUsageEventsReques
 import org.cloudfoundry.client.v2.serviceusageevents.GetServiceUsageEventsResponse;
 import org.cloudfoundry.client.v2.serviceusageevents.ListServiceUsageEventsRequest;
 import org.cloudfoundry.client.v2.serviceusageevents.ListServiceUsageEventsResponse;
+import org.cloudfoundry.client.v2.serviceusageevents.PurgeAndReseedServiceUsageEventsRequest;
 import org.cloudfoundry.client.v2.serviceusageevents.ServiceUsageEvents;
 import org.springframework.web.client.RestOperations;
 import org.springframework.web.util.UriComponentsBuilder;
@@ -71,6 +72,18 @@ public final class SpringServiceUsageEvents extends AbstractSpringOperations imp
                 builder.pathSegment("v2", "service_usage_events");
                 FilterBuilder.augment(builder, request);
                 QueryBuilder.augment(builder, request);
+            }
+
+        });
+    }
+
+    @Override
+    public Mono<Void> purgeAndReseed(final PurgeAndReseedServiceUsageEventsRequest request) {
+        return post(request, Void.class, new Consumer<UriComponentsBuilder>() {
+
+            @Override
+            public void accept(UriComponentsBuilder builder) {
+                builder.pathSegment("v2", "service_usage_events", "destructively_purge_all_and_reseed_existing_instances");
             }
 
         });

--- a/cloudfoundry-client-spring/src/test/java/org/cloudfoundry/client/spring/v2/serviceusageevents/SpringServiceUsageEventsTest.java
+++ b/cloudfoundry-client-spring/src/test/java/org/cloudfoundry/client/spring/v2/serviceusageevents/SpringServiceUsageEventsTest.java
@@ -22,11 +22,14 @@ import org.cloudfoundry.client.v2.serviceusageevents.GetServiceUsageEventsReques
 import org.cloudfoundry.client.v2.serviceusageevents.GetServiceUsageEventsResponse;
 import org.cloudfoundry.client.v2.serviceusageevents.ListServiceUsageEventsRequest;
 import org.cloudfoundry.client.v2.serviceusageevents.ListServiceUsageEventsResponse;
+import org.cloudfoundry.client.v2.serviceusageevents.PurgeAndReseedServiceUsageEventsRequest;
 import org.cloudfoundry.client.v2.serviceusageevents.ServiceUsageEventResource;
 import org.cloudfoundry.client.v2.serviceusageevents.ServiceUsageEventsEntity;
 import reactor.core.publisher.Mono;
 
 import static org.springframework.http.HttpMethod.GET;
+import static org.springframework.http.HttpMethod.POST;
+import static org.springframework.http.HttpStatus.NO_CONTENT;
 import static org.springframework.http.HttpStatus.OK;
 
 public final class SpringServiceUsageEventsTest {
@@ -108,25 +111,25 @@ public final class SpringServiceUsageEventsTest {
                 .totalPages(1)
                 .totalResults(1)
                 .resource(ServiceUsageEventResource.builder()
-                    .metadata(Resource.Metadata.builder()
-                        .createdAt("2015-07-27T22:43:30Z")
-                        .id("0c9c59b8-3462-4acf-be39-aa987f087146")
-                        .url("/v2/service_usage_events/0c9c59b8-3462-4acf-be39-aa987f087146")
-                        .build())
-                    .entity(ServiceUsageEventsEntity.builder()
-                        .state("CREATED")
-                        .organizationId("guid-4dd5a051-3460-4246-a842-1dc2d5983c51")
-                        .spaceId("guid-76bd662b-fd5b-4b5c-a393-d65e67f99d53")
-                        .spaceName("name-2154")
-                        .serviceInstanceId("guid-15a7c119-838d-4516-acd9-062dec25d934")
-                        .serviceInstanceName("name-2155")
-                        .serviceInstanceType("type-2")
-                        .servicePlanId("guid-eddab64c-7be0-407e-91b0-82a8093cdfc5")
-                        .servicePlanName("name-2156")
-                        .serviceId("guid-d471c693-824c-44a6-b069-a679e323326d")
-                        .serviceLabel("label-77")
-                        .build())
-                    .build()
+                        .metadata(Resource.Metadata.builder()
+                            .createdAt("2015-07-27T22:43:30Z")
+                            .id("0c9c59b8-3462-4acf-be39-aa987f087146")
+                            .url("/v2/service_usage_events/0c9c59b8-3462-4acf-be39-aa987f087146")
+                            .build())
+                        .entity(ServiceUsageEventsEntity.builder()
+                            .state("CREATED")
+                            .organizationId("guid-4dd5a051-3460-4246-a842-1dc2d5983c51")
+                            .spaceId("guid-76bd662b-fd5b-4b5c-a393-d65e67f99d53")
+                            .spaceName("name-2154")
+                            .serviceInstanceId("guid-15a7c119-838d-4516-acd9-062dec25d934")
+                            .serviceInstanceName("name-2155")
+                            .serviceInstanceType("type-2")
+                            .servicePlanId("guid-eddab64c-7be0-407e-91b0-82a8093cdfc5")
+                            .servicePlanName("name-2156")
+                            .serviceId("guid-d471c693-824c-44a6-b069-a679e323326d")
+                            .serviceLabel("label-77")
+                            .build())
+                        .build()
                 )
                 .build();
         }
@@ -142,6 +145,38 @@ public final class SpringServiceUsageEventsTest {
         @Override
         protected Mono<ListServiceUsageEventsResponse> invoke(ListServiceUsageEventsRequest request) {
             return this.serviceUsageEvents.list(request);
+        }
+    }
+
+    public static final class PurgeAndReseed extends AbstractApiTest<PurgeAndReseedServiceUsageEventsRequest, Void> {
+
+        private final SpringServiceUsageEvents serviceUsageEvents = new SpringServiceUsageEvents(this.restTemplate, this.root, PROCESSOR_GROUP);
+
+        @Override
+        protected PurgeAndReseedServiceUsageEventsRequest getInvalidRequest() {
+            return null;
+        }
+
+        @Override
+        protected RequestContext getRequestContext() {
+            return new RequestContext()
+                .method(POST).path("/v2/service_usage_events/destructively_purge_all_and_reseed_existing_instances")
+                .status(NO_CONTENT);
+        }
+
+        @Override
+        protected Void getResponse() {
+            return null;
+        }
+
+        @Override
+        protected PurgeAndReseedServiceUsageEventsRequest getValidRequest() throws Exception {
+            return PurgeAndReseedServiceUsageEventsRequest.builder().build();
+        }
+
+        @Override
+        protected Mono<Void> invoke(PurgeAndReseedServiceUsageEventsRequest request) {
+            return this.serviceUsageEvents.purgeAndReseed(request);
         }
     }
 

--- a/cloudfoundry-client/src/main/java/org/cloudfoundry/client/v2/serviceusageevents/ServiceUsageEvents.java
+++ b/cloudfoundry-client/src/main/java/org/cloudfoundry/client/v2/serviceusageevents/ServiceUsageEvents.java
@@ -40,4 +40,12 @@ public interface ServiceUsageEvents {
      */
     Mono<ListServiceUsageEventsResponse> list(ListServiceUsageEventsRequest request);
 
+    /**
+     * Makes the <a href="http://apidocs.cloudfoundry.org/214/service_usage_events/purge_and_reseed_service_usage_events.html">Purge and Reseed Service Usage Events</a> request
+     *
+     * @param request the Purge and Reseed Service Usage Events
+     * @return the response from the Purge and Reseed Service Usage Events request
+     */
+    Mono<Void> purgeAndReseed(PurgeAndReseedServiceUsageEventsRequest request);
+
 }

--- a/cloudfoundry-client/src/main/lombok/org/cloudfoundry/client/v2/serviceusageevents/PurgeAndReseedServiceUsageEventsRequest.java
+++ b/cloudfoundry-client/src/main/lombok/org/cloudfoundry/client/v2/serviceusageevents/PurgeAndReseedServiceUsageEventsRequest.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2013-2016 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.cloudfoundry.client.v2.serviceusageevents;
+
+import lombok.Builder;
+import lombok.Data;
+import org.cloudfoundry.client.Validatable;
+import org.cloudfoundry.client.ValidationResult;
+
+/**
+ * The request payload for the Purge and Reseed Service Usage Events operation
+ */
+@Data
+public class PurgeAndReseedServiceUsageEventsRequest implements Validatable {
+
+    @Builder
+    PurgeAndReseedServiceUsageEventsRequest() {
+    }
+
+    @Override
+    public ValidationResult isValid() {
+        return ValidationResult.builder().build();
+    }
+
+}


### PR DESCRIPTION
This change adds the api to purge and reseed service usage events (```POST /v2/service_usage_events/destructively_purge_all_and_reseed_existing_instances```)
See  [this story](https://www.pivotaltracker.com/projects/816799/stories/101451582)
@nebhale : I willingly named the method ```purgeAndReseed``` because it does not a ```DELETE``` operation