### PR TITLE
Update Identity Zone

### DIFF
--- a/cloudfoundry-client-spring/src/main/lombok/org/cloudfoundry/spring/uaa/identityzonemanagement/SpringIdentityZoneManagement.java
+++ b/cloudfoundry-client-spring/src/main/lombok/org/cloudfoundry/spring/uaa/identityzonemanagement/SpringIdentityZoneManagement.java
@@ -27,6 +27,8 @@ import org.cloudfoundry.uaa.identityzonemanagement.GetIdentityZoneResponse;
 import org.cloudfoundry.uaa.identityzonemanagement.IdentityZoneManagement;
 import org.cloudfoundry.uaa.identityzonemanagement.ListIdentityZoneRequest;
 import org.cloudfoundry.uaa.identityzonemanagement.ListIdentityZoneResponse;
+import org.cloudfoundry.uaa.identityzonemanagement.UpdateIdentityZoneRequest;
+import org.cloudfoundry.uaa.identityzonemanagement.UpdateIdentityZoneResponse;
 import org.springframework.web.client.RestOperations;
 import reactor.core.publisher.Mono;
 import reactor.core.publisher.SchedulerGroup;
@@ -68,6 +70,11 @@ public final class SpringIdentityZoneManagement extends AbstractSpringOperations
     @Override
     public Mono<ListIdentityZoneResponse> list(ListIdentityZoneRequest request) {
         return get(request, ListIdentityZoneResponse.class, builder -> builder.pathSegment("identity-zones"));
+    }
+
+    @Override
+    public Mono<UpdateIdentityZoneResponse> update(UpdateIdentityZoneRequest request) {
+        return put(request, UpdateIdentityZoneResponse.class, builder -> builder.pathSegment("identity-zones", request.getIdentityZoneId()));
     }
 
 }

--- a/cloudfoundry-client-spring/src/test/java/org/cloudfoundry/spring/uaa/identityzonemanagement/SpringIdentityZoneManagementTest.java
+++ b/cloudfoundry-client-spring/src/test/java/org/cloudfoundry/spring/uaa/identityzonemanagement/SpringIdentityZoneManagementTest.java
@@ -26,11 +26,14 @@ import org.cloudfoundry.uaa.identityzonemanagement.GetIdentityZoneResponse;
 import org.cloudfoundry.uaa.identityzonemanagement.IdentityZone;
 import org.cloudfoundry.uaa.identityzonemanagement.ListIdentityZoneRequest;
 import org.cloudfoundry.uaa.identityzonemanagement.ListIdentityZoneResponse;
+import org.cloudfoundry.uaa.identityzonemanagement.UpdateIdentityZoneRequest;
+import org.cloudfoundry.uaa.identityzonemanagement.UpdateIdentityZoneResponse;
 import reactor.core.publisher.Mono;
 
 import static org.springframework.http.HttpMethod.DELETE;
 import static org.springframework.http.HttpMethod.GET;
 import static org.springframework.http.HttpMethod.POST;
+import static org.springframework.http.HttpMethod.PUT;
 import static org.springframework.http.HttpStatus.CREATED;
 import static org.springframework.http.HttpStatus.OK;
 
@@ -217,6 +220,52 @@ public final class SpringIdentityZoneManagementTest {
         @Override
         protected Mono<ListIdentityZoneResponse> invoke(ListIdentityZoneRequest request) {
             return this.identityZoneManagement.list(request);
+        }
+    }
+
+    public static final class Update extends AbstractApiTest<UpdateIdentityZoneRequest, UpdateIdentityZoneResponse> {
+
+        private final SpringIdentityZoneManagement identityZoneManagement = new SpringIdentityZoneManagement(this.restTemplate, this.root, PROCESSOR_GROUP);
+
+        @Override
+        protected UpdateIdentityZoneRequest getInvalidRequest() {
+            return UpdateIdentityZoneRequest.builder().build();
+        }
+
+        @Override
+        protected RequestContext getRequestContext() {
+            return new RequestContext()
+                .method(PUT).path("/identity-zones/testzone1")
+                .requestPayload("fixtures/uaa/identity-zones/PUT_request.json")
+                .status(OK)
+                .responsePayload("fixtures/uaa/identity-zones/PUT_response.json");
+        }
+
+        @Override
+        protected UpdateIdentityZoneResponse getResponse() {
+            return UpdateIdentityZoneResponse.builder()
+                .createdAt(1426258488910L)
+                .description("Like the Twilight Zone but tastier[testzone1].")
+                .identityZoneId("testzone1")
+                .name("The Twiglet Zone[testzone1]")
+                .subDomain("testzone1")
+                .version(0)
+                .build();
+        }
+
+        @Override
+        protected UpdateIdentityZoneRequest getValidRequest() throws Exception {
+            return UpdateIdentityZoneRequest.builder()
+                .description("Like the Twilight Zone but tastier[testzone1].")
+                .identityZoneId("testzone1")
+                .name("The Twiglet Zone[testzone1]")
+                .subDomain("testzone1")
+                .build();
+        }
+
+        @Override
+        protected Mono<UpdateIdentityZoneResponse> invoke(UpdateIdentityZoneRequest request) {
+            return this.identityZoneManagement.update(request);
         }
     }
 

--- a/cloudfoundry-client-spring/src/test/resources/fixtures/uaa/identity-zones/PUT_request.json
+++ b/cloudfoundry-client-spring/src/test/resources/fixtures/uaa/identity-zones/PUT_request.json
@@ -1,0 +1,5 @@
+{
+  "subdomain": "testzone1",
+  "name": "The Twiglet Zone[testzone1]",
+  "description": "Like the Twilight Zone but tastier[testzone1]."
+}

--- a/cloudfoundry-client-spring/src/test/resources/fixtures/uaa/identity-zones/PUT_response.json
+++ b/cloudfoundry-client-spring/src/test/resources/fixtures/uaa/identity-zones/PUT_response.json
@@ -1,0 +1,9 @@
+{
+  "created": 1426258488910,
+  "description": "Like the Twilight Zone but tastier[testzone1].",
+  "id": "testzone1",
+  "last_modified": null,
+  "name": "The Twiglet Zone[testzone1]",
+  "subdomain": "testzone1",
+  "version": 0
+}

--- a/cloudfoundry-client/src/main/java/org/cloudfoundry/uaa/identityzonemanagement/IdentityZoneManagement.java
+++ b/cloudfoundry-client/src/main/java/org/cloudfoundry/uaa/identityzonemanagement/IdentityZoneManagement.java
@@ -55,4 +55,12 @@ public interface IdentityZoneManagement {
      */
     Mono<ListIdentityZoneResponse> list(ListIdentityZoneRequest request);
 
+    /**
+     * Makes the <a href="https://github.com/cloudfoundry/uaa/blob/master/docs/UAA-APIs.rst#create-or-update-identity-zones-post-or-put-identity-zones">Update Identity Zone</a> request
+     *
+     * @param request the Update Identity Zone request
+     * @return the response from the Update Identity Zone request
+     */
+    Mono<UpdateIdentityZoneResponse> update(UpdateIdentityZoneRequest request);
+
 }

--- a/cloudfoundry-client/src/main/lombok/org/cloudfoundry/uaa/identityzonemanagement/UpdateIdentityZoneRequest.java
+++ b/cloudfoundry-client/src/main/lombok/org/cloudfoundry/uaa/identityzonemanagement/UpdateIdentityZoneRequest.java
@@ -1,0 +1,110 @@
+/*
+ * Copyright 2013-2016 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.cloudfoundry.uaa.identityzonemanagement;
+
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.Builder;
+import lombok.Data;
+import lombok.Getter;
+import org.cloudfoundry.Validatable;
+import org.cloudfoundry.ValidationResult;
+
+/**
+ * The request payload for the update identity zone operation
+ */
+@Data
+public final class UpdateIdentityZoneRequest implements Validatable {
+
+    /**
+     * The description of the identity zone.
+     *
+     * @param description the description
+     * @return the description
+     */
+    @Getter(onMethod = @__(@JsonProperty("description")))
+    private final String description;
+
+    /**
+     * The id of the identity zone. When not provided, an identifier will be generated
+     *
+     * @param identityZoneId the identity zone id
+     * @return the identity zone id
+     */
+    @Getter(onMethod = @__(@JsonIgnore))
+    private final String identityZoneId;
+
+    /**
+     * The name of the identity zone.
+     *
+     * @param name the name
+     * @return the name
+     */
+    @Getter(onMethod = @__(@JsonProperty("name")))
+    private final String name;
+
+    /**
+     * The unique subdomain. It will be converted into lowercase upon creation.
+     *
+     * @param subdomain the subdomain
+     * @return the subdomain
+     */
+    @Getter(onMethod = @__(@JsonProperty("subdomain")))
+    private final String subDomain;
+
+    /**
+     * The version of the identity zone.
+     *
+     * @param version the version
+     * @return the version
+     */
+    @Getter(onMethod = @__(@JsonProperty("version")))
+    private final Integer version;
+
+    @Builder
+    UpdateIdentityZoneRequest(String description,
+                              String identityZoneId,
+                              String name,
+                              String subDomain,
+                              Integer version) {
+        this.description = description;
+        this.identityZoneId = identityZoneId;
+        this.name = name;
+        this.subDomain = subDomain;
+        this.version = version;
+    }
+
+    @Override
+    public ValidationResult isValid() {
+        ValidationResult.ValidationResultBuilder builder = ValidationResult.builder();
+
+        if (this.identityZoneId == null) {
+            builder.message("identity zone id must be specified");
+        }
+
+        if (this.name == null) {
+            builder.message("name must be specified");
+        }
+
+        if (this.subDomain == null) {
+            builder.message("sub domain must be specified");
+        }
+
+        return builder.build();
+    }
+
+}

--- a/cloudfoundry-client/src/main/lombok/org/cloudfoundry/uaa/identityzonemanagement/UpdateIdentityZoneResponse.java
+++ b/cloudfoundry-client/src/main/lombok/org/cloudfoundry/uaa/identityzonemanagement/UpdateIdentityZoneResponse.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2013-2016 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.cloudfoundry.uaa.identityzonemanagement;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.Builder;
+import lombok.Data;
+import lombok.EqualsAndHashCode;
+import lombok.ToString;
+
+/**
+ * The response from the update identity zone request
+ */
+@Data
+@EqualsAndHashCode(callSuper = true)
+@ToString(callSuper = true)
+public final class UpdateIdentityZoneResponse extends AbstractIdentityZone {
+
+    @Builder
+    UpdateIdentityZoneResponse(@JsonProperty("created") Long createdAt,
+                               @JsonProperty("description") String description,
+                               @JsonProperty("id") String identityZoneId,
+                               @JsonProperty("name") String name,
+                               @JsonProperty("subdomain") String subDomain,
+                               @JsonProperty("last_modified") Long updatedAt,
+                               @JsonProperty("version") Integer version) {
+
+        super(createdAt, description, identityZoneId, name, subDomain, updatedAt, version);
+    }
+
+}

--- a/cloudfoundry-client/src/test/java/org/cloudfoundry/uaa/identityzonemanagement/UpdateIdentityZoneRequestTest.java
+++ b/cloudfoundry-client/src/test/java/org/cloudfoundry/uaa/identityzonemanagement/UpdateIdentityZoneRequestTest.java
@@ -1,0 +1,76 @@
+/*
+ * Copyright 2013-2016 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.cloudfoundry.uaa.identityzonemanagement;
+
+import org.cloudfoundry.ValidationResult;
+import org.junit.Test;
+
+import static org.cloudfoundry.ValidationResult.Status.INVALID;
+import static org.cloudfoundry.ValidationResult.Status.VALID;
+import static org.junit.Assert.assertEquals;
+
+public class UpdateIdentityZoneRequestTest {
+
+    @Test
+    public void isNotValidNoId() {
+        ValidationResult result = UpdateIdentityZoneRequest.builder()
+            .name("test-name")
+            .subDomain("test-sub-domain")
+            .build()
+            .isValid();
+
+        assertEquals(INVALID, result.getStatus());
+        assertEquals("identity zone id must be specified", result.getMessages().get(0));
+    }
+
+    @Test
+    public void isNotValidNoName() {
+        ValidationResult result = UpdateIdentityZoneRequest.builder()
+            .identityZoneId("test-id")
+            .subDomain("test-sub-domain")
+            .build()
+            .isValid();
+
+        assertEquals(INVALID, result.getStatus());
+        assertEquals("name must be specified", result.getMessages().get(0));
+    }
+
+    @Test
+    public void isNotValidNoSubdomain() {
+        ValidationResult result = UpdateIdentityZoneRequest.builder()
+            .identityZoneId("test-id")
+            .name("test-name")
+            .build()
+            .isValid();
+
+        assertEquals(INVALID, result.getStatus());
+        assertEquals("sub domain must be specified", result.getMessages().get(0));
+    }
+
+    @Test
+    public void isValid() {
+        ValidationResult result = UpdateIdentityZoneRequest.builder()
+            .identityZoneId("test-id")
+            .name("test-name")
+            .subDomain("test-sub-domain")
+            .build()
+            .isValid();
+
+        assertEquals(VALID, result.getStatus());
+    }
+
+}


### PR DESCRIPTION
This change adds the api to update an identity zone (```PUT /identity-zones```)
See [this story](https://www.pivotaltracker.com/projects/816799/stories/114245169)
@nebhale : 
- strange that the ```PUT``` is done under /identity-zones instead of ```/identity-zones/:identity-zone-id```
- I've put status code ```OK``` in the tests (not sure about the good one)