### PR TITLE
Get Identity Zone

### DIFF
--- a/cloudfoundry-client-spring/src/main/lombok/org/cloudfoundry/spring/uaa/identityzonemanagement/SpringIdentityZoneManagement.java
+++ b/cloudfoundry-client-spring/src/main/lombok/org/cloudfoundry/spring/uaa/identityzonemanagement/SpringIdentityZoneManagement.java
@@ -20,6 +20,8 @@ import lombok.ToString;
 import org.cloudfoundry.spring.util.AbstractSpringOperations;
 import org.cloudfoundry.uaa.identityzonemanagement.CreateIdentityZoneRequest;
 import org.cloudfoundry.uaa.identityzonemanagement.CreateIdentityZoneResponse;
+import org.cloudfoundry.uaa.identityzonemanagement.GetIdentityZoneRequest;
+import org.cloudfoundry.uaa.identityzonemanagement.GetIdentityZoneResponse;
 import org.cloudfoundry.uaa.identityzonemanagement.IdentityZoneManagement;
 import org.springframework.web.client.RestOperations;
 import org.springframework.web.util.UriComponentsBuilder;
@@ -58,4 +60,16 @@ public final class SpringIdentityZoneManagement extends AbstractSpringOperations
         });
     }
 
+    @Override
+    public Mono<GetIdentityZoneResponse> get(final GetIdentityZoneRequest request) {
+        return get(request, GetIdentityZoneResponse.class, new Consumer<UriComponentsBuilder>() {
+
+            @Override
+            public void accept(UriComponentsBuilder builder) {
+                builder.pathSegment("identity-zones", request.getIdentityZoneId());
+            }
+
+        });
+    }
+    
 }

--- a/cloudfoundry-client-spring/src/test/java/org/cloudfoundry/spring/uaa/identityzonemanagement/SpringIdentityZoneManagementTest.java
+++ b/cloudfoundry-client-spring/src/test/java/org/cloudfoundry/spring/uaa/identityzonemanagement/SpringIdentityZoneManagementTest.java
@@ -19,10 +19,16 @@ package org.cloudfoundry.spring.uaa.identityzonemanagement;
 import org.cloudfoundry.spring.AbstractApiTest;
 import org.cloudfoundry.uaa.identityzonemanagement.CreateIdentityZoneRequest;
 import org.cloudfoundry.uaa.identityzonemanagement.CreateIdentityZoneResponse;
+import org.cloudfoundry.uaa.identityzonemanagement.GetIdentityZoneRequest;
+import org.cloudfoundry.uaa.identityzonemanagement.GetIdentityZoneResponse;
 import reactor.core.publisher.Mono;
 
+import java.util.Date;
+
+import static org.springframework.http.HttpMethod.GET;
 import static org.springframework.http.HttpMethod.POST;
 import static org.springframework.http.HttpStatus.CREATED;
+import static org.springframework.http.HttpStatus.OK;
 
 public final class SpringIdentityZoneManagementTest {
 
@@ -47,7 +53,7 @@ public final class SpringIdentityZoneManagementTest {
         @Override
         protected CreateIdentityZoneResponse getResponse() {
             return CreateIdentityZoneResponse.builder()
-                .createdAt("2015-07-27T22:43:20Z")
+                .createdAt(1426258488910L)
                 .description("Like the Twilight Zone but tastier[testzone1].")
                 .identityZoneId("testzone1")
                 .name("The Twiglet Zone[testzone1]")
@@ -69,6 +75,49 @@ public final class SpringIdentityZoneManagementTest {
         @Override
         protected Mono<CreateIdentityZoneResponse> invoke(CreateIdentityZoneRequest request) {
             return this.identityZoneManagement.create(request);
+        }
+    }
+
+    public static final class Get extends AbstractApiTest<GetIdentityZoneRequest, GetIdentityZoneResponse> {
+
+        private final SpringIdentityZoneManagement identityZoneManagement = new SpringIdentityZoneManagement(this.restTemplate, this.root, PROCESSOR_GROUP);
+
+        @Override
+        protected GetIdentityZoneRequest getInvalidRequest() {
+            return GetIdentityZoneRequest.builder().build();
+        }
+
+        @Override
+        protected RequestContext getRequestContext() {
+            return new RequestContext()
+                .method(GET).path("/identity-zones/identity-zone-id")
+                .status(OK)
+                .responsePayload("uaa/identity-zones/GET_{id}_response.json");
+        }
+
+        @Override
+        protected GetIdentityZoneResponse getResponse() {
+            return GetIdentityZoneResponse.builder()
+                .createdAt(946710000000L)
+                .description("The test zone")
+                .identityZoneId("identity-zone-id")
+                .name("test")
+                .subDomain("test")
+                .updatedAt(946710000000L)
+                .version(0)
+                .build();
+        }
+
+        @Override
+        protected GetIdentityZoneRequest getValidRequest() throws Exception {
+            return GetIdentityZoneRequest.builder()
+                .identityZoneId("identity-zone-id")
+                .build();
+        }
+
+        @Override
+        protected Mono<GetIdentityZoneResponse> invoke(GetIdentityZoneRequest request) {
+            return this.identityZoneManagement.get(request);
         }
     }
 

--- a/cloudfoundry-client-spring/src/test/resources/uaa/identity-zones/GET_{id}_response.json
+++ b/cloudfoundry-client-spring/src/test/resources/uaa/identity-zones/GET_{id}_response.json
@@ -1,0 +1,9 @@
+{
+  "id": "identity-zone-id",
+  "subdomain": "test",
+  "name": "test",
+  "version": 0,
+  "description": "The test zone",
+  "created": 946710000000,
+  "last_modified": 946710000000
+}

--- a/cloudfoundry-client-spring/src/test/resources/uaa/identity-zones/POST_response.json
+++ b/cloudfoundry-client-spring/src/test/resources/uaa/identity-zones/POST_response.json
@@ -1,5 +1,5 @@
 {
-  "created": "2015-07-27T22:43:20Z",
+  "created": 1426258488910,
   "description": "Like the Twilight Zone but tastier[testzone1].",
   "id": "testzone1",
   "last_modified": null,

--- a/cloudfoundry-client/src/main/java/org/cloudfoundry/uaa/identityzonemanagement/IdentityZoneManagement.java
+++ b/cloudfoundry-client/src/main/java/org/cloudfoundry/uaa/identityzonemanagement/IdentityZoneManagement.java
@@ -31,4 +31,12 @@ public interface IdentityZoneManagement {
      */
     Mono<CreateIdentityZoneResponse> create(CreateIdentityZoneRequest request);
 
+    /**
+     * Makes the <a href="https://github.com/cloudfoundry/uaa/blob/master/docs/UAA-APIs.rst#get-single-identity-zone-get-identity-zones-identityzoneid">Get Identity Zone</a> request
+     *
+     * @param request the Get Identity Zone request
+     * @return the response from the Get Identity Zone request
+     */
+    Mono<GetIdentityZoneResponse> get(GetIdentityZoneRequest request);
+
 }

--- a/cloudfoundry-client/src/main/lombok/org/cloudfoundry/uaa/identityzonemanagement/GetIdentityZoneRequest.java
+++ b/cloudfoundry-client/src/main/lombok/org/cloudfoundry/uaa/identityzonemanagement/GetIdentityZoneRequest.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright 2013-2016 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.cloudfoundry.uaa.identityzonemanagement;
+
+
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import lombok.Builder;
+import lombok.Data;
+import lombok.Getter;
+import org.cloudfoundry.Validatable;
+import org.cloudfoundry.ValidationResult;
+
+/**
+ * The request payload for the Get Identity Zone operation
+ */
+@Data
+public final class GetIdentityZoneRequest implements Validatable {
+
+    /**
+     * The identity zone id
+     *
+     * @param identityZoneId the identity zone id
+     * @return the identity zone id
+     */
+    @Getter(onMethod = @__(@JsonIgnore))
+    private final String identityZoneId;
+
+    @Builder
+    GetIdentityZoneRequest(String identityZoneId) {
+        this.identityZoneId = identityZoneId;
+    }
+
+    @Override
+    public ValidationResult isValid() {
+        ValidationResult.ValidationResultBuilder builder = ValidationResult.builder();
+
+        if (this.identityZoneId == null) {
+            builder.message("identity zone id must be specified");
+        }
+
+        return builder.build();
+    }
+
+}

--- a/cloudfoundry-client/src/main/lombok/org/cloudfoundry/uaa/identityzonemanagement/GetIdentityZoneResponse.java
+++ b/cloudfoundry-client/src/main/lombok/org/cloudfoundry/uaa/identityzonemanagement/GetIdentityZoneResponse.java
@@ -23,21 +23,21 @@ import lombok.EqualsAndHashCode;
 import lombok.ToString;
 
 /**
- * The response from the create identity zone request
+ * The resource response payload for the Get Identity Zone Response
  */
 @Data
 @EqualsAndHashCode(callSuper = true)
 @ToString(callSuper = true)
-public final class CreateIdentityZoneResponse extends IdentityZoneEntity {
+public final class GetIdentityZoneResponse extends IdentityZoneEntity {
 
     @Builder
-    CreateIdentityZoneResponse(@JsonProperty("created") Long createdAt,
-                               @JsonProperty("description") String description,
-                               @JsonProperty("id") String identityZoneId,
-                               @JsonProperty("name") String name,
-                               @JsonProperty("subdomain") String subDomain,
-                               @JsonProperty("last_modified") Long updatedAt,
-                               @JsonProperty("version") Integer version) {
+    GetIdentityZoneResponse(@JsonProperty("created") Long createdAt,
+                            @JsonProperty("description") String description,
+                            @JsonProperty("id") String identityZoneId,
+                            @JsonProperty("name") String name,
+                            @JsonProperty("subdomain") String subDomain,
+                            @JsonProperty("last_modified") Long updatedAt,
+                            @JsonProperty("version") Integer version) {
         super(createdAt, description, identityZoneId, name, subDomain, updatedAt, version);
     }
 

--- a/cloudfoundry-client/src/main/lombok/org/cloudfoundry/uaa/identityzonemanagement/IdentityZoneEntity.java
+++ b/cloudfoundry-client/src/main/lombok/org/cloudfoundry/uaa/identityzonemanagement/IdentityZoneEntity.java
@@ -31,7 +31,7 @@ public class IdentityZoneEntity {
      * @param createdAt the creation date
      * @return the creation date
      */
-    private final String createdAt;
+    private final Long createdAt;
 
     /**
      * The description of the identity zone.
@@ -71,7 +71,7 @@ public class IdentityZoneEntity {
      * @param updatedAt the last modification date
      * @return the last modification date
      */
-    private final String updatedAt;
+    private final Long updatedAt;
 
     /**
      * The version of the identity zone.
@@ -81,12 +81,12 @@ public class IdentityZoneEntity {
      */
     private final Integer version;
 
-    protected IdentityZoneEntity(@JsonProperty("created") String createdAt,
+    protected IdentityZoneEntity(@JsonProperty("created") Long createdAt,
                                  @JsonProperty("description") String description,
                                  @JsonProperty("id") String identityZoneId,
                                  @JsonProperty("name") String name,
                                  @JsonProperty("subdomain") String subDomain,
-                                 @JsonProperty("last_modified") String updatedAt,
+                                 @JsonProperty("last_modified") Long updatedAt,
                                  @JsonProperty("version") Integer version) {
         this.createdAt = createdAt;
         this.description = description;

--- a/cloudfoundry-client/src/test/java/org/cloudfoundry/uaa/identityzonemanagement/GetIdentityZoneRequestTest.java
+++ b/cloudfoundry-client/src/test/java/org/cloudfoundry/uaa/identityzonemanagement/GetIdentityZoneRequestTest.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2013-2016 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.cloudfoundry.uaa.identityzonemanagement;
+
+import org.cloudfoundry.ValidationResult;
+import org.junit.Test;
+
+import static org.cloudfoundry.ValidationResult.Status.INVALID;
+import static org.cloudfoundry.ValidationResult.Status.VALID;
+import static org.junit.Assert.assertEquals;
+
+public final class GetIdentityZoneRequestTest {
+
+    @Test
+    public void isNotValidNoId() {
+        ValidationResult result = GetIdentityZoneRequest.builder()
+            .build()
+            .isValid();
+
+        assertEquals(INVALID, result.getStatus());
+        assertEquals("identity zone id must be specified", result.getMessages().get(0));
+    }
+
+    @Test
+    public void isValid() {
+        ValidationResult result = GetIdentityZoneRequest.builder()
+            .identityZoneId("test-identity-zone-id")
+            .build()
+            .isValid();
+
+        assertEquals(VALID, result.getStatus());
+    }
+
+}


### PR DESCRIPTION
this change adds the api to get an identity zone (```GET /identity-zones/{identityZoneId}```)
See [this story](https://www.pivotaltracker.com/projects/816799/stories/114245231)
@nebhale : caught sight of that date were not JSON string but timestamp in ```IdentityZoneEntity```. Typed them as ```java.util.Date```