### PR TITLE
Feature add route support to User Provided Service Instances

### DIFF
--- a/cloudfoundry-client-spring/src/test/java/org/cloudfoundry/spring/client/v2/userprovidedserviceinstances/SpringUserProvidedServiceInstancesTest.java
+++ b/cloudfoundry-client-spring/src/test/java/org/cloudfoundry/spring/client/v2/userprovidedserviceinstances/SpringUserProvidedServiceInstancesTest.java
@@ -78,8 +78,10 @@ public final class SpringUserProvidedServiceInstancesTest {
                     .spaceId("0d45d43f-7d50-43c6-9981-b32ce8d5a373")
                     .type("user_provided_service_instance")
                     .syslogDrainUrl("syslog://example.com")
+                    .routeServiceUrl("https://logger.example.com")
                     .spaceUrl("/v2/spaces/0d45d43f-7d50-43c6-9981-b32ce8d5a373")
                     .serviceBindingsUrl("/v2/user_provided_service_instances/34d5500e-712d-49ef-8bbe-c9ac349532da/service_bindings")
+                    .routesUrl("/v2/user_provided_service_instances/34d5500e-712d-49ef-8bbe-c9ac349532da/routes")
                     .build())
                 .build();
         }
@@ -90,6 +92,7 @@ public final class SpringUserProvidedServiceInstancesTest {
                 .spaceId("0d45d43f-7d50-43c6-9981-b32ce8d5a373")
                 .name("my-user-provided-instance")
                 .credential("somekey", "somevalue")
+                .routeServiceUrl("https://logger.example.com")
                 .syslogDrainUrl("syslog://example.com")
                 .build();
         }
@@ -167,6 +170,7 @@ public final class SpringUserProvidedServiceInstancesTest {
                     .syslogDrainUrl("https://foo.com/url-89")
                     .spaceUrl("/v2/spaces/cebb3962-4e5b-4204-b117-3140ec4a62d9")
                     .serviceBindingsUrl("/v2/user_provided_service_instances/8c12fd06-6639-4844-b5e7-a6831cadbbcc/service_bindings")
+                    .routesUrl("/v2/user_provided_service_instances/8c12fd06-6639-4844-b5e7-a6831cadbbcc/routes")
                     .build())
                 .build();
         }
@@ -220,6 +224,7 @@ public final class SpringUserProvidedServiceInstancesTest {
                         .syslogDrainUrl("https://foo.com/url-90")
                         .spaceUrl("/v2/spaces/2fff6e71-d329-4991-9c89-7fa8abca70df")
                         .serviceBindingsUrl("/v2/user_provided_service_instances/8db6d37b-1ca8-4d0a-b1d3-2a6aaceae866/service_bindings")
+                        .routesUrl("/v2/user_provided_service_instances/8db6d37b-1ca8-4d0a-b1d3-2a6aaceae866/routes")
                         .build())
                     .build())
                 .build();
@@ -328,6 +333,7 @@ public final class SpringUserProvidedServiceInstancesTest {
                     .syslogDrainUrl("https://foo.com/url-91")
                     .spaceUrl("/v2/spaces/438b5923-fe7a-4459-bbcd-a7c27332bad3")
                     .serviceBindingsUrl("/v2/user_provided_service_instances/e2c198b1-fa15-414e-a9a4-31537996b39d/service_bindings")
+                    .routesUrl("/v2/user_provided_service_instances/e2c198b1-fa15-414e-a9a4-31537996b39d/routes")
                     .build())
                 .build();
         }

--- a/cloudfoundry-client-spring/src/test/resources/client/v2/user_provided_service_instances/GET_response.json
+++ b/cloudfoundry-client-spring/src/test/resources/client/v2/user_provided_service_instances/GET_response.json
@@ -19,8 +19,10 @@
         "space_guid": "2fff6e71-d329-4991-9c89-7fa8abca70df",
         "type": "user_provided_service_instance",
         "syslog_drain_url": "https://foo.com/url-90",
+        "route_service_url": null,
         "space_url": "/v2/spaces/2fff6e71-d329-4991-9c89-7fa8abca70df",
-        "service_bindings_url": "/v2/user_provided_service_instances/8db6d37b-1ca8-4d0a-b1d3-2a6aaceae866/service_bindings"
+        "service_bindings_url": "/v2/user_provided_service_instances/8db6d37b-1ca8-4d0a-b1d3-2a6aaceae866/service_bindings",
+        "routes_url": "/v2/user_provided_service_instances/8db6d37b-1ca8-4d0a-b1d3-2a6aaceae866/routes"
       }
     }
   ]

--- a/cloudfoundry-client-spring/src/test/resources/client/v2/user_provided_service_instances/GET_{id}_response.json
+++ b/cloudfoundry-client-spring/src/test/resources/client/v2/user_provided_service_instances/GET_{id}_response.json
@@ -13,7 +13,9 @@
     "space_guid": "cebb3962-4e5b-4204-b117-3140ec4a62d9",
     "type": "user_provided_service_instance",
     "syslog_drain_url": "https://foo.com/url-89",
+    "route_service_url": null,
     "space_url": "/v2/spaces/cebb3962-4e5b-4204-b117-3140ec4a62d9",
-    "service_bindings_url": "/v2/user_provided_service_instances/8c12fd06-6639-4844-b5e7-a6831cadbbcc/service_bindings"
+    "service_bindings_url": "/v2/user_provided_service_instances/8c12fd06-6639-4844-b5e7-a6831cadbbcc/service_bindings",
+    "routes_url": "/v2/user_provided_service_instances/8c12fd06-6639-4844-b5e7-a6831cadbbcc/routes"
   }
 }

--- a/cloudfoundry-client-spring/src/test/resources/client/v2/user_provided_service_instances/POST_request.json
+++ b/cloudfoundry-client-spring/src/test/resources/client/v2/user_provided_service_instances/POST_request.json
@@ -4,5 +4,6 @@
   },
   "name": "my-user-provided-instance",
   "space_guid": "0d45d43f-7d50-43c6-9981-b32ce8d5a373",
-  "syslog_drain_url": "syslog://example.com"
+  "syslog_drain_url": "syslog://example.com",
+  "route_service_url": "https://logger.example.com"
 }

--- a/cloudfoundry-client-spring/src/test/resources/client/v2/user_provided_service_instances/POST_response.json
+++ b/cloudfoundry-client-spring/src/test/resources/client/v2/user_provided_service_instances/POST_response.json
@@ -13,7 +13,9 @@
     "space_guid": "0d45d43f-7d50-43c6-9981-b32ce8d5a373",
     "type": "user_provided_service_instance",
     "syslog_drain_url": "syslog://example.com",
+    "route_service_url": "https://logger.example.com",
     "space_url": "/v2/spaces/0d45d43f-7d50-43c6-9981-b32ce8d5a373",
-    "service_bindings_url": "/v2/user_provided_service_instances/34d5500e-712d-49ef-8bbe-c9ac349532da/service_bindings"
+    "service_bindings_url": "/v2/user_provided_service_instances/34d5500e-712d-49ef-8bbe-c9ac349532da/service_bindings",
+    "routes_url": "/v2/user_provided_service_instances/34d5500e-712d-49ef-8bbe-c9ac349532da/routes"
   }
 }

--- a/cloudfoundry-client-spring/src/test/resources/client/v2/user_provided_service_instances/PUT_{id}_response.json
+++ b/cloudfoundry-client-spring/src/test/resources/client/v2/user_provided_service_instances/PUT_{id}_response.json
@@ -13,7 +13,9 @@
     "space_guid": "438b5923-fe7a-4459-bbcd-a7c27332bad3",
     "type": "user_provided_service_instance",
     "syslog_drain_url": "https://foo.com/url-91",
+    "route_service_url": null,
     "space_url": "/v2/spaces/438b5923-fe7a-4459-bbcd-a7c27332bad3",
-    "service_bindings_url": "/v2/user_provided_service_instances/e2c198b1-fa15-414e-a9a4-31537996b39d/service_bindings"
+    "service_bindings_url": "/v2/user_provided_service_instances/e2c198b1-fa15-414e-a9a4-31537996b39d/service_bindings",
+    "routes_url": "/v2/user_provided_service_instances/e2c198b1-fa15-414e-a9a4-31537996b39d/routes"
   }
 }

--- a/cloudfoundry-client/src/main/lombok/org/cloudfoundry/client/v2/userprovidedserviceinstances/CreateUserProvidedServiceInstanceRequest.java
+++ b/cloudfoundry-client/src/main/lombok/org/cloudfoundry/client/v2/userprovidedserviceinstances/CreateUserProvidedServiceInstanceRequest.java
@@ -53,6 +53,15 @@ public final class CreateUserProvidedServiceInstanceRequest implements Validatab
     private final String name;
 
     /**
+     * URL to which requests for bound routes will be forwarded
+     *
+     * @param routeServiceUrl the route service url
+     * @return the route service url
+     */
+    @Getter(onMethod = @__(@JsonProperty("route_service_url")))
+    private final String routeServiceUrl;
+
+    /**
      * The space id
      *
      * @param spaceId the space id
@@ -73,10 +82,12 @@ public final class CreateUserProvidedServiceInstanceRequest implements Validatab
     @Builder
     CreateUserProvidedServiceInstanceRequest(@Singular Map<String, Object> credentials,
                                              String name,
+                                             String routeServiceUrl,
                                              String spaceId,
                                              String syslogDrainUrl) {
         this.credentials = credentials;
         this.name = name;
+        this.routeServiceUrl = routeServiceUrl;
         this.spaceId = spaceId;
         this.syslogDrainUrl = syslogDrainUrl;
     }

--- a/cloudfoundry-client/src/main/lombok/org/cloudfoundry/client/v2/userprovidedserviceinstances/UpdateUserProvidedServiceInstanceRequest.java
+++ b/cloudfoundry-client/src/main/lombok/org/cloudfoundry/client/v2/userprovidedserviceinstances/UpdateUserProvidedServiceInstanceRequest.java
@@ -53,6 +53,15 @@ public final class UpdateUserProvidedServiceInstanceRequest implements Validatab
     private final String name;
 
     /**
+     * URL to which requests for bound routes will be forwarded
+     *
+     * @param routeServiceUrl the route service url
+     * @return the route service url
+     */
+    @Getter(onMethod = @__(@JsonProperty("route_service_url")))
+    private final String routeServiceUrl;
+
+    /**
      * The url for the syslog_drain to direct to
      *
      * @param syslogDrainUrl the syslog drain url
@@ -73,10 +82,12 @@ public final class UpdateUserProvidedServiceInstanceRequest implements Validatab
     @Builder
     UpdateUserProvidedServiceInstanceRequest(@Singular Map<String, Object> credentials,
                                              String name,
+                                             String routeServiceUrl,
                                              String syslogDrainUrl,
                                              String userProvidedServiceInstanceId) {
         this.credentials = credentials;
         this.name = name;
+        this.routeServiceUrl = routeServiceUrl;
         this.syslogDrainUrl = syslogDrainUrl;
         this.userProvidedServiceInstanceId = userProvidedServiceInstanceId;
     }

--- a/cloudfoundry-client/src/main/lombok/org/cloudfoundry/client/v2/userprovidedserviceinstances/UserProvidedServiceInstanceEntity.java
+++ b/cloudfoundry-client/src/main/lombok/org/cloudfoundry/client/v2/userprovidedserviceinstances/UserProvidedServiceInstanceEntity.java
@@ -47,6 +47,22 @@ public final class UserProvidedServiceInstanceEntity {
     private final String name;
 
     /**
+     * URL to which requests for bound routes will be forwarded
+     *
+     * @param routeServiceUrl the route service url
+     * @return the route service url
+     */
+    private final String routeServiceUrl;
+
+    /**
+     * The routes url
+     *
+     * @param routesUrl the routes url
+     * @return the routes url
+     */
+    private final String routesUrl;
+
+    /**
      * The service bindings url
      *
      * @param serviceBindingsUrl the service bindings url
@@ -89,6 +105,8 @@ public final class UserProvidedServiceInstanceEntity {
     @Builder
     UserProvidedServiceInstanceEntity(@JsonProperty("credentials") @Singular Map<String, Object> credentials,
                                       @JsonProperty("name") String name,
+                                      @JsonProperty("route_service_url") String routeServiceUrl,
+                                      @JsonProperty("routes_url") String routesUrl,
                                       @JsonProperty("service_bindings_url") String serviceBindingsUrl,
                                       @JsonProperty("space_guid") String spaceId,
                                       @JsonProperty("space_url") String spaceUrl,
@@ -96,6 +114,8 @@ public final class UserProvidedServiceInstanceEntity {
                                       @JsonProperty("type") String type) {
         this.credentials = credentials;
         this.name = name;
+        this.routeServiceUrl = routeServiceUrl;
+        this.routesUrl = routesUrl;
         this.serviceBindingsUrl = serviceBindingsUrl;
         this.spaceId = spaceId;
         this.spaceUrl = spaceUrl;

--- a/cloudfoundry-client/src/test/java/org/cloudfoundry/client/v2/userprovidedserviceinstances/GetUserProvidedServiceInstanceRequestTest.java
+++ b/cloudfoundry-client/src/test/java/org/cloudfoundry/client/v2/userprovidedserviceinstances/GetUserProvidedServiceInstanceRequestTest.java
@@ -26,6 +26,16 @@ import static org.junit.Assert.assertEquals;
 public final class GetUserProvidedServiceInstanceRequestTest {
 
     @Test
+    public void isNotValidNoId() {
+        ValidationResult result = GetUserProvidedServiceInstanceRequest.builder()
+            .build()
+            .isValid();
+
+        assertEquals(INVALID, result.getStatus());
+        assertEquals("user provided service instance id must be specified", result.getMessages().get(0));
+    }
+
+    @Test
     public void isValid() {
         ValidationResult result = GetUserProvidedServiceInstanceRequest.builder()
             .userProvidedServiceInstanceId("test-user-provided-service-instance-id")
@@ -33,16 +43,6 @@ public final class GetUserProvidedServiceInstanceRequestTest {
             .isValid();
 
         assertEquals(VALID, result.getStatus());
-    }
-
-    @Test
-    public void isValidNoId() {
-        ValidationResult result = GetUserProvidedServiceInstanceRequest.builder()
-            .build()
-            .isValid();
-
-        assertEquals(INVALID, result.getStatus());
-        assertEquals("user provided service instance id must be specified", result.getMessages().get(0));
     }
 
 }


### PR DESCRIPTION
Add support for:
- ```route_service_url```: in ```POST``` and ```PUT``` requests
- ```route_service_url``` and ```routes_url``` in all returned entity response

:warning: do not merge this code before #406 