### PR TITLE
Create Identity zone

### DIFF
--- a/cloudfoundry-client-spring/src/main/lombok/org/cloudfoundry/spring/uaa/identityzonemanagement/SpringIdentityZoneManagement.java
+++ b/cloudfoundry-client-spring/src/main/lombok/org/cloudfoundry/spring/uaa/identityzonemanagement/SpringIdentityZoneManagement.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright 2013-2016 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.cloudfoundry.spring.uaa.identityzonemanagement;
+
+import lombok.ToString;
+import org.cloudfoundry.spring.util.AbstractSpringOperations;
+import org.cloudfoundry.uaa.identityzonemanagement.CreateIdentityZoneRequest;
+import org.cloudfoundry.uaa.identityzonemanagement.CreateIdentityZoneResponse;
+import org.cloudfoundry.uaa.identityzonemanagement.IdentityZoneManagement;
+import org.springframework.web.client.RestOperations;
+import org.springframework.web.util.UriComponentsBuilder;
+import reactor.core.publisher.Mono;
+import reactor.core.publisher.SchedulerGroup;
+import reactor.fn.Consumer;
+
+import java.net.URI;
+
+/**
+ * The Spring-based implementation of {@link IdentityZoneManagement}
+ */
+@ToString(callSuper = true)
+public final class SpringIdentityZoneManagement extends AbstractSpringOperations implements IdentityZoneManagement {
+
+    /**
+     * Creates an instance
+     *
+     * @param restOperations the {@link RestOperations} to use to communicate with the server
+     * @param root           the root URI of the server.  Typically something like {@code https://uaa.run.pivotal.io}.
+     * @param schedulerGroup The group to use when making requests
+     */
+    public SpringIdentityZoneManagement(RestOperations restOperations, URI root, SchedulerGroup schedulerGroup) {
+        super(restOperations, root, schedulerGroup);
+    }
+
+    @Override
+    public Mono<CreateIdentityZoneResponse> create(CreateIdentityZoneRequest request) {
+        return post(request, CreateIdentityZoneResponse.class, new Consumer<UriComponentsBuilder>() {
+
+            @Override
+            public void accept(UriComponentsBuilder builder) {
+                builder.pathSegment("identity-zones");
+            }
+
+        });
+    }
+
+}

--- a/cloudfoundry-client-spring/src/test/java/org/cloudfoundry/spring/uaa/SpringUaaClientTest.java
+++ b/cloudfoundry-client-spring/src/test/java/org/cloudfoundry/spring/uaa/SpringUaaClientTest.java
@@ -30,4 +30,9 @@ public final class SpringUaaClientTest extends AbstractRestTest {
         assertNotNull(this.client.accessTokenAdministration());
     }
 
+    @Test
+    public void identityZoneManagement() {
+        assertNotNull(this.client.identityZoneManagement());
+    }
+
 }

--- a/cloudfoundry-client-spring/src/test/java/org/cloudfoundry/spring/uaa/identityzonemanagement/SpringIdentityZoneManagementTest.java
+++ b/cloudfoundry-client-spring/src/test/java/org/cloudfoundry/spring/uaa/identityzonemanagement/SpringIdentityZoneManagementTest.java
@@ -1,0 +1,75 @@
+/*
+ * Copyright 2013-2016 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.cloudfoundry.spring.uaa.identityzonemanagement;
+
+import org.cloudfoundry.spring.AbstractApiTest;
+import org.cloudfoundry.uaa.identityzonemanagement.CreateIdentityZoneRequest;
+import org.cloudfoundry.uaa.identityzonemanagement.CreateIdentityZoneResponse;
+import reactor.core.publisher.Mono;
+
+import static org.springframework.http.HttpMethod.POST;
+import static org.springframework.http.HttpStatus.CREATED;
+
+public final class SpringIdentityZoneManagementTest {
+
+    public static final class Create extends AbstractApiTest<CreateIdentityZoneRequest, CreateIdentityZoneResponse> {
+
+        private final SpringIdentityZoneManagement identityZoneManagement = new SpringIdentityZoneManagement(this.restTemplate, this.root, PROCESSOR_GROUP);
+
+        @Override
+        protected CreateIdentityZoneRequest getInvalidRequest() {
+            return CreateIdentityZoneRequest.builder().build();
+        }
+
+        @Override
+        protected RequestContext getRequestContext() {
+            return new RequestContext()
+                .method(POST).path("/identity-zones")
+                .requestPayload("uaa/identity-zones/POST_request.json")
+                .status(CREATED)
+                .responsePayload("uaa/identity-zones/POST_response.json");
+        }
+
+        @Override
+        protected CreateIdentityZoneResponse getResponse() {
+            return CreateIdentityZoneResponse.builder()
+                .createdAt("2015-07-27T22:43:20Z")
+                .description("Like the Twilight Zone but tastier[testzone1].")
+                .identityZoneId("testzone1")
+                .name("The Twiglet Zone[testzone1]")
+                .subDomain("testzone1")
+                .version(0)
+                .build();
+        }
+
+        @Override
+        protected CreateIdentityZoneRequest getValidRequest() throws Exception {
+            return CreateIdentityZoneRequest.builder()
+                .description("Like the Twilight Zone but tastier[testzone1].")
+                .identityZoneId("testzone1")
+                .name("The Twiglet Zone[testzone1]")
+                .subDomain("testzone1")
+                .build();
+        }
+
+        @Override
+        protected Mono<CreateIdentityZoneResponse> invoke(CreateIdentityZoneRequest request) {
+            return this.identityZoneManagement.create(request);
+        }
+    }
+
+}

--- a/cloudfoundry-client-spring/src/test/resources/uaa/identity-zones/POST_request.json
+++ b/cloudfoundry-client-spring/src/test/resources/uaa/identity-zones/POST_request.json
@@ -1,0 +1,6 @@
+{
+  "id": "testzone1",
+  "subdomain": "testzone1",
+  "name": "The Twiglet Zone[testzone1]",
+  "description": "Like the Twilight Zone but tastier[testzone1]."
+}

--- a/cloudfoundry-client-spring/src/test/resources/uaa/identity-zones/POST_response.json
+++ b/cloudfoundry-client-spring/src/test/resources/uaa/identity-zones/POST_response.json
@@ -1,0 +1,9 @@
+{
+  "created": "2015-07-27T22:43:20Z",
+  "description": "Like the Twilight Zone but tastier[testzone1].",
+  "id": "testzone1",
+  "last_modified": null,
+  "name": "The Twiglet Zone[testzone1]",
+  "subdomain": "testzone1",
+  "version": 0
+}

--- a/cloudfoundry-client/src/main/java/org/cloudfoundry/uaa/identityzonemanagement/IdentityZoneManagement.java
+++ b/cloudfoundry-client/src/main/java/org/cloudfoundry/uaa/identityzonemanagement/IdentityZoneManagement.java
@@ -14,28 +14,21 @@
  * limitations under the License.
  */
 
-package org.cloudfoundry.uaa;
+package org.cloudfoundry.uaa.identityzonemanagement;
 
-import org.cloudfoundry.uaa.accesstokenadministration.AccessTokenAdministration;
-import org.cloudfoundry.uaa.identityzonemanagement.IdentityZoneManagement;
+import reactor.core.publisher.Mono;
 
 /**
- * Main entry point to the UAA Client API
+ * Main entry point to the UAA Identity Zone Management Client API
  */
-public interface UaaClient {
+public interface IdentityZoneManagement {
 
     /**
-     * Main entry point to the UAA Access Token Administration Client API
+     * Makes the <a href="https://github.com/cloudfoundry/uaa/blob/master/docs/UAA-APIs.rst#create-or-update-identity-zones-post-or-put-identity-zones">Create Identity Zone</a> request
      *
-     * @return the UAA Access Token Administration Client API
+     * @param request the Create Identity Zone request
+     * @return the response from the Create Identity Zone request
      */
-    AccessTokenAdministration accessTokenAdministration();
-
-    /**
-     * Main entry point to the UAA Identity Zone Management Client API
-     *
-     * @return the UAA Identity Zone Management Client API
-     */
-    IdentityZoneManagement identityZoneManagement();
+    Mono<CreateIdentityZoneResponse> create(CreateIdentityZoneRequest request);
 
 }

--- a/cloudfoundry-client/src/main/lombok/org/cloudfoundry/uaa/identityzonemanagement/CreateIdentityZoneRequest.java
+++ b/cloudfoundry-client/src/main/lombok/org/cloudfoundry/uaa/identityzonemanagement/CreateIdentityZoneRequest.java
@@ -1,0 +1,108 @@
+/*
+ * Copyright 2013-2016 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.cloudfoundry.uaa.identityzonemanagement;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.Builder;
+import lombok.Data;
+import lombok.Getter;
+import org.cloudfoundry.Validatable;
+import org.cloudfoundry.ValidationResult;
+
+import static com.fasterxml.jackson.annotation.JsonInclude.Include.NON_NULL;
+
+/**
+ * The request payload for the create identity zone operation
+ */
+@Data
+public final class CreateIdentityZoneRequest implements Validatable {
+
+    /**
+     * The description of the identity zone.
+     *
+     * @param description the description
+     * @return the description
+     */
+    @Getter(onMethod = @__(@JsonProperty("description")))
+    private final String description;
+
+    /**
+     * The id of the identity zone. When not provided, an identifier will be generated
+     *
+     * @param identityZoneId the identity zone id
+     * @return the identity zone id
+     */
+    @Getter(onMethod = @__({@JsonProperty("id"), @JsonInclude(NON_NULL)}))
+    private final String identityZoneId;
+
+    /**
+     * The name of the identity zone.
+     *
+     * @param name the name
+     * @return the name
+     */
+    @Getter(onMethod = @__(@JsonProperty("name")))
+    private final String name;
+
+    /**
+     * The unique subdomain. It will be converted into lowercase upon creation.
+     *
+     * @param subdomain the subdomain
+     * @return the subdomain
+     */
+    @Getter(onMethod = @__(@JsonProperty("subdomain")))
+    private final String subDomain;
+
+    /**
+     * The version of the identity zone.
+     *
+     * @param version the version
+     * @return the version
+     */
+    @Getter(onMethod = @__(@JsonProperty("version")))
+    private final Integer version;
+
+    @Builder
+    CreateIdentityZoneRequest(String description,
+                              String identityZoneId,
+                              String name,
+                              String subDomain,
+                              Integer version) {
+        this.description = description;
+        this.identityZoneId = identityZoneId;
+        this.name = name;
+        this.subDomain = subDomain;
+        this.version = version;
+    }
+
+    @Override
+    public ValidationResult isValid() {
+        ValidationResult.ValidationResultBuilder builder = ValidationResult.builder();
+
+        if (this.name == null) {
+            builder.message("name must be specified");
+        }
+
+        if (this.subDomain == null) {
+            builder.message("sub domain must be specified");
+        }
+
+        return builder.build();
+    }
+
+}

--- a/cloudfoundry-client/src/main/lombok/org/cloudfoundry/uaa/identityzonemanagement/CreateIdentityZoneResponse.java
+++ b/cloudfoundry-client/src/main/lombok/org/cloudfoundry/uaa/identityzonemanagement/CreateIdentityZoneResponse.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2013-2016 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.cloudfoundry.uaa.identityzonemanagement;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.Builder;
+import lombok.Data;
+import lombok.EqualsAndHashCode;
+import lombok.ToString;
+
+/**
+ * The response from the create identity zone request
+ */
+@Data
+@EqualsAndHashCode(callSuper = true)
+@ToString(callSuper = true)
+public final class CreateIdentityZoneResponse extends IdentityZoneEntity {
+
+    @Builder
+    CreateIdentityZoneResponse(@JsonProperty("created") String createdAt,
+                               @JsonProperty("description") String description,
+                               @JsonProperty("id") String identityZoneId,
+                               @JsonProperty("name") String name,
+                               @JsonProperty("subdomain") String subDomain,
+                               @JsonProperty("last_modified") String updatedAt,
+                               @JsonProperty("version") Integer version) {
+        super(createdAt, description, identityZoneId, name, subDomain, updatedAt, version);
+    }
+
+}

--- a/cloudfoundry-client/src/main/lombok/org/cloudfoundry/uaa/identityzonemanagement/IdentityZoneEntity.java
+++ b/cloudfoundry-client/src/main/lombok/org/cloudfoundry/uaa/identityzonemanagement/IdentityZoneEntity.java
@@ -1,0 +1,100 @@
+/*
+ * Copyright 2013-2016 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.cloudfoundry.uaa.identityzonemanagement;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.Data;
+
+/**
+ * The entity response payload for Identity Zone
+ */
+@Data
+public class IdentityZoneEntity {
+
+    /**
+     * The creation date of the identity zone.
+     *
+     * @param createdAt the creation date
+     * @return the creation date
+     */
+    private final String createdAt;
+
+    /**
+     * The description of the identity zone.
+     *
+     * @param description the description
+     * @return the description
+     */
+    private final String description;
+
+    /**
+     * The id of the identity zone.
+     *
+     * @param identityZoneId the identity zone id
+     * @return the identity zone id
+     */
+    private final String identityZoneId;
+
+    /**
+     * The name of the identity zone.
+     *
+     * @param name the name
+     * @return the name
+     */
+    private final String name;
+
+    /**
+     * The unique sub domain. It will be converted into lowercase upon creation.
+     *
+     * @param subDomain the sub domain
+     * @return the sub domain
+     */
+    private final String subDomain;
+
+    /**
+     * The last modification date of the identity zone.
+     *
+     * @param updatedAt the last modification date
+     * @return the last modification date
+     */
+    private final String updatedAt;
+
+    /**
+     * The version of the identity zone.
+     *
+     * @param version the version
+     * @return the version
+     */
+    private final Integer version;
+
+    protected IdentityZoneEntity(@JsonProperty("created") String createdAt,
+                                 @JsonProperty("description") String description,
+                                 @JsonProperty("id") String identityZoneId,
+                                 @JsonProperty("name") String name,
+                                 @JsonProperty("subdomain") String subDomain,
+                                 @JsonProperty("last_modified") String updatedAt,
+                                 @JsonProperty("version") Integer version) {
+        this.createdAt = createdAt;
+        this.description = description;
+        this.identityZoneId = identityZoneId;
+        this.name = name;
+        this.subDomain = subDomain;
+        this.updatedAt = updatedAt;
+        this.version = version;
+    }
+
+}

--- a/cloudfoundry-client/src/test/java/org/cloudfoundry/uaa/identityzonemanagement/CreateIdentityZoneRequestTest.java
+++ b/cloudfoundry-client/src/test/java/org/cloudfoundry/uaa/identityzonemanagement/CreateIdentityZoneRequestTest.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright 2013-2016 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.cloudfoundry.uaa.identityzonemanagement;
+
+import org.cloudfoundry.ValidationResult;
+import org.junit.Test;
+
+import static org.cloudfoundry.ValidationResult.Status.INVALID;
+import static org.cloudfoundry.ValidationResult.Status.VALID;
+import static org.junit.Assert.assertEquals;
+
+public final class CreateIdentityZoneRequestTest {
+
+    @Test
+    public void isNotValidNoName() {
+        ValidationResult result = CreateIdentityZoneRequest.builder()
+            .subDomain("test-sub-domain")
+            .build()
+            .isValid();
+
+        assertEquals(INVALID, result.getStatus());
+        assertEquals("name must be specified", result.getMessages().get(0));
+    }
+
+    @Test
+    public void isNotValidNoSubdomain() {
+        ValidationResult result = CreateIdentityZoneRequest.builder()
+            .name("test-name")
+            .build()
+            .isValid();
+
+        assertEquals(INVALID, result.getStatus());
+        assertEquals("sub domain must be specified", result.getMessages().get(0));
+    }
+
+
+    @Test
+    public void isValid() {
+        ValidationResult result = CreateIdentityZoneRequest.builder()
+            .name("test-name")
+            .subDomain("test-sub-domain")
+            .build()
+            .isValid();
+
+        assertEquals(VALID, result.getStatus());
+    }
+
+}


### PR DESCRIPTION
This change adds the api to create an identity zone (POST /identity-zones)
See [this story](https://www.pivotaltracker.com/projects/816799/stories/114245163)

@nebhale : few remarks
- ```GetTokenKeyRequest``` should be under *src/main/lombok* instead of *src/main/java*
- To implement the ```CreateIdentityZoneRequest``` I took a look at [the model code](https://github.com/cloudfoundry/uaa/blob/master/model/src/main/java/org/cloudfoundry/identity/uaa/zone/IdentityZone.java) to get the mandatory fields
- Following the same approach I supposed the same entity was returned by the *UAA* [server](https://github.com/cloudfoundry/uaa/blob/master/server/src/main/java/org/cloudfoundry/identity/uaa/zone/IdentityZoneEndpoints.java)
- I implemented the test folowwing the same logic

As usual I will take any of your remarks. :smile: 