### PR TITLE
Delete User Provided Service Instance

### DIFF
--- a/cloudfoundry-client-spring/src/main/lombok/org/cloudfoundry/spring/client/v2/userprovidedserviceinstances/SpringUserProvidedServiceInstances.java
+++ b/cloudfoundry-client-spring/src/main/lombok/org/cloudfoundry/spring/client/v2/userprovidedserviceinstances/SpringUserProvidedServiceInstances.java
@@ -19,6 +19,7 @@ package org.cloudfoundry.spring.client.v2.userprovidedserviceinstances;
 import lombok.ToString;
 import org.cloudfoundry.client.v2.userprovidedserviceinstances.CreateUserProvidedServiceInstanceRequest;
 import org.cloudfoundry.client.v2.userprovidedserviceinstances.CreateUserProvidedServiceInstanceResponse;
+import org.cloudfoundry.client.v2.userprovidedserviceinstances.DeleteUserProvidedServiceInstanceRequest;
 import org.cloudfoundry.client.v2.userprovidedserviceinstances.ListUserProvidedServiceInstancesRequest;
 import org.cloudfoundry.client.v2.userprovidedserviceinstances.ListUserProvidedServiceInstancesResponse;
 import org.cloudfoundry.client.v2.userprovidedserviceinstances.UserProvidedServiceInstances;
@@ -56,6 +57,18 @@ public final class SpringUserProvidedServiceInstances extends AbstractSpringOper
             @Override
             public void accept(UriComponentsBuilder builder) {
                 builder.pathSegment("v2", "user_provided_service_instances");
+            }
+
+        });
+    }
+
+    @Override
+    public Mono<Void> delete(final DeleteUserProvidedServiceInstanceRequest request) {
+        return delete(request, Void.class, new Consumer<UriComponentsBuilder>() {
+
+            @Override
+            public void accept(UriComponentsBuilder builder) {
+                builder.pathSegment("v2", "user_provided_service_instances", request.getUserProvidedServiceInstanceId());
             }
 
         });

--- a/cloudfoundry-client-spring/src/test/java/org/cloudfoundry/spring/client/v2/userprovidedserviceinstances/SpringUserProvidedServiceInstancesTest.java
+++ b/cloudfoundry-client-spring/src/test/java/org/cloudfoundry/spring/client/v2/userprovidedserviceinstances/SpringUserProvidedServiceInstancesTest.java
@@ -19,6 +19,7 @@ package org.cloudfoundry.spring.client.v2.userprovidedserviceinstances;
 import org.cloudfoundry.client.v2.Resource;
 import org.cloudfoundry.client.v2.userprovidedserviceinstances.CreateUserProvidedServiceInstanceRequest;
 import org.cloudfoundry.client.v2.userprovidedserviceinstances.CreateUserProvidedServiceInstanceResponse;
+import org.cloudfoundry.client.v2.userprovidedserviceinstances.DeleteUserProvidedServiceInstanceRequest;
 import org.cloudfoundry.client.v2.userprovidedserviceinstances.ListUserProvidedServiceInstancesRequest;
 import org.cloudfoundry.client.v2.userprovidedserviceinstances.ListUserProvidedServiceInstancesResponse;
 import org.cloudfoundry.client.v2.userprovidedserviceinstances.UserProvidedServiceInstanceEntity;
@@ -26,9 +27,11 @@ import org.cloudfoundry.client.v2.userprovidedserviceinstances.UserProvidedServi
 import org.cloudfoundry.spring.AbstractApiTest;
 import reactor.core.publisher.Mono;
 
+import static org.springframework.http.HttpMethod.DELETE;
 import static org.springframework.http.HttpMethod.GET;
 import static org.springframework.http.HttpMethod.POST;
 import static org.springframework.http.HttpStatus.CREATED;
+import static org.springframework.http.HttpStatus.NO_CONTENT;
 import static org.springframework.http.HttpStatus.OK;
 
 public final class SpringUserProvidedServiceInstancesTest {
@@ -84,6 +87,40 @@ public final class SpringUserProvidedServiceInstancesTest {
         @Override
         protected Mono<CreateUserProvidedServiceInstanceResponse> invoke(CreateUserProvidedServiceInstanceRequest request) {
             return this.userProvidedServiceInstances.create(request);
+        }
+    }
+
+    public static final class Delete extends AbstractApiTest<DeleteUserProvidedServiceInstanceRequest, Void> {
+
+        private final SpringUserProvidedServiceInstances userProvidedServiceInstances = new SpringUserProvidedServiceInstances(this.restTemplate, this.root, PROCESSOR_GROUP);
+
+        @Override
+        protected DeleteUserProvidedServiceInstanceRequest getInvalidRequest() {
+            return DeleteUserProvidedServiceInstanceRequest.builder().build();
+        }
+
+        @Override
+        protected RequestContext getRequestContext() {
+            return new RequestContext()
+                .method(DELETE).path("/v2/user_provided_service_instances/5b6b45c8-89be-48d2-affd-f64346ad4d93")
+                .status(NO_CONTENT);
+        }
+
+        @Override
+        protected Void getResponse() {
+            return null;
+        }
+
+        @Override
+        protected DeleteUserProvidedServiceInstanceRequest getValidRequest() throws Exception {
+            return DeleteUserProvidedServiceInstanceRequest.builder()
+                .userProvidedServiceInstanceId("5b6b45c8-89be-48d2-affd-f64346ad4d93")
+                .build();
+        }
+
+        @Override
+        protected Mono<Void> invoke(DeleteUserProvidedServiceInstanceRequest request) {
+            return this.userProvidedServiceInstances.delete(request);
         }
     }
 

--- a/cloudfoundry-client/src/main/java/org/cloudfoundry/client/v2/userprovidedserviceinstances/UserProvidedServiceInstances.java
+++ b/cloudfoundry-client/src/main/java/org/cloudfoundry/client/v2/userprovidedserviceinstances/UserProvidedServiceInstances.java
@@ -33,6 +33,14 @@ public interface UserProvidedServiceInstances {
     Mono<CreateUserProvidedServiceInstanceResponse> create(CreateUserProvidedServiceInstanceRequest request);
 
     /**
+     * Makes the <a href="http://apidocs.cloudfoundry.org/214/user_provided_service_instances/delete_a_particular_user_provided_service_instance.html">Delete the User Provided Service Instance</a> request
+     *
+     * @param request the Delete User Provided Service Instance request
+     * @return the response from the Delete User Provided Service Instance request
+     */
+    Mono<Void> delete(DeleteUserProvidedServiceInstanceRequest request);
+
+    /**
      * Makes the <a href="http://apidocs.cloudfoundry.org/214/user_provided_service_instances/list_all_user_provided_service_instances.html">List User Provided Service Instances</a> request
      *
      * @param request the List User Provided Service Instances request

--- a/cloudfoundry-client/src/main/lombok/org/cloudfoundry/client/v2/serviceinstances/DeleteServiceInstanceRequest.java
+++ b/cloudfoundry-client/src/main/lombok/org/cloudfoundry/client/v2/serviceinstances/DeleteServiceInstanceRequest.java
@@ -19,11 +19,16 @@ package org.cloudfoundry.client.v2.serviceinstances;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import lombok.Builder;
+import lombok.Data;
 import lombok.Getter;
 import org.cloudfoundry.QueryParameter;
 import org.cloudfoundry.Validatable;
 import org.cloudfoundry.ValidationResult;
 
+/**
+ * The request payload for the Delete Service Instance operation.
+ */
+@Data
 public final class DeleteServiceInstanceRequest implements Validatable {
 
     /**

--- a/cloudfoundry-client/src/main/lombok/org/cloudfoundry/client/v2/userprovidedserviceinstances/DeleteUserProvidedServiceInstanceRequest.java
+++ b/cloudfoundry-client/src/main/lombok/org/cloudfoundry/client/v2/userprovidedserviceinstances/DeleteUserProvidedServiceInstanceRequest.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright 2013-2016 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.cloudfoundry.client.v2.userprovidedserviceinstances;
+
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import lombok.Builder;
+import lombok.Data;
+import lombok.Getter;
+import org.cloudfoundry.Validatable;
+import org.cloudfoundry.ValidationResult;
+
+/**
+ * The request payload for the Delete User Provided Service Instance operation.
+ */
+@Data
+public final class DeleteUserProvidedServiceInstanceRequest implements Validatable {
+
+    /**
+     * The user provided service instance id
+     *
+     * @param userProvidedServiceInstanceId the user provided service instance id
+     * @return the user provided service instance id
+     */
+    @Getter(onMethod = @__(@JsonIgnore))
+    private final String userProvidedServiceInstanceId;
+
+    @Builder
+    DeleteUserProvidedServiceInstanceRequest(String userProvidedServiceInstanceId) {
+        this.userProvidedServiceInstanceId = userProvidedServiceInstanceId;
+    }
+
+    @Override
+    public ValidationResult isValid() {
+        ValidationResult.ValidationResultBuilder builder = ValidationResult.builder();
+
+        if (this.userProvidedServiceInstanceId == null) {
+            builder.message("user provided service instance id must be specified");
+        }
+
+        return builder.build();
+    }
+
+}

--- a/cloudfoundry-client/src/test/java/org/cloudfoundry/client/v2/userprovidedserviceinstances/DeleteUserProvidedServiceInstanceRequestTest.java
+++ b/cloudfoundry-client/src/test/java/org/cloudfoundry/client/v2/userprovidedserviceinstances/DeleteUserProvidedServiceInstanceRequestTest.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2013-2016 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.cloudfoundry.client.v2.userprovidedserviceinstances;
+
+import org.cloudfoundry.ValidationResult;
+import org.junit.Test;
+
+import static org.cloudfoundry.ValidationResult.Status.INVALID;
+import static org.cloudfoundry.ValidationResult.Status.VALID;
+import static org.junit.Assert.assertEquals;
+
+public final class DeleteUserProvidedServiceInstanceRequestTest {
+
+    @Test
+    public void isValid() {
+        ValidationResult result = DeleteUserProvidedServiceInstanceRequest.builder()
+            .userProvidedServiceInstanceId("test-user-provided-service-instance-id")
+            .build()
+            .isValid();
+
+        assertEquals(VALID, result.getStatus());
+    }
+
+    @Test
+    public void isValidNoId() {
+        ValidationResult result = DeleteUserProvidedServiceInstanceRequest.builder()
+            .build()
+            .isValid();
+
+        assertEquals(INVALID, result.getStatus());
+        assertEquals("user provided service instance id must be specified", result.getMessages().get(0));
+    }
+
+}


### PR DESCRIPTION
This change adds the api to delete a user provided service instance (```DELETE /v2/user_provided_service_instances/:guid```)
See [this story](https://www.pivotaltracker.com/projects/816799/stories/101452060)
