### PR TITLE
Mapping an App and a Route

### DIFF
--- a/cloudfoundry-client-spring/src/main/lombok/org/cloudfoundry/spring/client/SpringCloudFoundryClient.java
+++ b/cloudfoundry-client-spring/src/main/lombok/org/cloudfoundry/spring/client/SpringCloudFoundryClient.java
@@ -31,6 +31,7 @@ import org.cloudfoundry.client.v2.job.Jobs;
 import org.cloudfoundry.client.v2.organizationquotadefinitions.OrganizationQuotaDefinitions;
 import org.cloudfoundry.client.v2.organizations.Organizations;
 import org.cloudfoundry.client.v2.privatedomains.PrivateDomains;
+import org.cloudfoundry.client.v2.routemappings.RouteMappings;
 import org.cloudfoundry.client.v2.routes.Routes;
 import org.cloudfoundry.client.v2.servicebindings.ServiceBindings;
 import org.cloudfoundry.client.v2.servicebrokers.ServiceBrokers;
@@ -60,6 +61,7 @@ import org.cloudfoundry.spring.client.v2.jobs.SpringJobs;
 import org.cloudfoundry.spring.client.v2.organizations.SpringOrganizations;
 import org.cloudfoundry.spring.client.v2.privatedomains.SpringPrivateDomains;
 import org.cloudfoundry.spring.client.v2.quotadefinitions.SpringOrganizationQuotaDefinitions;
+import org.cloudfoundry.spring.client.v2.routemappings.SpringRouteMappings;
 import org.cloudfoundry.spring.client.v2.routes.SpringRoutes;
 import org.cloudfoundry.spring.client.v2.servicebindings.SpringServiceBindings;
 import org.cloudfoundry.spring.client.v2.servicebrokers.SpringServiceBrokers;
@@ -135,6 +137,8 @@ public final class SpringCloudFoundryClient implements CloudFoundryClient {
 
     private final Processes processes;
 
+    private final RouteMappings routeMappings;
+
     private final Routes routes;
 
     private final ServiceBindings serviceBindings;
@@ -197,6 +201,7 @@ public final class SpringCloudFoundryClient implements CloudFoundryClient {
         this.packages = new SpringPackages(restOperations, root, schedulerGroup);
         this.privateDomains = new SpringPrivateDomains(restOperations, root, schedulerGroup);
         this.processes = new SpringProcesses(restOperations, root, schedulerGroup);
+        this.routeMappings = new SpringRouteMappings(restOperations, root, schedulerGroup);
         this.routes = new SpringRoutes(restOperations, root, schedulerGroup);
         this.sharedDomains = new SpringSharedDomains(restOperations, root, schedulerGroup);
         this.serviceBindings = new SpringServiceBindings(restOperations, root, schedulerGroup);
@@ -308,6 +313,11 @@ public final class SpringCloudFoundryClient implements CloudFoundryClient {
     @Override
     public Processes processes() {
         return processes;
+    }
+
+    @Override
+    public RouteMappings routeMappings() {
+        return this.routeMappings;
     }
 
     @Override

--- a/cloudfoundry-client-spring/src/main/lombok/org/cloudfoundry/spring/client/v2/routemappings/SpringRouteMappings.java
+++ b/cloudfoundry-client-spring/src/main/lombok/org/cloudfoundry/spring/client/v2/routemappings/SpringRouteMappings.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright 2013-2016 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.cloudfoundry.spring.client.v2.routemappings;
+
+import lombok.ToString;
+import org.cloudfoundry.client.v2.routemappings.CreateRouteMappingRequest;
+import org.cloudfoundry.client.v2.routemappings.CreateRouteMappingResponse;
+import org.cloudfoundry.client.v2.routemappings.RouteMappings;
+import org.cloudfoundry.spring.util.AbstractSpringOperations;
+import org.springframework.web.client.RestOperations;
+import org.springframework.web.util.UriComponentsBuilder;
+import reactor.core.publisher.Mono;
+import reactor.core.publisher.SchedulerGroup;
+import reactor.fn.Consumer;
+
+import java.net.URI;
+
+/**
+ * The Spring-based implementation of {@link RouteMappings}
+ */
+@ToString(callSuper = true)
+public final class SpringRouteMappings extends AbstractSpringOperations implements RouteMappings {
+
+    /**
+     * Creates an instance
+     *
+     * @param restOperations the {@link RestOperations} to use to communicate with the server
+     * @param root           the root URI of the server.  Typically something like {@code https://api.run.pivotal.io}.
+     * @param schedulerGroup The group to use when making requests
+     */
+    public SpringRouteMappings(RestOperations restOperations, URI root, SchedulerGroup schedulerGroup) {
+        super(restOperations, root, schedulerGroup);
+    }
+
+    @Override
+    public Mono<CreateRouteMappingResponse> create(final CreateRouteMappingRequest request) {
+        return post(request, CreateRouteMappingResponse.class, new Consumer<UriComponentsBuilder>() {
+
+            @Override
+            public void accept(UriComponentsBuilder builder) {
+                builder.pathSegment("v2", "route_mappings");
+            }
+
+        });
+    }
+
+}

--- a/cloudfoundry-client-spring/src/test/java/org/cloudfoundry/spring/client/SpringCloudFoundryClientTest.java
+++ b/cloudfoundry-client-spring/src/test/java/org/cloudfoundry/spring/client/SpringCloudFoundryClientTest.java
@@ -104,6 +104,11 @@ public final class SpringCloudFoundryClientTest extends AbstractRestTest {
     }
 
     @Test
+    public void routeMappings() {
+        assertNotNull(this.client.routeMappings());
+    }
+
+    @Test
     public void routes() {
         assertNotNull(this.client.routes());
     }

--- a/cloudfoundry-client-spring/src/test/java/org/cloudfoundry/spring/client/v2/routemappings/SpringRouteMappingsTest.java
+++ b/cloudfoundry-client-spring/src/test/java/org/cloudfoundry/spring/client/v2/routemappings/SpringRouteMappingsTest.java
@@ -1,0 +1,82 @@
+/*
+ * Copyright 2013-2016 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.cloudfoundry.spring.client.v2.routemappings;
+
+import org.cloudfoundry.client.v2.Resource;
+import org.cloudfoundry.client.v2.routemappings.CreateRouteMappingRequest;
+import org.cloudfoundry.client.v2.routemappings.CreateRouteMappingResponse;
+import org.cloudfoundry.client.v2.routemappings.RouteMappingEntity;
+import org.cloudfoundry.spring.AbstractApiTest;
+import reactor.core.publisher.Mono;
+
+import static org.springframework.http.HttpMethod.POST;
+import static org.springframework.http.HttpStatus.CREATED;
+
+public final class SpringRouteMappingsTest {
+
+    public static final class Create extends AbstractApiTest<CreateRouteMappingRequest, CreateRouteMappingResponse> {
+
+        private final SpringRouteMappings routeMappings = new SpringRouteMappings(this.restTemplate, this.root, PROCESSOR_GROUP);
+
+        @Override
+        protected CreateRouteMappingRequest getInvalidRequest() {
+            return CreateRouteMappingRequest.builder().build();
+        }
+
+        @Override
+        protected RequestContext getRequestContext() {
+            return new RequestContext()
+                .method(POST).path("/v2/route_mappings")
+                .requestPayload("client/v2/route_mappings/POST_request.json")
+                .status(CREATED)
+                .responsePayload("client/v2/route_mappings/POST_response.json");
+        }
+
+        @Override
+        protected CreateRouteMappingResponse getResponse() {
+            return CreateRouteMappingResponse.builder()
+                .metadata(Resource.Metadata.builder()
+                    .createdAt("2016-01-19T19:40:59Z")
+                    .id("ca9cdd28-53c4-4b8e-a7e0-1838f69b8f91")
+                    .url("/v2/route_mappings/ca9cdd28-53c4-4b8e-a7e0-1838f69b8f91")
+                    .build())
+                .entity(RouteMappingEntity.builder()
+                    .applicationId("d232b485-b035-4d65-9f77-6b867d859de5")
+                    .applicationPort(8888)
+                    .routeId("c041e8a3-64d0-4beb-bac8-1900e3aedd07")
+                    .applicationUrl("/v2/apps/d232b485-b035-4d65-9f77-6b867d859de5")
+                    .routeUrl("/v2/routes/c041e8a3-64d0-4beb-bac8-1900e3aedd07")
+                    .build())
+                .build();
+        }
+
+        @Override
+        protected CreateRouteMappingRequest getValidRequest() throws Exception {
+            return CreateRouteMappingRequest.builder()
+                .applicationId("d232b485-b035-4d65-9f77-6b867d859de5")
+                .routeId("c041e8a3-64d0-4beb-bac8-1900e3aedd07")
+                .applicationPort(8888)
+                .build();
+        }
+
+        @Override
+        protected Mono<CreateRouteMappingResponse> invoke(CreateRouteMappingRequest request) {
+            return this.routeMappings.create(request);
+        }
+    }
+
+}

--- a/cloudfoundry-client-spring/src/test/resources/client/v2/route_mappings/POST_request.json
+++ b/cloudfoundry-client-spring/src/test/resources/client/v2/route_mappings/POST_request.json
@@ -1,0 +1,5 @@
+{
+  "app_guid": "d232b485-b035-4d65-9f77-6b867d859de5",
+  "route_guid": "c041e8a3-64d0-4beb-bac8-1900e3aedd07",
+  "app_port": 8888
+}

--- a/cloudfoundry-client-spring/src/test/resources/client/v2/route_mappings/POST_response.json
+++ b/cloudfoundry-client-spring/src/test/resources/client/v2/route_mappings/POST_response.json
@@ -1,0 +1,15 @@
+{
+  "metadata": {
+    "guid": "ca9cdd28-53c4-4b8e-a7e0-1838f69b8f91",
+    "url": "/v2/route_mappings/ca9cdd28-53c4-4b8e-a7e0-1838f69b8f91",
+    "created_at": "2016-01-19T19:40:59Z",
+    "updated_at": null
+  },
+  "entity": {
+    "app_guid": "d232b485-b035-4d65-9f77-6b867d859de5",
+    "app_port": 8888,
+    "route_guid": "c041e8a3-64d0-4beb-bac8-1900e3aedd07",
+    "app_url": "/v2/apps/d232b485-b035-4d65-9f77-6b867d859de5",
+    "route_url": "/v2/routes/c041e8a3-64d0-4beb-bac8-1900e3aedd07"
+  }
+}

--- a/cloudfoundry-client/src/main/java/org/cloudfoundry/client/CloudFoundryClient.java
+++ b/cloudfoundry-client/src/main/java/org/cloudfoundry/client/CloudFoundryClient.java
@@ -25,6 +25,7 @@ import org.cloudfoundry.client.v2.job.Jobs;
 import org.cloudfoundry.client.v2.organizationquotadefinitions.OrganizationQuotaDefinitions;
 import org.cloudfoundry.client.v2.organizations.Organizations;
 import org.cloudfoundry.client.v2.privatedomains.PrivateDomains;
+import org.cloudfoundry.client.v2.routemappings.RouteMappings;
 import org.cloudfoundry.client.v2.routes.Routes;
 import org.cloudfoundry.client.v2.servicebindings.ServiceBindings;
 import org.cloudfoundry.client.v2.servicebrokers.ServiceBrokers;
@@ -156,9 +157,16 @@ public interface CloudFoundryClient {
     Processes processes();
 
     /**
+     * Main entry point to the Cloud Foundry Route Mappings Client API
+     *
+     * @return the Cloud Foundry Route Mappings Client API
+     */
+    RouteMappings routeMappings();
+
+    /**
      * Main entry point to the Cloud Foundry Routes Client API
      *
-     * @return the Cloud Foundry Packages Client API
+     * @return the Cloud Foundry Routes Client API
      */
     Routes routes();
 

--- a/cloudfoundry-client/src/main/java/org/cloudfoundry/client/v2/routemappings/RouteMappings.java
+++ b/cloudfoundry-client/src/main/java/org/cloudfoundry/client/v2/routemappings/RouteMappings.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2013-2016 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.cloudfoundry.client.v2.routemappings;
+
+import reactor.core.publisher.Mono;
+
+/**
+ * Main entry point to the Cloud Foundry Route Mappings V2 Client API
+ */
+public interface RouteMappings {
+
+    /**
+     * Makes the <a href="http://apidocs.cloudfoundry.org/229/routes_mapping/mapping_an_app_and_a_route.html">Creating a Route Mapping</a> request
+     *
+     * @param request the Creating a Route Mapping request
+     * @return the response from the Creating a Route Mapping request
+     */
+    Mono<CreateRouteMappingResponse> create(CreateRouteMappingRequest request);
+
+}

--- a/cloudfoundry-client/src/main/lombok/org/cloudfoundry/client/v2/routemappings/CreateRouteMappingRequest.java
+++ b/cloudfoundry-client/src/main/lombok/org/cloudfoundry/client/v2/routemappings/CreateRouteMappingRequest.java
@@ -1,0 +1,81 @@
+/*
+ * Copyright 2013-2016 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.cloudfoundry.client.v2.routemappings;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.Builder;
+import lombok.Data;
+import lombok.Getter;
+import org.cloudfoundry.Validatable;
+import org.cloudfoundry.ValidationResult;
+
+/**
+ * The request payload for the Creating a Route Mapping operation
+ */
+@Data
+public final class CreateRouteMappingRequest implements Validatable {
+
+    /**
+     * The application id
+     *
+     * @param applicationId the application id
+     * @return the application id
+     */
+    @Getter(onMethod = @__(@JsonProperty("app_guid")))
+    private final String applicationId;
+
+    /**
+     * The application port on which the application should listen, and to which requests for the mapped route will be routed.
+     *
+     * @param applicationPort the application port
+     * @return the application port
+     */
+    @Getter(onMethod = @__(@JsonProperty("app_port")))
+    private final Integer applicationPort;
+
+    /**
+     * The route id
+     *
+     * @param routeId the route id
+     * @return route id
+     */
+    @Getter(onMethod = @__(@JsonProperty("route_guid")))
+    private final String routeId;
+
+    @Builder
+    CreateRouteMappingRequest(String applicationId, Integer applicationPort, String routeId) {
+        this.applicationId = applicationId;
+        this.applicationPort = applicationPort;
+        this.routeId = routeId;
+    }
+
+    @Override
+    public ValidationResult isValid() {
+        ValidationResult.ValidationResultBuilder builder = ValidationResult.builder();
+
+        if (this.applicationId == null) {
+            builder.message("application id must be specified");
+        }
+
+        if (this.routeId == null) {
+            builder.message("route id must be specified");
+        }
+
+        return builder.build();
+    }
+
+}

--- a/cloudfoundry-client/src/main/lombok/org/cloudfoundry/client/v2/routemappings/CreateRouteMappingResponse.java
+++ b/cloudfoundry-client/src/main/lombok/org/cloudfoundry/client/v2/routemappings/CreateRouteMappingResponse.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2013-2016 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.cloudfoundry.client.v2.routemappings;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.Builder;
+import lombok.Data;
+import lombok.EqualsAndHashCode;
+import lombok.ToString;
+import org.cloudfoundry.client.v2.Resource;
+
+/**
+ * The response payload for the Creating a Route Mapping operation
+ */
+@Data
+@EqualsAndHashCode(callSuper = true)
+@ToString(callSuper = true)
+public final class CreateRouteMappingResponse extends Resource<RouteMappingEntity> {
+
+    @Builder
+    CreateRouteMappingResponse(@JsonProperty("entity") RouteMappingEntity entity,
+                               @JsonProperty("metadata") Metadata metadata) {
+        super(entity, metadata);
+    }
+
+}

--- a/cloudfoundry-client/src/main/lombok/org/cloudfoundry/client/v2/routemappings/RouteMappingEntity.java
+++ b/cloudfoundry-client/src/main/lombok/org/cloudfoundry/client/v2/routemappings/RouteMappingEntity.java
@@ -1,0 +1,82 @@
+/*
+ * Copyright 2013-2016 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.cloudfoundry.client.v2.routemappings;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.Builder;
+import lombok.Data;
+
+/**
+ * The entity response payload for the Route Mapping resource
+ */
+@Data
+public final class RouteMappingEntity {
+
+    /**
+     * The application id
+     *
+     * @param applicationId the application id
+     * @return the application id
+     */
+    private final String applicationId;
+
+    /**
+     * The application port
+     *
+     * @param applicationPort the application port
+     * @return the application port
+     */
+    private final Integer applicationPort;
+
+    /**
+     * The application url
+     *
+     * @param applicationUrl the application url
+     * @return the application url
+     */
+    private final String applicationUrl;
+
+    /**
+     * The route id
+     *
+     * @param routeId the route id
+     * @return route id
+     */
+    private final String routeId;
+
+    /**
+     * The route url
+     *
+     * @param routeUrl the route url
+     * @return the route url
+     */
+    private final String routeUrl;
+
+    @Builder
+    RouteMappingEntity(@JsonProperty("app_guid") String applicationId,
+                       @JsonProperty("app_port") Integer applicationPort,
+                       @JsonProperty("app_url") String applicationUrl,
+                       @JsonProperty("route_guid") String routeId,
+                       @JsonProperty("route_url") String routeUrl) {
+        this.applicationId = applicationId;
+        this.applicationPort = applicationPort;
+        this.applicationUrl = applicationUrl;
+        this.routeId = routeId;
+        this.routeUrl = routeUrl;
+    }
+
+}

--- a/cloudfoundry-client/src/test/java/org/cloudfoundry/client/v2/routemappings/CreateRouteMappingRequestTest.java
+++ b/cloudfoundry-client/src/test/java/org/cloudfoundry/client/v2/routemappings/CreateRouteMappingRequestTest.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright 2013-2016 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.cloudfoundry.client.v2.routemappings;
+
+import org.cloudfoundry.ValidationResult;
+import org.junit.Test;
+
+import static org.cloudfoundry.ValidationResult.Status.INVALID;
+import static org.cloudfoundry.ValidationResult.Status.VALID;
+import static org.junit.Assert.assertEquals;
+
+public final class CreateRouteMappingRequestTest {
+
+    @Test
+    public void isNotValidNoApplicationId() {
+        ValidationResult result = CreateRouteMappingRequest.builder()
+            .routeId("route-id")
+            .build()
+            .isValid();
+
+        assertEquals(INVALID, result.getStatus());
+        assertEquals("application id must be specified", result.getMessages().get(0));
+    }
+
+    @Test
+    public void isNotValidNoRouteId() {
+        ValidationResult result = CreateRouteMappingRequest.builder()
+            .applicationId("application-id")
+            .build()
+            .isValid();
+
+        assertEquals(INVALID, result.getStatus());
+        assertEquals("route id must be specified", result.getMessages().get(0));
+    }
+
+    @Test
+    public void isValid() {
+        ValidationResult result = CreateRouteMappingRequest.builder()
+            .applicationId("application-id")
+            .routeId("route-id")
+            .build()
+            .isValid();
+
+        assertEquals(VALID, result.getStatus());
+    }
+
+}


### PR DESCRIPTION
This change adds the api to map an app and a route (```POST /v2/route_mappings```)
See [this story](https://www.pivotaltracker.com/projects/816799/stories/112357623)
@nebhale : few points of discussions:
1- I willingly named the operation 
```java
Mono<CreateRouteMappingResponse> create(CreateRouteMappingRequest request)
```
Because it appears as a create entity method (```POST``` under the ```route_mappings``` context)
2- Following the same logic I wondered whether the *guid* was not a documentation error and did not add it in the ```CreateRouteMappingRequest ```