### PR TITLE
Delete Identity Zone

### DIFF
--- a/cloudfoundry-client-spring/src/main/lombok/org/cloudfoundry/spring/uaa/identityzonemanagement/SpringIdentityZoneManagement.java
+++ b/cloudfoundry-client-spring/src/main/lombok/org/cloudfoundry/spring/uaa/identityzonemanagement/SpringIdentityZoneManagement.java
@@ -20,6 +20,8 @@ import lombok.ToString;
 import org.cloudfoundry.spring.util.AbstractSpringOperations;
 import org.cloudfoundry.uaa.identityzonemanagement.CreateIdentityZoneRequest;
 import org.cloudfoundry.uaa.identityzonemanagement.CreateIdentityZoneResponse;
+import org.cloudfoundry.uaa.identityzonemanagement.DeleteIdentityZoneRequest;
+import org.cloudfoundry.uaa.identityzonemanagement.DeleteIdentityZoneResponse;
 import org.cloudfoundry.uaa.identityzonemanagement.GetIdentityZoneRequest;
 import org.cloudfoundry.uaa.identityzonemanagement.GetIdentityZoneResponse;
 import org.cloudfoundry.uaa.identityzonemanagement.IdentityZoneManagement;
@@ -49,8 +51,13 @@ public final class SpringIdentityZoneManagement extends AbstractSpringOperations
     }
 
     @Override
-    public Mono<CreateIdentityZoneResponse> create(CreateIdentityZoneRequest request) {
+    public Mono<CreateIdentityZoneResponse> create(final CreateIdentityZoneRequest request) {
         return post(request, CreateIdentityZoneResponse.class, builder -> builder.pathSegment("identity-zones"));
+    }
+
+    @Override
+    public Mono<DeleteIdentityZoneResponse> delete(final DeleteIdentityZoneRequest request) {
+        return delete(request, DeleteIdentityZoneResponse.class, builder -> builder.pathSegment("identity-zones", request.getIdentityZoneId()));
     }
 
     @Override

--- a/cloudfoundry-client-spring/src/test/java/org/cloudfoundry/spring/uaa/identityzonemanagement/SpringIdentityZoneManagementTest.java
+++ b/cloudfoundry-client-spring/src/test/java/org/cloudfoundry/spring/uaa/identityzonemanagement/SpringIdentityZoneManagementTest.java
@@ -19,6 +19,8 @@ package org.cloudfoundry.spring.uaa.identityzonemanagement;
 import org.cloudfoundry.spring.AbstractApiTest;
 import org.cloudfoundry.uaa.identityzonemanagement.CreateIdentityZoneRequest;
 import org.cloudfoundry.uaa.identityzonemanagement.CreateIdentityZoneResponse;
+import org.cloudfoundry.uaa.identityzonemanagement.DeleteIdentityZoneRequest;
+import org.cloudfoundry.uaa.identityzonemanagement.DeleteIdentityZoneResponse;
 import org.cloudfoundry.uaa.identityzonemanagement.GetIdentityZoneRequest;
 import org.cloudfoundry.uaa.identityzonemanagement.GetIdentityZoneResponse;
 import org.cloudfoundry.uaa.identityzonemanagement.IdentityZone;
@@ -26,6 +28,7 @@ import org.cloudfoundry.uaa.identityzonemanagement.ListIdentityZoneRequest;
 import org.cloudfoundry.uaa.identityzonemanagement.ListIdentityZoneResponse;
 import reactor.core.publisher.Mono;
 
+import static org.springframework.http.HttpMethod.DELETE;
 import static org.springframework.http.HttpMethod.GET;
 import static org.springframework.http.HttpMethod.POST;
 import static org.springframework.http.HttpStatus.CREATED;
@@ -78,6 +81,50 @@ public final class SpringIdentityZoneManagementTest {
             return this.identityZoneManagement.create(request);
         }
     }
+
+    public static final class Delete extends AbstractApiTest<DeleteIdentityZoneRequest, DeleteIdentityZoneResponse> {
+
+        private final SpringIdentityZoneManagement identityZoneManagement = new SpringIdentityZoneManagement(this.restTemplate, this.root, PROCESSOR_GROUP);
+
+        @Override
+        protected DeleteIdentityZoneRequest getInvalidRequest() {
+            return DeleteIdentityZoneRequest.builder().build();
+        }
+
+        @Override
+        protected RequestContext getRequestContext() {
+            return new RequestContext()
+                .method(DELETE).path("/identity-zones/identity-zone-id")
+                .status(OK)
+                .responsePayload("fixtures/uaa/identity-zones/DELETE_{id}_response.json");
+        }
+
+        @Override
+        protected DeleteIdentityZoneResponse getResponse() {
+            return DeleteIdentityZoneResponse.builder()
+                .createdAt(946710000000L)
+                .description("The test zone")
+                .identityZoneId("identity-zone-id")
+                .name("test")
+                .subDomain("test")
+                .updatedAt(946710000000L)
+                .version(0)
+                .build();
+        }
+
+        @Override
+        protected DeleteIdentityZoneRequest getValidRequest() throws Exception {
+            return DeleteIdentityZoneRequest.builder()
+                .identityZoneId("identity-zone-id")
+                .build();
+        }
+
+        @Override
+        protected Mono<DeleteIdentityZoneResponse> invoke(DeleteIdentityZoneRequest request) {
+            return this.identityZoneManagement.delete(request);
+        }
+    }
+
 
     public static final class Get extends AbstractApiTest<GetIdentityZoneRequest, GetIdentityZoneResponse> {
 

--- a/cloudfoundry-client-spring/src/test/resources/fixtures/uaa/identity-zones/DELETE_{id}_response.json
+++ b/cloudfoundry-client-spring/src/test/resources/fixtures/uaa/identity-zones/DELETE_{id}_response.json
@@ -1,0 +1,9 @@
+{
+  "id": "identity-zone-id",
+  "subdomain": "test",
+  "name": "test",
+  "version": 0,
+  "description": "The test zone",
+  "created": 946710000000,
+  "last_modified": 946710000000
+}

--- a/cloudfoundry-client/src/main/java/org/cloudfoundry/uaa/identityzonemanagement/IdentityZoneManagement.java
+++ b/cloudfoundry-client/src/main/java/org/cloudfoundry/uaa/identityzonemanagement/IdentityZoneManagement.java
@@ -32,6 +32,14 @@ public interface IdentityZoneManagement {
     Mono<CreateIdentityZoneResponse> create(CreateIdentityZoneRequest request);
 
     /**
+     * Makes the <a href="https://github.com/cloudfoundry/uaa/blob/master/docs/UAA-APIs.rst#delete-single-identity-zone-delete-identity-zones-identityzoneid">Delete the Identity Zone</a> request
+     *
+     * @param request the Delete Identity Zone request
+     * @return the response from the Delete Identity Zone request
+     */
+    Mono<DeleteIdentityZoneResponse> delete(DeleteIdentityZoneRequest request);
+
+    /**
      * Makes the <a href="https://github.com/cloudfoundry/uaa/blob/master/docs/UAA-APIs.rst#get-single-identity-zone-get-identity-zones-identityzoneid">Get Identity Zone</a> request
      *
      * @param request the Get Identity Zone request

--- a/cloudfoundry-client/src/main/lombok/org/cloudfoundry/uaa/identityzonemanagement/DeleteIdentityZoneRequest.java
+++ b/cloudfoundry-client/src/main/lombok/org/cloudfoundry/uaa/identityzonemanagement/DeleteIdentityZoneRequest.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright 2013-2016 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.cloudfoundry.uaa.identityzonemanagement;
+
+
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import lombok.Builder;
+import lombok.Data;
+import lombok.Getter;
+import org.cloudfoundry.Validatable;
+import org.cloudfoundry.ValidationResult;
+
+/**
+ * The request payload for the Delete Identity Zone operation
+ */
+@Data
+public final class DeleteIdentityZoneRequest implements Validatable {
+
+    /**
+     * The identity zone id
+     *
+     * @param identityZoneId the identity zone id
+     * @return the identity zone id
+     */
+    @Getter(onMethod = @__(@JsonIgnore))
+    private final String identityZoneId;
+
+    @Builder
+    DeleteIdentityZoneRequest(String identityZoneId) {
+        this.identityZoneId = identityZoneId;
+    }
+
+    @Override
+    public ValidationResult isValid() {
+        ValidationResult.ValidationResultBuilder builder = ValidationResult.builder();
+
+        if (this.identityZoneId == null) {
+            builder.message("identity zone id must be specified");
+        }
+
+        return builder.build();
+    }
+
+}

--- a/cloudfoundry-client/src/main/lombok/org/cloudfoundry/uaa/identityzonemanagement/DeleteIdentityZoneResponse.java
+++ b/cloudfoundry-client/src/main/lombok/org/cloudfoundry/uaa/identityzonemanagement/DeleteIdentityZoneResponse.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2013-2016 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.cloudfoundry.uaa.identityzonemanagement;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.Builder;
+import lombok.Data;
+import lombok.EqualsAndHashCode;
+import lombok.ToString;
+
+/**
+ * The resource response payload for the Delete Identity Zone Response
+ */
+@Data
+@EqualsAndHashCode(callSuper = true)
+@ToString(callSuper = true)
+public final class DeleteIdentityZoneResponse extends AbstractIdentityZone {
+
+    @Builder
+    DeleteIdentityZoneResponse(@JsonProperty("created") Long createdAt,
+                               @JsonProperty("description") String description,
+                               @JsonProperty("id") String identityZoneId,
+                               @JsonProperty("name") String name,
+                               @JsonProperty("subdomain") String subDomain,
+                               @JsonProperty("last_modified") Long updatedAt,
+                               @JsonProperty("version") Integer version) {
+
+        super(createdAt, description, identityZoneId, name, subDomain, updatedAt, version);
+    }
+
+}

--- a/cloudfoundry-client/src/test/java/org/cloudfoundry/uaa/identityzonemanagement/DeleteIdentityZoneRequestTest.java
+++ b/cloudfoundry-client/src/test/java/org/cloudfoundry/uaa/identityzonemanagement/DeleteIdentityZoneRequestTest.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2013-2016 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.cloudfoundry.uaa.identityzonemanagement;
+
+import org.cloudfoundry.ValidationResult;
+import org.junit.Test;
+
+import static org.cloudfoundry.ValidationResult.Status.INVALID;
+import static org.cloudfoundry.ValidationResult.Status.VALID;
+import static org.junit.Assert.assertEquals;
+
+public final class DeleteIdentityZoneRequestTest {
+
+    @Test
+    public void isNotValidNoId() {
+        ValidationResult result = DeleteIdentityZoneRequest.builder()
+            .build()
+            .isValid();
+
+        assertEquals(INVALID, result.getStatus());
+        assertEquals("identity zone id must be specified", result.getMessages().get(0));
+    }
+
+    @Test
+    public void isValid() {
+        ValidationResult result = DeleteIdentityZoneRequest.builder()
+            .identityZoneId("test-identity-zone-id")
+            .build()
+            .isValid();
+
+        assertEquals(VALID, result.getStatus());
+    }
+
+}


### PR DESCRIPTION
This change adds the api to delete an identity zone (```DELETE /identity-zones/{identityZoneId}```)
See [this story](https://www.pivotaltracker.com/projects/816799/stories/114245315)
@nebhale : strange, according to the api ```DELETE``` verb returns ```OK``` status **and** a the entity that will be removed...