### PR TITLE
List Service Bindings for User Provided Service Instance

### DIFF
--- a/cloudfoundry-client-spring/src/main/lombok/org/cloudfoundry/spring/client/v2/userprovidedserviceinstances/SpringUserProvidedServiceInstances.java
+++ b/cloudfoundry-client-spring/src/main/lombok/org/cloudfoundry/spring/client/v2/userprovidedserviceinstances/SpringUserProvidedServiceInstances.java
@@ -20,9 +20,12 @@ import lombok.ToString;
 import org.cloudfoundry.client.v2.userprovidedserviceinstances.CreateUserProvidedServiceInstanceRequest;
 import org.cloudfoundry.client.v2.userprovidedserviceinstances.CreateUserProvidedServiceInstanceResponse;
 import org.cloudfoundry.client.v2.userprovidedserviceinstances.DeleteUserProvidedServiceInstanceRequest;
+import org.cloudfoundry.client.v2.userprovidedserviceinstances.ListUserProvidedServiceInstanceServiceBindingsRequest;
+import org.cloudfoundry.client.v2.userprovidedserviceinstances.ListUserProvidedServiceInstanceServiceBindingsResponse;
 import org.cloudfoundry.client.v2.userprovidedserviceinstances.ListUserProvidedServiceInstancesRequest;
 import org.cloudfoundry.client.v2.userprovidedserviceinstances.ListUserProvidedServiceInstancesResponse;
 import org.cloudfoundry.client.v2.userprovidedserviceinstances.UserProvidedServiceInstances;
+import org.cloudfoundry.spring.client.v2.FilterBuilder;
 import org.cloudfoundry.spring.util.AbstractSpringOperations;
 import org.cloudfoundry.spring.util.QueryBuilder;
 import org.springframework.web.client.RestOperations;
@@ -81,6 +84,20 @@ public final class SpringUserProvidedServiceInstances extends AbstractSpringOper
             @Override
             public void accept(UriComponentsBuilder builder) {
                 builder.pathSegment("v2", "user_provided_service_instances");
+                QueryBuilder.augment(builder, request);
+            }
+
+        });
+    }
+
+    @Override
+    public Mono<ListUserProvidedServiceInstanceServiceBindingsResponse> listServiceBindings(final ListUserProvidedServiceInstanceServiceBindingsRequest request) {
+        return get(request, ListUserProvidedServiceInstanceServiceBindingsResponse.class, new Consumer<UriComponentsBuilder>() {
+
+            @Override
+            public void accept(UriComponentsBuilder builder) {
+                builder.pathSegment("v2", "user_provided_service_instances", request.getUserProvidedServiceInstanceId(), "service_bindings");
+                FilterBuilder.augment(builder, request);
                 QueryBuilder.augment(builder, request);
             }
 

--- a/cloudfoundry-client-spring/src/test/java/org/cloudfoundry/spring/client/v2/userprovidedserviceinstances/SpringUserProvidedServiceInstancesTest.java
+++ b/cloudfoundry-client-spring/src/test/java/org/cloudfoundry/spring/client/v2/userprovidedserviceinstances/SpringUserProvidedServiceInstancesTest.java
@@ -17,9 +17,13 @@
 package org.cloudfoundry.spring.client.v2.userprovidedserviceinstances;
 
 import org.cloudfoundry.client.v2.Resource;
+import org.cloudfoundry.client.v2.servicebindings.ServiceBindingEntity;
+import org.cloudfoundry.client.v2.servicebindings.ServiceBindingResource;
 import org.cloudfoundry.client.v2.userprovidedserviceinstances.CreateUserProvidedServiceInstanceRequest;
 import org.cloudfoundry.client.v2.userprovidedserviceinstances.CreateUserProvidedServiceInstanceResponse;
 import org.cloudfoundry.client.v2.userprovidedserviceinstances.DeleteUserProvidedServiceInstanceRequest;
+import org.cloudfoundry.client.v2.userprovidedserviceinstances.ListUserProvidedServiceInstanceServiceBindingsRequest;
+import org.cloudfoundry.client.v2.userprovidedserviceinstances.ListUserProvidedServiceInstanceServiceBindingsResponse;
 import org.cloudfoundry.client.v2.userprovidedserviceinstances.ListUserProvidedServiceInstancesRequest;
 import org.cloudfoundry.client.v2.userprovidedserviceinstances.ListUserProvidedServiceInstancesResponse;
 import org.cloudfoundry.client.v2.userprovidedserviceinstances.UserProvidedServiceInstanceEntity;
@@ -175,6 +179,61 @@ public final class SpringUserProvidedServiceInstancesTest {
         @Override
         protected Mono<ListUserProvidedServiceInstancesResponse> invoke(ListUserProvidedServiceInstancesRequest request) {
             return this.userProvidedServiceInstances.list(request);
+        }
+    }
+
+    public static final class ListServiceBindings extends AbstractApiTest<ListUserProvidedServiceInstanceServiceBindingsRequest, ListUserProvidedServiceInstanceServiceBindingsResponse> {
+
+        private final SpringUserProvidedServiceInstances userProvidedServiceInstances = new SpringUserProvidedServiceInstances(this.restTemplate, this.root, PROCESSOR_GROUP);
+
+        @Override
+        protected ListUserProvidedServiceInstanceServiceBindingsRequest getInvalidRequest() {
+            return ListUserProvidedServiceInstanceServiceBindingsRequest.builder().build();
+        }
+
+        @Override
+        protected RequestContext getRequestContext() {
+            return new RequestContext()
+                .method(GET).path("/v2/user_provided_service_instances/16c81612-6a63-4faa-8cd5-acc80771b562/service_bindings?page=-1")
+                .status(OK)
+                .responsePayload("client/v2/user_provided_service_instances/GET_{id}_service_bindings_response.json");
+        }
+
+        @Override
+        protected ListUserProvidedServiceInstanceServiceBindingsResponse getResponse() {
+            return ListUserProvidedServiceInstanceServiceBindingsResponse.builder()
+                .totalPages(1)
+                .totalResults(1)
+                .resource(ServiceBindingResource.builder()
+                    .metadata(Resource.Metadata.builder()
+                            .createdAt("2016-01-26T22:20:16Z")
+                            .id("e6b8d548-e009-47d4-ab79-675e3da6bb52")
+                            .url("/v2/service_bindings/e6b8d548-e009-47d4-ab79-675e3da6bb52")
+                            .build()
+                    )
+                    .entity(ServiceBindingEntity.builder()
+                        .applicationId("a9bbd896-7500-45be-a75a-25e3d254f67c")
+                        .serviceInstanceId("16c81612-6a63-4faa-8cd5-acc80771b562")
+                        .credential("creds-key-29", "creds-val-29")
+                        .gatewayName("")
+                        .applicationUrl("/v2/apps/a9bbd896-7500-45be-a75a-25e3d254f67c")
+                        .serviceInstanceUrl("/v2/user_provided_service_instances/16c81612-6a63-4faa-8cd5-acc80771b562")
+                        .build())
+                    .build())
+                .build();
+        }
+
+        @Override
+        protected ListUserProvidedServiceInstanceServiceBindingsRequest getValidRequest() throws Exception {
+            return ListUserProvidedServiceInstanceServiceBindingsRequest.builder()
+                .userProvidedServiceInstanceId("16c81612-6a63-4faa-8cd5-acc80771b562")
+                .page(-1)
+                .build();
+        }
+
+        @Override
+        protected Mono<ListUserProvidedServiceInstanceServiceBindingsResponse> invoke(ListUserProvidedServiceInstanceServiceBindingsRequest request) {
+            return this.userProvidedServiceInstances.listServiceBindings(request);
         }
     }
 

--- a/cloudfoundry-client-spring/src/test/resources/client/v2/user_provided_service_instances/GET_{id}_service_bindings_response.json
+++ b/cloudfoundry-client-spring/src/test/resources/client/v2/user_provided_service_instances/GET_{id}_service_bindings_response.json
@@ -1,0 +1,30 @@
+{
+  "total_results": 1,
+  "total_pages": 1,
+  "prev_url": null,
+  "next_url": null,
+  "resources": [
+    {
+      "metadata": {
+        "guid": "e6b8d548-e009-47d4-ab79-675e3da6bb52",
+        "url": "/v2/service_bindings/e6b8d548-e009-47d4-ab79-675e3da6bb52",
+        "created_at": "2016-01-26T22:20:16Z",
+        "updated_at": null
+      },
+      "entity": {
+        "app_guid": "a9bbd896-7500-45be-a75a-25e3d254f67c",
+        "service_instance_guid": "16c81612-6a63-4faa-8cd5-acc80771b562",
+        "credentials": {
+          "creds-key-29": "creds-val-29"
+        },
+        "binding_options": {
+        },
+        "gateway_data": null,
+        "gateway_name": "",
+        "syslog_drain_url": null,
+        "app_url": "/v2/apps/a9bbd896-7500-45be-a75a-25e3d254f67c",
+        "service_instance_url": "/v2/user_provided_service_instances/16c81612-6a63-4faa-8cd5-acc80771b562"
+      }
+    }
+  ]
+}

--- a/cloudfoundry-client/src/main/java/org/cloudfoundry/client/v2/userprovidedserviceinstances/UserProvidedServiceInstances.java
+++ b/cloudfoundry-client/src/main/java/org/cloudfoundry/client/v2/userprovidedserviceinstances/UserProvidedServiceInstances.java
@@ -50,4 +50,13 @@ public interface UserProvidedServiceInstances {
      */
     Mono<ListUserProvidedServiceInstancesResponse> list(ListUserProvidedServiceInstancesRequest request);
 
+    /**
+     * Makes the <a href="http://apidocs.cloudfoundry.org/latest-release/user_provided_service_instances/list_all_service_bindings_for_the_user_provided_service_instance.html">List all Service
+     * Bindings for the User Provided Service Instance</a> request
+     *
+     * @param request the List Service Bindings request
+     * @return the response from the List Service Bindings request
+     */
+    Mono<ListUserProvidedServiceInstanceServiceBindingsResponse> listServiceBindings(ListUserProvidedServiceInstanceServiceBindingsRequest request);
+
 }

--- a/cloudfoundry-client/src/main/lombok/org/cloudfoundry/client/v2/userprovidedserviceinstances/ListUserProvidedServiceInstanceServiceBindingsRequest.java
+++ b/cloudfoundry-client/src/main/lombok/org/cloudfoundry/client/v2/userprovidedserviceinstances/ListUserProvidedServiceInstanceServiceBindingsRequest.java
@@ -1,0 +1,79 @@
+/*
+ * Copyright 2013-2016 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.cloudfoundry.client.v2.userprovidedserviceinstances;
+
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import lombok.Builder;
+import lombok.Data;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.Singular;
+import lombok.ToString;
+import org.cloudfoundry.Validatable;
+import org.cloudfoundry.ValidationResult;
+import org.cloudfoundry.client.v2.InFilterParameter;
+import org.cloudfoundry.client.v2.PaginatedRequest;
+
+import java.util.List;
+
+/**
+ * The request payload for the List all Service Bindings for the User Provided Service Instance operation
+ */
+@Data
+@EqualsAndHashCode(callSuper = true)
+@ToString(callSuper = true)
+public final class ListUserProvidedServiceInstanceServiceBindingsRequest extends PaginatedRequest implements Validatable {
+
+    /**
+     * The ids of the applications
+     *
+     * @param applicationIds the ids of the applications to filter on
+     * @return the ids of the applications to filter on
+     */
+    @Getter(onMethod = @__(@InFilterParameter("app_guid")))
+    private final List<String> applicationIds;
+
+    /**
+     * The user provided service instance id
+     *
+     * @param userProvidedServiceInstanceId the user provided service instance id
+     * @return the user provided  service instance id
+     */
+    @Getter(onMethod = @__(@JsonIgnore))
+    private final String userProvidedServiceInstanceId;
+
+    @Builder
+    ListUserProvidedServiceInstanceServiceBindingsRequest(OrderDirection orderDirection, Integer page, Integer resultsPerPage,
+                                                          @Singular List<String> applicationIds,
+                                                          String userProvidedServiceInstanceId) {
+        super(orderDirection, page, resultsPerPage);
+        this.applicationIds = applicationIds;
+        this.userProvidedServiceInstanceId = userProvidedServiceInstanceId;
+    }
+
+    @Override
+    public ValidationResult isValid() {
+        ValidationResult.ValidationResultBuilder builder = ValidationResult.builder();
+
+        if (this.userProvidedServiceInstanceId == null) {
+            builder.message("user provided service instance id must be specified");
+        }
+
+        return builder.build();
+    }
+
+}

--- a/cloudfoundry-client/src/main/lombok/org/cloudfoundry/client/v2/userprovidedserviceinstances/ListUserProvidedServiceInstanceServiceBindingsResponse.java
+++ b/cloudfoundry-client/src/main/lombok/org/cloudfoundry/client/v2/userprovidedserviceinstances/ListUserProvidedServiceInstanceServiceBindingsResponse.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2013-2016 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.cloudfoundry.client.v2.userprovidedserviceinstances;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.Builder;
+import lombok.Data;
+import lombok.EqualsAndHashCode;
+import lombok.Singular;
+import lombok.ToString;
+import org.cloudfoundry.client.v2.PaginatedResponse;
+import org.cloudfoundry.client.v2.servicebindings.ServiceBindingResource;
+
+import java.util.List;
+
+/**
+ * The response payload for the List all Service Bindings for the User Provided Service Instance operation
+ */
+@Data
+@EqualsAndHashCode(callSuper = true)
+@ToString(callSuper = true)
+public final class ListUserProvidedServiceInstanceServiceBindingsResponse extends PaginatedResponse<ServiceBindingResource> {
+
+    @Builder
+    ListUserProvidedServiceInstanceServiceBindingsResponse(@JsonProperty("next_url") String nextUrl,
+                                                           @JsonProperty("prev_url") String previousUrl,
+                                                           @JsonProperty("resources") @Singular List<ServiceBindingResource> resources,
+                                                           @JsonProperty("total_pages") Integer totalPages,
+                                                           @JsonProperty("total_results") Integer totalResults) {
+        super(nextUrl, previousUrl, resources, totalPages, totalResults);
+    }
+
+}

--- a/cloudfoundry-client/src/test/java/org/cloudfoundry/client/v2/userprovidedserviceinstances/ListUserProvidedServiceInstanceServiceBindingsRequestTest.java
+++ b/cloudfoundry-client/src/test/java/org/cloudfoundry/client/v2/userprovidedserviceinstances/ListUserProvidedServiceInstanceServiceBindingsRequestTest.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2013-2016 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.cloudfoundry.client.v2.userprovidedserviceinstances;
+
+
+import org.cloudfoundry.ValidationResult;
+import org.junit.Test;
+
+import static org.cloudfoundry.ValidationResult.Status.INVALID;
+import static org.cloudfoundry.ValidationResult.Status.VALID;
+import static org.junit.Assert.assertEquals;
+
+public final class ListUserProvidedServiceInstanceServiceBindingsRequestTest {
+
+    @Test
+    public void isValid() {
+        ValidationResult result = ListUserProvidedServiceInstanceServiceBindingsRequest.builder()
+            .userProvidedServiceInstanceId("test-user-provided-service-instance-id")
+            .build()
+            .isValid();
+
+        assertEquals(VALID, result.getStatus());
+    }
+
+    @Test
+    public void isValidNoId() {
+        ValidationResult result = ListUserProvidedServiceInstanceServiceBindingsRequest.builder()
+            .build()
+            .isValid();
+
+        assertEquals(INVALID, result.getStatus());
+        assertEquals("user provided service instance id must be specified", result.getMessages().get(0));
+    }
+
+}


### PR DESCRIPTION
This change adds the api to list service bindings for the user provided service instance (```GET /v2/user_provided_service_instances/:guid/service_bindings```)
See [this story](https://www.pivotaltracker.com/projects/816799/stories/101452062)

@nebhale : I think [this documentation](http://apidocs.cloudfoundry.org/230/user_provided_service_instances/list_all_service_bindings_for_the_user_provided_service_instance.html) also lacks [the side note added](http://apidocs.cloudfoundry.org/230/service_instances/list_all_service_bindings_for_the_service_instance.html) about the *IN* ```service_instance_guid``` parameter