### PR TITLE
Update User Provided Service Instance

### DIFF
--- a/cloudfoundry-client-spring/src/main/lombok/org/cloudfoundry/spring/client/v2/userprovidedserviceinstances/SpringUserProvidedServiceInstances.java
+++ b/cloudfoundry-client-spring/src/main/lombok/org/cloudfoundry/spring/client/v2/userprovidedserviceinstances/SpringUserProvidedServiceInstances.java
@@ -26,6 +26,8 @@ import org.cloudfoundry.client.v2.userprovidedserviceinstances.ListUserProvidedS
 import org.cloudfoundry.client.v2.userprovidedserviceinstances.ListUserProvidedServiceInstanceServiceBindingsResponse;
 import org.cloudfoundry.client.v2.userprovidedserviceinstances.ListUserProvidedServiceInstancesRequest;
 import org.cloudfoundry.client.v2.userprovidedserviceinstances.ListUserProvidedServiceInstancesResponse;
+import org.cloudfoundry.client.v2.userprovidedserviceinstances.UpdateUserProvidedServiceInstanceRequest;
+import org.cloudfoundry.client.v2.userprovidedserviceinstances.UpdateUserProvidedServiceInstanceResponse;
 import org.cloudfoundry.client.v2.userprovidedserviceinstances.UserProvidedServiceInstances;
 import org.cloudfoundry.spring.client.v2.FilterBuilder;
 import org.cloudfoundry.spring.util.AbstractSpringOperations;
@@ -113,6 +115,18 @@ public final class SpringUserProvidedServiceInstances extends AbstractSpringOper
                 builder.pathSegment("v2", "user_provided_service_instances", request.getUserProvidedServiceInstanceId(), "service_bindings");
                 FilterBuilder.augment(builder, request);
                 QueryBuilder.augment(builder, request);
+            }
+
+        });
+    }
+
+    @Override
+    public Mono<UpdateUserProvidedServiceInstanceResponse> update(final UpdateUserProvidedServiceInstanceRequest request) {
+        return put(request, UpdateUserProvidedServiceInstanceResponse.class, new Consumer<UriComponentsBuilder>() {
+
+            @Override
+            public void accept(UriComponentsBuilder builder) {
+                builder.pathSegment("v2", "user_provided_service_instances", request.getUserProvidedServiceInstanceId());
             }
 
         });

--- a/cloudfoundry-client-spring/src/test/java/org/cloudfoundry/spring/client/v2/userprovidedserviceinstances/SpringUserProvidedServiceInstancesTest.java
+++ b/cloudfoundry-client-spring/src/test/java/org/cloudfoundry/spring/client/v2/userprovidedserviceinstances/SpringUserProvidedServiceInstancesTest.java
@@ -28,6 +28,8 @@ import org.cloudfoundry.client.v2.userprovidedserviceinstances.ListUserProvidedS
 import org.cloudfoundry.client.v2.userprovidedserviceinstances.ListUserProvidedServiceInstanceServiceBindingsResponse;
 import org.cloudfoundry.client.v2.userprovidedserviceinstances.ListUserProvidedServiceInstancesRequest;
 import org.cloudfoundry.client.v2.userprovidedserviceinstances.ListUserProvidedServiceInstancesResponse;
+import org.cloudfoundry.client.v2.userprovidedserviceinstances.UpdateUserProvidedServiceInstanceRequest;
+import org.cloudfoundry.client.v2.userprovidedserviceinstances.UpdateUserProvidedServiceInstanceResponse;
 import org.cloudfoundry.client.v2.userprovidedserviceinstances.UserProvidedServiceInstanceEntity;
 import org.cloudfoundry.client.v2.userprovidedserviceinstances.UserProvidedServiceInstanceResource;
 import org.cloudfoundry.spring.AbstractApiTest;
@@ -36,6 +38,8 @@ import reactor.core.publisher.Mono;
 import static org.springframework.http.HttpMethod.DELETE;
 import static org.springframework.http.HttpMethod.GET;
 import static org.springframework.http.HttpMethod.POST;
+import static org.springframework.http.HttpMethod.PUT;
+import static org.springframework.http.HttpStatus.ACCEPTED;
 import static org.springframework.http.HttpStatus.CREATED;
 import static org.springframework.http.HttpStatus.NO_CONTENT;
 import static org.springframework.http.HttpStatus.OK;
@@ -286,6 +290,59 @@ public final class SpringUserProvidedServiceInstancesTest {
         @Override
         protected Mono<ListUserProvidedServiceInstanceServiceBindingsResponse> invoke(ListUserProvidedServiceInstanceServiceBindingsRequest request) {
             return this.userProvidedServiceInstances.listServiceBindings(request);
+        }
+    }
+
+    public static final class Update extends AbstractApiTest<UpdateUserProvidedServiceInstanceRequest, UpdateUserProvidedServiceInstanceResponse> {
+
+        private final SpringUserProvidedServiceInstances userProvidedServiceInstances = new SpringUserProvidedServiceInstances(this.restTemplate, this.root, PROCESSOR_GROUP);
+
+        @Override
+        protected UpdateUserProvidedServiceInstanceRequest getInvalidRequest() {
+            return UpdateUserProvidedServiceInstanceRequest.builder().build();
+        }
+
+        @Override
+        protected RequestContext getRequestContext() {
+            return new RequestContext()
+                .method(PUT).path("/v2/user_provided_service_instances/e2c198b1-fa15-414e-a9a4-31537996b39d")
+                .requestPayload("client/v2/user_provided_service_instances/PUT_{id}_request.json")
+                .status(ACCEPTED)
+                .responsePayload("client/v2/user_provided_service_instances/PUT_{id}_response.json");
+        }
+
+        @Override
+        protected UpdateUserProvidedServiceInstanceResponse getResponse() {
+            return UpdateUserProvidedServiceInstanceResponse.builder()
+                .metadata(Resource.Metadata.builder()
+                    .createdAt("2016-02-19T02:04:06Z")
+                    .id("e2c198b1-fa15-414e-a9a4-31537996b39d")
+                    .updatedAt("2016-02-19T02:04:06Z")
+                    .url("/v2/user_provided_service_instances/e2c198b1-fa15-414e-a9a4-31537996b39d")
+                    .build())
+                .entity(UserProvidedServiceInstanceEntity.builder()
+                    .name("name-2565")
+                    .credential("somekey", "somenewvalue")
+                    .spaceId("438b5923-fe7a-4459-bbcd-a7c27332bad3")
+                    .type("user_provided_service_instance")
+                    .syslogDrainUrl("https://foo.com/url-91")
+                    .spaceUrl("/v2/spaces/438b5923-fe7a-4459-bbcd-a7c27332bad3")
+                    .serviceBindingsUrl("/v2/user_provided_service_instances/e2c198b1-fa15-414e-a9a4-31537996b39d/service_bindings")
+                    .build())
+                .build();
+        }
+
+        @Override
+        protected UpdateUserProvidedServiceInstanceRequest getValidRequest() throws Exception {
+            return UpdateUserProvidedServiceInstanceRequest.builder()
+                .credential("somekey", "somenewvalue")
+                .userProvidedServiceInstanceId("e2c198b1-fa15-414e-a9a4-31537996b39d")
+                .build();
+        }
+
+        @Override
+        protected Mono<UpdateUserProvidedServiceInstanceResponse> invoke(UpdateUserProvidedServiceInstanceRequest request) {
+            return this.userProvidedServiceInstances.update(request);
         }
     }
 

--- a/cloudfoundry-client-spring/src/test/resources/client/v2/user_provided_service_instances/PUT_{id}_request.json
+++ b/cloudfoundry-client-spring/src/test/resources/client/v2/user_provided_service_instances/PUT_{id}_request.json
@@ -1,0 +1,5 @@
+{
+  "credentials": {
+    "somekey": "somenewvalue"
+  }
+}

--- a/cloudfoundry-client-spring/src/test/resources/client/v2/user_provided_service_instances/PUT_{id}_response.json
+++ b/cloudfoundry-client-spring/src/test/resources/client/v2/user_provided_service_instances/PUT_{id}_response.json
@@ -1,0 +1,19 @@
+{
+  "metadata": {
+    "guid": "e2c198b1-fa15-414e-a9a4-31537996b39d",
+    "url": "/v2/user_provided_service_instances/e2c198b1-fa15-414e-a9a4-31537996b39d",
+    "created_at": "2016-02-19T02:04:06Z",
+    "updated_at": "2016-02-19T02:04:06Z"
+  },
+  "entity": {
+    "name": "name-2565",
+    "credentials": {
+      "somekey": "somenewvalue"
+    },
+    "space_guid": "438b5923-fe7a-4459-bbcd-a7c27332bad3",
+    "type": "user_provided_service_instance",
+    "syslog_drain_url": "https://foo.com/url-91",
+    "space_url": "/v2/spaces/438b5923-fe7a-4459-bbcd-a7c27332bad3",
+    "service_bindings_url": "/v2/user_provided_service_instances/e2c198b1-fa15-414e-a9a4-31537996b39d/service_bindings"
+  }
+}

--- a/cloudfoundry-client/src/main/java/org/cloudfoundry/client/v2/userprovidedserviceinstances/UserProvidedServiceInstances.java
+++ b/cloudfoundry-client/src/main/java/org/cloudfoundry/client/v2/userprovidedserviceinstances/UserProvidedServiceInstances.java
@@ -68,4 +68,12 @@ public interface UserProvidedServiceInstances {
      */
     Mono<ListUserProvidedServiceInstanceServiceBindingsResponse> listServiceBindings(ListUserProvidedServiceInstanceServiceBindingsRequest request);
 
+    /**
+     * Makes the <a href="http://apidocs.cloudfoundry.org/latest-release/user_provided_service_instances/updating_a_user_provided_service_instance.html">Update User Provided Service Instance</a> request
+     *
+     * @param request the Update User Provided Service Instance request
+     * @return the response from the Update User Provided Service Instance request
+     */
+    Mono<UpdateUserProvidedServiceInstanceResponse> update(UpdateUserProvidedServiceInstanceRequest request);
+
 }

--- a/cloudfoundry-client/src/main/lombok/org/cloudfoundry/client/v2/userprovidedserviceinstances/UpdateUserProvidedServiceInstanceRequest.java
+++ b/cloudfoundry-client/src/main/lombok/org/cloudfoundry/client/v2/userprovidedserviceinstances/UpdateUserProvidedServiceInstanceRequest.java
@@ -1,0 +1,95 @@
+/*
+ * Copyright 2013-2016 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.cloudfoundry.client.v2.userprovidedserviceinstances;
+
+
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.Singular;
+import org.cloudfoundry.Validatable;
+import org.cloudfoundry.ValidationResult;
+
+import java.util.Map;
+
+import static com.fasterxml.jackson.annotation.JsonInclude.Include.NON_EMPTY;
+
+/**
+ * The request payload for the Update User Provided Service Instance
+ */
+public final class UpdateUserProvidedServiceInstanceRequest implements Validatable {
+
+    /**
+     * Key/value pairs that can be stored to store credentials
+     *
+     * @return the credentials
+     */
+    @Getter(onMethod = @__({@JsonProperty("credentials"), @JsonInclude(NON_EMPTY)}))
+    private final Map<String, Object> credentials;
+
+    /**
+     * The name
+     *
+     * @param name the name
+     * @return the name
+     */
+    @Getter(onMethod = @__(@JsonProperty("name")))
+    private final String name;
+
+    /**
+     * The url for the syslog_drain to direct to
+     *
+     * @param syslogDrainUrl the syslog drain url
+     * @return the syslog drain url
+     */
+    @Getter(onMethod = @__(@JsonProperty("syslog_drain_url")))
+    private final String syslogDrainUrl;
+
+    /**
+     * The user provided service instance id
+     *
+     * @param userProvidedServiceInstanceId the user provided service instance id
+     * @return the user provided service instance id
+     */
+    @Getter(onMethod = @__(@JsonIgnore))
+    private final String userProvidedServiceInstanceId;
+
+    @Builder
+    UpdateUserProvidedServiceInstanceRequest(@Singular Map<String, Object> credentials,
+                                             String name,
+                                             String syslogDrainUrl,
+                                             String userProvidedServiceInstanceId) {
+        this.credentials = credentials;
+        this.name = name;
+        this.syslogDrainUrl = syslogDrainUrl;
+        this.userProvidedServiceInstanceId = userProvidedServiceInstanceId;
+    }
+
+    @Override
+    public ValidationResult isValid() {
+        ValidationResult.ValidationResultBuilder builder = ValidationResult.builder();
+
+        if (this.userProvidedServiceInstanceId == null) {
+            builder.message("user provided service instance id must be specified");
+        }
+
+        return builder.build();
+    }
+
+}

--- a/cloudfoundry-client/src/main/lombok/org/cloudfoundry/client/v2/userprovidedserviceinstances/UpdateUserProvidedServiceInstanceResponse.java
+++ b/cloudfoundry-client/src/main/lombok/org/cloudfoundry/client/v2/userprovidedserviceinstances/UpdateUserProvidedServiceInstanceResponse.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2013-2016 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.cloudfoundry.client.v2.userprovidedserviceinstances;
+
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.Builder;
+import lombok.Data;
+import lombok.EqualsAndHashCode;
+import lombok.ToString;
+import org.cloudfoundry.client.v2.Resource;
+
+/**
+ * The resource response payload for the Update User Provided Service Instance Response
+ */
+@Data
+@EqualsAndHashCode(callSuper = true)
+@ToString(callSuper = true)
+public final class UpdateUserProvidedServiceInstanceResponse extends Resource<UserProvidedServiceInstanceEntity> {
+
+    @Builder
+    UpdateUserProvidedServiceInstanceResponse(@JsonProperty("entity") UserProvidedServiceInstanceEntity entity,
+                                              @JsonProperty("metadata") Metadata metadata) {
+        super(entity, metadata);
+    }
+
+}

--- a/cloudfoundry-client/src/test/java/org/cloudfoundry/client/v2/userprovidedserviceinstances/UpdateUserProvidedServiceInstanceRequestTest.java
+++ b/cloudfoundry-client/src/test/java/org/cloudfoundry/client/v2/userprovidedserviceinstances/UpdateUserProvidedServiceInstanceRequestTest.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2013-2016 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.cloudfoundry.client.v2.userprovidedserviceinstances;
+
+import org.cloudfoundry.ValidationResult;
+import org.junit.Test;
+
+import static org.cloudfoundry.ValidationResult.Status.INVALID;
+import static org.cloudfoundry.ValidationResult.Status.VALID;
+import static org.junit.Assert.assertEquals;
+
+public class UpdateUserProvidedServiceInstanceRequestTest {
+
+    @Test
+    public void isNotValidNoId() {
+        ValidationResult result = UpdateUserProvidedServiceInstanceRequest.builder()
+            .build()
+            .isValid();
+
+        assertEquals(INVALID, result.getStatus());
+        assertEquals("user provided service instance id must be specified", result.getMessages().get(0));
+    }
+
+    @Test
+    public void isValid() {
+        ValidationResult result = UpdateUserProvidedServiceInstanceRequest.builder()
+            .userProvidedServiceInstanceId("test-id")
+            .build()
+            .isValid();
+
+        assertEquals(VALID, result.getStatus());
+    }
+
+}


### PR DESCRIPTION
This change adds the api to update a user provided service instance (```PUT /v2/user_provided_service_instances/:guid```)
See [this story](https://www.pivotaltracker.com/projects/816799/stories/101452068)

@nebhale : Few remarks
- I assumed [documentation](http://apidocs.cloudfoundry.org/231/user_provided_service_instances/updating_a_user_provided_service_instance.html) contained errors on two points: ```name``` is not mandatory and response status code is ```ACCEPTED``` instead of ```CREATED```
- I caught sight of the creation/update parameter ```route_service_url``` that leads to two response attributes ```route_service_url``` and ```route_url```. It is fixed in #407 
