### PR TITLE
Create User Provided Service Instance

### DIFF
--- a/cloudfoundry-client-spring/src/main/lombok/org/cloudfoundry/spring/client/SpringCloudFoundryClient.java
+++ b/cloudfoundry-client-spring/src/main/lombok/org/cloudfoundry/spring/client/SpringCloudFoundryClient.java
@@ -44,6 +44,7 @@ import org.cloudfoundry.client.v2.shareddomains.SharedDomains;
 import org.cloudfoundry.client.v2.spacequotadefinitions.SpaceQuotaDefinitions;
 import org.cloudfoundry.client.v2.spaces.Spaces;
 import org.cloudfoundry.client.v2.stacks.Stacks;
+import org.cloudfoundry.client.v2.userprovidedserviceinstances.UserProvidedServiceInstances;
 import org.cloudfoundry.client.v2.users.Users;
 import org.cloudfoundry.client.v3.applications.ApplicationsV3;
 import org.cloudfoundry.client.v3.droplets.Droplets;
@@ -72,6 +73,7 @@ import org.cloudfoundry.spring.client.v2.shareddomains.SpringSharedDomains;
 import org.cloudfoundry.spring.client.v2.spacequotadefinitions.SpringSpaceQuotaDefinitions;
 import org.cloudfoundry.spring.client.v2.spaces.SpringSpaces;
 import org.cloudfoundry.spring.client.v2.stacks.SpringStacks;
+import org.cloudfoundry.spring.client.v2.userprovidedserviceinstances.SpringUserProvidedServiceInstances;
 import org.cloudfoundry.spring.client.v2.users.SpringUsers;
 import org.cloudfoundry.spring.client.v3.applications.SpringApplicationsV3;
 import org.cloudfoundry.spring.client.v3.droplets.SpringDroplets;
@@ -163,6 +165,8 @@ public final class SpringCloudFoundryClient implements CloudFoundryClient {
 
     private final OAuth2TokenProvider tokenProvider;
 
+    private final UserProvidedServiceInstances userProvidedServiceInstances;
+
     private final Users users;
 
     @Builder
@@ -207,6 +211,7 @@ public final class SpringCloudFoundryClient implements CloudFoundryClient {
         this.spaces = new SpringSpaces(restOperations, root, schedulerGroup);
         this.stacks = new SpringStacks(restOperations, root, schedulerGroup);
         this.tasks = new SpringTasks(restOperations, root, schedulerGroup);
+        this.userProvidedServiceInstances = new SpringUserProvidedServiceInstances(restOperations, root, schedulerGroup);
         this.users = new SpringUsers(restOperations, root, schedulerGroup);
 
         this.connectionContext = connectionContext.toBuilder()
@@ -373,6 +378,11 @@ public final class SpringCloudFoundryClient implements CloudFoundryClient {
     @Override
     public Tasks tasks() {
         return tasks;
+    }
+
+    @Override
+    public UserProvidedServiceInstances userProvidedServiceInstances() {
+        return this.userProvidedServiceInstances;
     }
 
     @Override

--- a/cloudfoundry-client-spring/src/main/lombok/org/cloudfoundry/spring/client/v2/userprovidedserviceinstances/SpringUserProvidedServiceInstances.java
+++ b/cloudfoundry-client-spring/src/main/lombok/org/cloudfoundry/spring/client/v2/userprovidedserviceinstances/SpringUserProvidedServiceInstances.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright 2013-2016 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.cloudfoundry.spring.client.v2.userprovidedserviceinstances;
+
+import lombok.ToString;
+import org.cloudfoundry.client.v2.userprovidedserviceinstances.CreateUserProvidedServiceInstanceRequest;
+import org.cloudfoundry.client.v2.userprovidedserviceinstances.CreateUserProvidedServiceInstanceResponse;
+import org.cloudfoundry.client.v2.userprovidedserviceinstances.UserProvidedServiceInstances;
+import org.cloudfoundry.spring.util.AbstractSpringOperations;
+import org.springframework.web.client.RestOperations;
+import org.springframework.web.util.UriComponentsBuilder;
+import reactor.core.publisher.Mono;
+import reactor.core.publisher.SchedulerGroup;
+import reactor.fn.Consumer;
+
+import java.net.URI;
+
+/**
+ * The Spring-based implementation of {@link UserProvidedServiceInstances}
+ */
+@ToString(callSuper = true)
+public final class SpringUserProvidedServiceInstances extends AbstractSpringOperations implements UserProvidedServiceInstances {
+
+    /**
+     * Creates an instance
+     *
+     * @param restOperations the {@link RestOperations} to use to communicate with the server
+     * @param root           the root URI of the server.  Typically something like {@code https://api.run.pivotal.io}.
+     * @param schedulerGroup The group to use when making requests
+     */
+    public SpringUserProvidedServiceInstances(RestOperations restOperations, URI root, SchedulerGroup schedulerGroup) {
+        super(restOperations, root, schedulerGroup);
+    }
+
+    @Override
+    public Mono<CreateUserProvidedServiceInstanceResponse> create(final CreateUserProvidedServiceInstanceRequest request) {
+        return post(request, CreateUserProvidedServiceInstanceResponse.class, new Consumer<UriComponentsBuilder>() {
+
+            @Override
+            public void accept(UriComponentsBuilder builder) {
+                builder.pathSegment("v2", "user_provided_service_instances");
+            }
+
+        });
+    }
+}

--- a/cloudfoundry-client-spring/src/test/java/org/cloudfoundry/spring/client/SpringCloudFoundryClientTest.java
+++ b/cloudfoundry-client-spring/src/test/java/org/cloudfoundry/spring/client/SpringCloudFoundryClientTest.java
@@ -173,4 +173,14 @@ public final class SpringCloudFoundryClientTest extends AbstractRestTest {
         assertNotNull(this.client.tasks());
     }
 
+    @Test
+    public void userProvidedServiceInstances() {
+        assertNotNull(this.client.userProvidedServiceInstances());
+    }
+
+    @Test
+    public void users() {
+        assertNotNull(this.client.users());
+    }
+
 }

--- a/cloudfoundry-client-spring/src/test/java/org/cloudfoundry/spring/client/v2/userprovidedserviceinstances/SpringUserProvidedServiceInstancesTest.java
+++ b/cloudfoundry-client-spring/src/test/java/org/cloudfoundry/spring/client/v2/userprovidedserviceinstances/SpringUserProvidedServiceInstancesTest.java
@@ -1,0 +1,85 @@
+/*
+ * Copyright 2013-2016 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.cloudfoundry.spring.client.v2.userprovidedserviceinstances;
+
+import org.cloudfoundry.client.v2.Resource;
+import org.cloudfoundry.client.v2.userprovidedserviceinstances.CreateUserProvidedServiceInstanceRequest;
+import org.cloudfoundry.client.v2.userprovidedserviceinstances.CreateUserProvidedServiceInstanceResponse;
+import org.cloudfoundry.client.v2.userprovidedserviceinstances.UserProvidedServiceInstanceEntity;
+import org.cloudfoundry.spring.AbstractApiTest;
+import reactor.core.publisher.Mono;
+
+import static org.springframework.http.HttpMethod.POST;
+import static org.springframework.http.HttpStatus.CREATED;
+
+public final class SpringUserProvidedServiceInstancesTest {
+
+    public static final class Create extends AbstractApiTest<CreateUserProvidedServiceInstanceRequest, CreateUserProvidedServiceInstanceResponse> {
+
+        private final SpringUserProvidedServiceInstances userProvidedServiceInstances = new SpringUserProvidedServiceInstances(this.restTemplate, this.root, PROCESSOR_GROUP);
+
+        @Override
+        protected CreateUserProvidedServiceInstanceRequest getInvalidRequest() {
+            return CreateUserProvidedServiceInstanceRequest.builder().build();
+        }
+
+        @Override
+        protected RequestContext getRequestContext() {
+            return new RequestContext()
+                .method(POST).path("/v2/user_provided_service_instances")
+                .requestPayload("client/v2/user_provided_service_instances/POST_request.json")
+                .status(CREATED)
+                .responsePayload("client/v2/user_provided_service_instances/POST_response.json");
+        }
+
+        @Override
+        protected CreateUserProvidedServiceInstanceResponse getResponse() {
+            return CreateUserProvidedServiceInstanceResponse.builder()
+                .metadata(Resource.Metadata.builder()
+                    .createdAt("2015-07-27T22:43:35Z")
+                    .id("34d5500e-712d-49ef-8bbe-c9ac349532da")
+                    .url("/v2/user_provided_service_instances/34d5500e-712d-49ef-8bbe-c9ac349532da")
+                    .build())
+                .entity(UserProvidedServiceInstanceEntity.builder()
+                    .name("my-user-provided-instance")
+                    .credential("somekey", "somevalue")
+                    .spaceId("0d45d43f-7d50-43c6-9981-b32ce8d5a373")
+                    .type("user_provided_service_instance")
+                    .syslogDrainUrl("syslog://example.com")
+                    .spaceUrl("/v2/spaces/0d45d43f-7d50-43c6-9981-b32ce8d5a373")
+                    .serviceBindingsUrl("/v2/user_provided_service_instances/34d5500e-712d-49ef-8bbe-c9ac349532da/service_bindings")
+                    .build())
+                .build();
+        }
+
+        @Override
+        protected CreateUserProvidedServiceInstanceRequest getValidRequest() throws Exception {
+            return CreateUserProvidedServiceInstanceRequest.builder()
+                .spaceId("0d45d43f-7d50-43c6-9981-b32ce8d5a373")
+                .name("my-user-provided-instance")
+                .credential("somekey", "somevalue")
+                .syslogDrainUrl("syslog://example.com")
+                .build();
+        }
+
+        @Override
+        protected Mono<CreateUserProvidedServiceInstanceResponse> invoke(CreateUserProvidedServiceInstanceRequest request) {
+            return this.userProvidedServiceInstances.create(request);
+        }
+    }
+
+}

--- a/cloudfoundry-client-spring/src/test/resources/client/v2/user_provided_service_instances/POST_request.json
+++ b/cloudfoundry-client-spring/src/test/resources/client/v2/user_provided_service_instances/POST_request.json
@@ -1,0 +1,8 @@
+{
+  "credentials": {
+    "somekey": "somevalue"
+  },
+  "name": "my-user-provided-instance",
+  "space_guid": "0d45d43f-7d50-43c6-9981-b32ce8d5a373",
+  "syslog_drain_url": "syslog://example.com"
+}

--- a/cloudfoundry-client-spring/src/test/resources/client/v2/user_provided_service_instances/POST_response.json
+++ b/cloudfoundry-client-spring/src/test/resources/client/v2/user_provided_service_instances/POST_response.json
@@ -1,0 +1,19 @@
+{
+  "metadata": {
+    "guid": "34d5500e-712d-49ef-8bbe-c9ac349532da",
+    "url": "/v2/user_provided_service_instances/34d5500e-712d-49ef-8bbe-c9ac349532da",
+    "created_at": "2015-07-27T22:43:35Z",
+    "updated_at": null
+  },
+  "entity": {
+    "name": "my-user-provided-instance",
+    "credentials": {
+      "somekey": "somevalue"
+    },
+    "space_guid": "0d45d43f-7d50-43c6-9981-b32ce8d5a373",
+    "type": "user_provided_service_instance",
+    "syslog_drain_url": "syslog://example.com",
+    "space_url": "/v2/spaces/0d45d43f-7d50-43c6-9981-b32ce8d5a373",
+    "service_bindings_url": "/v2/user_provided_service_instances/34d5500e-712d-49ef-8bbe-c9ac349532da/service_bindings"
+  }
+}

--- a/cloudfoundry-client/src/main/java/org/cloudfoundry/client/CloudFoundryClient.java
+++ b/cloudfoundry-client/src/main/java/org/cloudfoundry/client/CloudFoundryClient.java
@@ -38,6 +38,7 @@ import org.cloudfoundry.client.v2.shareddomains.SharedDomains;
 import org.cloudfoundry.client.v2.spacequotadefinitions.SpaceQuotaDefinitions;
 import org.cloudfoundry.client.v2.spaces.Spaces;
 import org.cloudfoundry.client.v2.stacks.Stacks;
+import org.cloudfoundry.client.v2.userprovidedserviceinstances.UserProvidedServiceInstances;
 import org.cloudfoundry.client.v2.users.Users;
 import org.cloudfoundry.client.v3.applications.ApplicationsV3;
 import org.cloudfoundry.client.v3.droplets.Droplets;
@@ -251,6 +252,13 @@ public interface CloudFoundryClient {
      * @return the Cloud Foundry Tasks Client API
      */
     Tasks tasks();
+
+    /**
+     * Main entry point to the Cloud Foundry User Provided Service Instances Client API
+     *
+     * @return the Cloud Foundry User Provided Service Instances Client API
+     */
+    UserProvidedServiceInstances userProvidedServiceInstances();
 
     /**
      * Main entry point to the Cloud Foundry Users Client API

--- a/cloudfoundry-client/src/main/java/org/cloudfoundry/client/v2/userprovidedserviceinstances/UserProvidedServiceInstances.java
+++ b/cloudfoundry-client/src/main/java/org/cloudfoundry/client/v2/userprovidedserviceinstances/UserProvidedServiceInstances.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2013-2016 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.cloudfoundry.client.v2.userprovidedserviceinstances;
+
+import reactor.core.publisher.Mono;
+
+/**
+ * Main entry point to the Cloud Foundry User Provided Service Instances Client API
+ */
+public interface UserProvidedServiceInstances {
+
+    /**
+     * Makes the <a href="http://apidocs.cloudfoundry.org/214/user_provided_service_instances/creating_a_user_provided_service_instance.html">Create User Provided Service Instance</a> request
+     *
+     * @param request the Create User Provided Service Instance request
+     * @return the response from the Create User Provided Service Instance request
+     */
+    Mono<CreateUserProvidedServiceInstanceResponse> create(CreateUserProvidedServiceInstanceRequest request);
+
+}

--- a/cloudfoundry-client/src/main/lombok/org/cloudfoundry/client/v2/userprovidedserviceinstances/CreateUserProvidedServiceInstanceRequest.java
+++ b/cloudfoundry-client/src/main/lombok/org/cloudfoundry/client/v2/userprovidedserviceinstances/CreateUserProvidedServiceInstanceRequest.java
@@ -1,0 +1,99 @@
+/*
+ * Copyright 2013-2016 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.cloudfoundry.client.v2.userprovidedserviceinstances;
+
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.Singular;
+import org.cloudfoundry.Validatable;
+import org.cloudfoundry.ValidationResult;
+
+import java.util.Map;
+
+import static com.fasterxml.jackson.annotation.JsonInclude.Include.NON_EMPTY;
+
+/**
+ * The request payload for the Create User Provided Service Instance
+ */
+public final class CreateUserProvidedServiceInstanceRequest implements Validatable {
+
+
+    /**
+     * Key/value pairs that can be stored to store credentials
+     *
+     * @return the credentials
+     */
+    @Getter(onMethod = @__({@JsonProperty("credentials"), @JsonInclude(NON_EMPTY)}))
+    private final Map<String, Object> credentials;
+
+    /**
+     * The name
+     *
+     * @param name the name
+     * @return the name
+     */
+    @Getter(onMethod = @__(@JsonProperty("name")))
+    private final String name;
+
+    /**
+     * The space id
+     *
+     * @param spaceId the space id
+     * @return the space id
+     */
+    @Getter(onMethod = @__(@JsonProperty("space_guid")))
+    private final String spaceId;
+
+    /**
+     * The url for the syslog_drain to direct to
+     *
+     * @param syslogDrainUrl the syslog drain url
+     * @return the syslog drain url
+     */
+    @Getter(onMethod = @__(@JsonProperty("syslog_drain_url")))
+    private final String syslogDrainUrl;
+
+    @Builder
+    CreateUserProvidedServiceInstanceRequest(@Singular Map<String, Object> credentials,
+                                             String name,
+                                             String spaceId,
+                                             String syslogDrainUrl) {
+        this.credentials = credentials;
+        this.name = name;
+        this.spaceId = spaceId;
+        this.syslogDrainUrl = syslogDrainUrl;
+    }
+
+    @Override
+    public ValidationResult isValid() {
+        ValidationResult.ValidationResultBuilder builder = ValidationResult.builder();
+
+        if (this.name == null) {
+            builder.message("name must be specified");
+        }
+
+        if (this.spaceId == null) {
+            builder.message("space id must be specified");
+        }
+
+        return builder.build();
+    }
+
+}

--- a/cloudfoundry-client/src/main/lombok/org/cloudfoundry/client/v2/userprovidedserviceinstances/CreateUserProvidedServiceInstanceResponse.java
+++ b/cloudfoundry-client/src/main/lombok/org/cloudfoundry/client/v2/userprovidedserviceinstances/CreateUserProvidedServiceInstanceResponse.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2013-2016 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.cloudfoundry.client.v2.userprovidedserviceinstances;
+
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.Builder;
+import lombok.Data;
+import lombok.EqualsAndHashCode;
+import lombok.ToString;
+import org.cloudfoundry.client.v2.Resource;
+
+/**
+ * The response payload for the the Create User Provided Service Instance request.
+ */
+@Data
+@EqualsAndHashCode(callSuper = true)
+@ToString(callSuper = true)
+public final class CreateUserProvidedServiceInstanceResponse extends Resource<UserProvidedServiceInstanceEntity> {
+
+
+    @Builder
+    CreateUserProvidedServiceInstanceResponse(@JsonProperty("entity") UserProvidedServiceInstanceEntity entity,
+                                              @JsonProperty("metadata") Metadata metadata) {
+        super(entity, metadata);
+    }
+
+}

--- a/cloudfoundry-client/src/main/lombok/org/cloudfoundry/client/v2/userprovidedserviceinstances/UserProvidedServiceInstanceEntity.java
+++ b/cloudfoundry-client/src/main/lombok/org/cloudfoundry/client/v2/userprovidedserviceinstances/UserProvidedServiceInstanceEntity.java
@@ -1,0 +1,106 @@
+/*
+ * Copyright 2013-2016 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.cloudfoundry.client.v2.userprovidedserviceinstances;
+
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.Builder;
+import lombok.Data;
+import lombok.Singular;
+
+import java.util.Map;
+
+/**
+ * The entity response payload for User Provided Service Instances
+ */
+@Data
+public final class UserProvidedServiceInstanceEntity {
+
+    /**
+     * The credentials
+     *
+     * @param credentials the credentials
+     * @return the credentials
+     */
+    private final Map<String, Object> credentials;
+
+    /**
+     * The name
+     *
+     * @param name the name
+     * @return the name
+     */
+    private final String name;
+
+    /**
+     * The service bindings url
+     *
+     * @param serviceBindingsUrl the service bindings url
+     * @return the service bindings url
+     */
+    private final String serviceBindingsUrl;
+
+    /**
+     * The space id
+     *
+     * @param spaceId the space id
+     * @return the space id
+     */
+    private final String spaceId;
+
+    /**
+     * The space url
+     *
+     * @param spaceUrl the space url
+     * @return the space url
+     */
+    private final String spaceUrl;
+
+    /**
+     * The url for the syslog_drain to direct to
+     *
+     * @param syslogDrainUrl the syslog drain url
+     * @return the syslog drain url
+     */
+    private final String syslogDrainUrl;
+
+    /**
+     * The type
+     *
+     * @param type the type
+     * @return the type
+     */
+    private final String type;
+
+    @Builder
+    UserProvidedServiceInstanceEntity(@JsonProperty("credentials") @Singular Map<String, Object> credentials,
+                                      @JsonProperty("name") String name,
+                                      @JsonProperty("service_bindings_url") String serviceBindingsUrl,
+                                      @JsonProperty("space_guid") String spaceId,
+                                      @JsonProperty("space_url") String spaceUrl,
+                                      @JsonProperty("syslog_drain_url") String syslogDrainUrl,
+                                      @JsonProperty("type") String type) {
+        this.credentials = credentials;
+        this.name = name;
+        this.serviceBindingsUrl = serviceBindingsUrl;
+        this.spaceId = spaceId;
+        this.spaceUrl = spaceUrl;
+        this.syslogDrainUrl = syslogDrainUrl;
+        this.type = type;
+    }
+
+}

--- a/cloudfoundry-client/src/test/java/org/cloudfoundry/client/v2/userprovidedserviceinstances/CreateUserProvidedServiceInstanceRequestTest.java
+++ b/cloudfoundry-client/src/test/java/org/cloudfoundry/client/v2/userprovidedserviceinstances/CreateUserProvidedServiceInstanceRequestTest.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright 2013-2016 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.cloudfoundry.client.v2.userprovidedserviceinstances;
+
+import org.cloudfoundry.ValidationResult;
+import org.junit.Test;
+
+import static org.cloudfoundry.ValidationResult.Status.INVALID;
+import static org.cloudfoundry.ValidationResult.Status.VALID;
+import static org.junit.Assert.assertEquals;
+
+public final class CreateUserProvidedServiceInstanceRequestTest {
+
+    @Test
+    public void isNotValidNoName() {
+        ValidationResult result = CreateUserProvidedServiceInstanceRequest.builder()
+            .spaceId("space-id")
+            .build()
+            .isValid();
+
+        assertEquals(INVALID, result.getStatus());
+        assertEquals("name must be specified", result.getMessages().get(0));
+    }
+
+    @Test
+    public void isNotValidNoSpaceId() {
+        ValidationResult result = CreateUserProvidedServiceInstanceRequest.builder()
+            .name("name")
+            .build()
+            .isValid();
+
+        assertEquals(INVALID, result.getStatus());
+        assertEquals("space id must be specified", result.getMessages().get(0));
+    }
+
+    @Test
+    public void isValid() {
+        ValidationResult result = CreateUserProvidedServiceInstanceRequest.builder()
+            .name("name")
+            .spaceId("space-id")
+            .build()
+            .isValid();
+
+        assertEquals(VALID, result.getStatus());
+    }
+
+}


### PR DESCRIPTION
This change adds the api to create a user provided service instance (```POST /v2/user_provided_service_instances```)
See [this story](https://www.pivotaltracker.com/projects/816799/stories/101452058)
@nebhale The documentation say the post is on ```/v2/user_provided_service_instances/``` instead of ```/v2/user_provided_service_instances``` (extra slash at the end)