### PR TITLE
Create Identity Provider

### DIFF
--- a/cloudfoundry-client-spring/src/main/java/org/cloudfoundry/spring/util/RequestHeaderBuilder.java
+++ b/cloudfoundry-client-spring/src/main/java/org/cloudfoundry/spring/util/RequestHeaderBuilder.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright 2013-2016 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.cloudfoundry.spring.util;
+
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
+import org.cloudfoundry.RequestHeader;
+import org.springframework.core.annotation.AnnotationUtils;
+import org.springframework.http.HttpHeaders;
+import org.springframework.util.ReflectionUtils;
+
+import java.lang.reflect.Method;
+import java.util.Arrays;
+import java.util.Iterator;
+
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+public final class RequestHeaderBuilder {
+
+    /**
+     * Populates a {@link HttpHeaders} with headers based on the methods annotated with {@link RequestHeader}
+     *
+     * @param headers  the headers to populate
+     * @param instance the instance to inspect and invoke
+     */
+    public static void populate(HttpHeaders headers, Object instance) {
+        Method[] methods = ReflectionUtils.getAllDeclaredMethods(instance.getClass());
+        Arrays.sort(methods, MethodNameComparator.INSTANCE);
+
+        for (Method method : methods) {
+            RequestHeader requestHeader = AnnotationUtils.getAnnotation(method, RequestHeader.class);
+            if (requestHeader == null) {
+                continue;
+            }
+
+            ReflectionUtils.makeAccessible(method);
+            Object value = ReflectionUtils.invokeMethod(method, instance);
+
+            if (value != null) {
+                if (Iterable.class.isInstance(value)) {
+                    for (Iterator<?> it = Iterable.class.cast(value).iterator(); it.hasNext(); ) {
+                        Object subValue = it.next();
+                        if (subValue != null) {
+                            headers.add(requestHeader.value(), subValue.toString());
+                        }
+                    }
+                } else {
+                    headers.add(requestHeader.value(), value.toString());
+                }
+            }
+        }
+    }
+
+}

--- a/cloudfoundry-client-spring/src/main/lombok/org/cloudfoundry/spring/client/v3/packages/SpringPackages.java
+++ b/cloudfoundry-client-spring/src/main/lombok/org/cloudfoundry/spring/client/v3/packages/SpringPackages.java
@@ -106,7 +106,7 @@ public final class SpringPackages extends AbstractSpringOperations implements Pa
     @Override
     public Mono<UploadPackageResponse> upload(UploadPackageRequest request) {
         return postWithBody(request, () -> CollectionUtils.singletonMultiValueMap("bits", getApplicationPart(request)), UploadPackageResponse.class,
-            builder -> builder.pathSegment("v3", "packages", request.getPackageId(), "upload"));
+            builder -> builder.pathSegment("v3", "packages", request.getPackageId(), "upload"), null);
     }
 
     private static HttpEntity<Resource> getApplicationPart(UploadPackageRequest request) {

--- a/cloudfoundry-client-spring/src/main/lombok/org/cloudfoundry/spring/uaa/SpringUaaClient.java
+++ b/cloudfoundry-client-spring/src/main/lombok/org/cloudfoundry/spring/uaa/SpringUaaClient.java
@@ -24,6 +24,7 @@ import org.cloudfoundry.client.v2.info.GetInfoRequest;
 import org.cloudfoundry.client.v2.info.GetInfoResponse;
 import org.cloudfoundry.spring.client.SpringCloudFoundryClient;
 import org.cloudfoundry.spring.uaa.accesstokenadministration.SpringAccessTokenAdministration;
+import org.cloudfoundry.spring.uaa.identityproviders.SpringIdentityProviders;
 import org.cloudfoundry.spring.uaa.identityzonemanagement.SpringIdentityZoneManagement;
 import org.cloudfoundry.spring.util.SchedulerGroupBuilder;
 import org.cloudfoundry.spring.util.network.ConnectionContext;
@@ -32,6 +33,7 @@ import org.cloudfoundry.spring.util.network.OAuth2RestTemplateBuilder;
 import org.cloudfoundry.spring.util.network.SslCertificateTruster;
 import org.cloudfoundry.uaa.UaaClient;
 import org.cloudfoundry.uaa.accesstokenadministration.AccessTokenAdministration;
+import org.cloudfoundry.uaa.identityproviders.IdentityProviders;
 import org.cloudfoundry.uaa.identityzonemanagement.IdentityZoneManagement;
 import org.springframework.security.oauth2.client.OAuth2RestOperations;
 import org.springframework.web.client.RestOperations;
@@ -51,10 +53,13 @@ public final class SpringUaaClient implements UaaClient {
 
     private final SpringAccessTokenAdministration accessTokenAdministration;
 
+    private final SpringIdentityProviders identityProviders;
+
     private final SpringIdentityZoneManagement identityZoneManagement;
 
     SpringUaaClient(RestOperations restOperations, URI root, SchedulerGroup schedulerGroup) {
         this.accessTokenAdministration = new SpringAccessTokenAdministration(restOperations, root, schedulerGroup);
+        this.identityProviders = new SpringIdentityProviders(restOperations, root, schedulerGroup);
         this.identityZoneManagement = new SpringIdentityZoneManagement(restOperations, root, schedulerGroup);
     }
 
@@ -68,6 +73,11 @@ public final class SpringUaaClient implements UaaClient {
     @Override
     public AccessTokenAdministration accessTokenAdministration() {
         return this.accessTokenAdministration;
+    }
+
+    @Override
+    public IdentityProviders identityProviders() {
+        return this.identityProviders;
     }
 
     @Override

--- a/cloudfoundry-client-spring/src/main/lombok/org/cloudfoundry/spring/uaa/identityproviders/SpringIdentityProviders.java
+++ b/cloudfoundry-client-spring/src/main/lombok/org/cloudfoundry/spring/uaa/identityproviders/SpringIdentityProviders.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright 2013-2016 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.cloudfoundry.spring.uaa.identityproviders;
+
+import lombok.ToString;
+import org.cloudfoundry.spring.util.AbstractSpringOperations;
+import org.cloudfoundry.spring.util.RequestHeaderBuilder;
+import org.cloudfoundry.uaa.identityproviders.CreateIdentityProviderRequest;
+import org.cloudfoundry.uaa.identityproviders.CreateIdentityProviderResponse;
+import org.cloudfoundry.uaa.identityproviders.IdentityProviders;
+import org.springframework.web.client.RestOperations;
+import reactor.core.publisher.Mono;
+import reactor.core.publisher.SchedulerGroup;
+
+import java.net.URI;
+
+/**
+ * The Spring-based implementation of {@link IdentityProviders}
+ */
+@ToString(callSuper = true)
+public final class SpringIdentityProviders extends AbstractSpringOperations implements IdentityProviders {
+
+    /**
+     * Creates an instance
+     *
+     * @param restOperations the {@link RestOperations} to use to communicate with the server
+     * @param root           the root URI of the server.  Typically something like {@code https://uaa.run.pivotal.io}.
+     * @param schedulerGroup The group to use when making requests
+     */
+    public SpringIdentityProviders(RestOperations restOperations, URI root, SchedulerGroup schedulerGroup) {
+        super(restOperations, root, schedulerGroup);
+    }
+
+    @Override
+    public Mono<CreateIdentityProviderResponse> create(CreateIdentityProviderRequest request) {
+        return post(request, CreateIdentityProviderResponse.class, builder -> builder.pathSegment("identity-providers"), headers -> RequestHeaderBuilder.populate(headers, request));
+    }
+
+}

--- a/cloudfoundry-client-spring/src/test/java/org/cloudfoundry/spring/AbstractRestTest.java
+++ b/cloudfoundry-client-spring/src/test/java/org/cloudfoundry/spring/AbstractRestTest.java
@@ -44,6 +44,7 @@ import reactor.core.publisher.SchedulerGroup;
 import java.net.URI;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Objects;
 
 import static org.springframework.http.HttpStatus.UNPROCESSABLE_ENTITY;
 import static org.springframework.http.MediaType.APPLICATION_JSON;
@@ -162,6 +163,17 @@ public abstract class AbstractRestTest {
 
         public RequestContext path(String path) {
             this.path = path;
+            return this;
+        }
+
+        public RequestContext requestHeader(String name, String value) {
+            if (name != null) {
+                this.requestMatchers.add(request -> {
+                    Assert.isTrue(request.getHeaders().containsKey(name));
+                    Assert.isTrue(request.getHeaders().get(name).size() == 1);
+                    Assert.isTrue(Objects.equals(request.getHeaders().getFirst(name), value));
+                });
+            }
             return this;
         }
 

--- a/cloudfoundry-client-spring/src/test/java/org/cloudfoundry/spring/uaa/SpringUaaClientTest.java
+++ b/cloudfoundry-client-spring/src/test/java/org/cloudfoundry/spring/uaa/SpringUaaClientTest.java
@@ -31,6 +31,11 @@ public final class SpringUaaClientTest extends AbstractRestTest {
     }
 
     @Test
+    public void identityProviders() {
+        assertNotNull(this.client.identityProviders());
+    }
+
+    @Test
     public void identityZoneManagement() {
         assertNotNull(this.client.identityZoneManagement());
     }

--- a/cloudfoundry-client-spring/src/test/java/org/cloudfoundry/spring/uaa/identityproviders/SpringIdentityProvidersTest.java
+++ b/cloudfoundry-client-spring/src/test/java/org/cloudfoundry/spring/uaa/identityproviders/SpringIdentityProvidersTest.java
@@ -1,0 +1,82 @@
+/*
+ * Copyright 2013-2016 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.cloudfoundry.spring.uaa.identityproviders;
+
+import org.cloudfoundry.spring.AbstractApiTest;
+import org.cloudfoundry.uaa.identityproviders.CreateIdentityProviderRequest;
+import org.cloudfoundry.uaa.identityproviders.CreateIdentityProviderResponse;
+import reactor.core.publisher.Mono;
+
+import static org.springframework.http.HttpMethod.POST;
+import static org.springframework.http.HttpStatus.CREATED;
+
+public final class SpringIdentityProvidersTest {
+
+    public static final class Create extends AbstractApiTest<CreateIdentityProviderRequest, CreateIdentityProviderResponse> {
+
+        private final SpringIdentityProviders identityProviders = new SpringIdentityProviders(this.restTemplate, this.root, PROCESSOR_GROUP);
+
+        @Override
+        protected CreateIdentityProviderRequest getInvalidRequest() {
+            return CreateIdentityProviderRequest.builder().build();
+        }
+
+        @Override
+        protected RequestContext getRequestContext() {
+            return new RequestContext()
+                .method(POST).path("/identity-providers")
+                .requestHeader("X-Identity-Zone-Id", "testzone1")
+                .requestPayload("fixtures/uaa/identity-providers/POST_request.json")
+                .status(CREATED)
+                .responsePayload("fixtures/uaa/identity-providers/POST_response.json");
+        }
+
+        @Override
+        protected CreateIdentityProviderResponse getResponse() {
+            return CreateIdentityProviderResponse.builder()
+                .active(true)
+                .config(null)
+                .createdAt(1426260091149L)
+                .id("50cf6125-4372-475e-94e8-c43f84111e75")
+                .identityZoneId("testzone1")
+                .name("internal")
+                .originKey("uaa")
+                .type("internal")
+                .updatedAt(1426260091149L)
+                .version(0)
+                .build();
+        }
+
+        @Override
+        protected CreateIdentityProviderRequest getValidRequest() throws Exception {
+            return CreateIdentityProviderRequest.builder()
+                .active(true)
+                .identityZoneId("testzone1")
+                .name("internal")
+                .originKey("uaa")
+                .type("internal")
+                .version(0)
+                .build();
+        }
+
+        @Override
+        protected Mono<CreateIdentityProviderResponse> invoke(CreateIdentityProviderRequest request) {
+            return this.identityProviders.create(request);
+        }
+    }
+
+}

--- a/cloudfoundry-client-spring/src/test/java/org/cloudfoundry/spring/util/RequestHeaderBuilderTest.java
+++ b/cloudfoundry-client-spring/src/test/java/org/cloudfoundry/spring/util/RequestHeaderBuilderTest.java
@@ -1,0 +1,87 @@
+/*
+ * Copyright 2013-2016 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.cloudfoundry.spring.util;
+
+import org.cloudfoundry.RequestHeader;
+import org.junit.Test;
+import org.springframework.http.HttpHeaders;
+
+import java.util.Arrays;
+import java.util.List;
+
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.notNullValue;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertThat;
+
+public class RequestHeaderBuilderTest {
+
+    @Test
+    public void test() {
+        HttpHeaders headers = new HttpHeaders();
+
+        RequestHeaderBuilder.populate(headers, new StubHeadersSubClass());
+
+        assertThat(headers.size(), is(equalTo(3)));
+        assertFalse(headers.containsKey("test-header-null"));
+
+        assertThat(headers.get("test-header-string"), is(notNullValue()));
+        assertThat(headers.get("test-header-string").size(), is(equalTo(1)));
+        assertThat(headers.getFirst("test-header-string"), is(equalTo("test-value")));
+
+        assertThat(headers.get("test-header-iterable-1"), is(notNullValue()));
+        assertThat(headers.get("test-header-iterable-1").size(), is(equalTo(2)));
+        assertThat(headers.get("test-header-iterable-1").get(0), is(equalTo("value1")));
+        assertThat(headers.get("test-header-iterable-1").get(1), is(equalTo("value2")));
+
+        assertThat(headers.get("test-header-iterable-2"), is(notNullValue()));
+        assertThat(headers.get("test-header-iterable-2").size(), is(equalTo(2)));
+        assertThat(headers.get("test-header-iterable-2").get(0), is(equalTo("value1")));
+        assertThat(headers.get("test-header-iterable-2").get(1), is(equalTo("value2")));
+
+    }
+
+    private static abstract class StubHeaders {
+
+        @RequestHeader("test-header-null")
+        final String getNull() {
+            return null;
+        }
+
+        @RequestHeader("test-header-iterable-1")
+        final List<String> getParameterIterable() {
+            return Arrays.asList("value1", "value2");
+        }
+
+        @RequestHeader("test-header-string")
+        final String getParameterString() {
+            return "test-value";
+        }
+
+    }
+
+    private static final class StubHeadersSubClass extends StubHeaders {
+
+        @RequestHeader("test-header-iterable-2")
+        final List<String> getParameterIterable2() {
+            return Arrays.asList("value1", "value2");
+        }
+
+    }
+
+}

--- a/cloudfoundry-client-spring/src/test/resources/fixtures/uaa/identity-providers/POST_request.json
+++ b/cloudfoundry-client-spring/src/test/resources/fixtures/uaa/identity-providers/POST_request.json
@@ -1,0 +1,7 @@
+{
+  "originKey": "uaa",
+  "name": "internal",
+  "type": "internal",
+  "version": 0,
+  "active": true
+}

--- a/cloudfoundry-client-spring/src/test/resources/fixtures/uaa/identity-providers/POST_response.json
+++ b/cloudfoundry-client-spring/src/test/resources/fixtures/uaa/identity-providers/POST_response.json
@@ -1,0 +1,12 @@
+{
+  "id": "50cf6125-4372-475e-94e8-c43f84111e75",
+  "originKey": "uaa",
+  "name": "internal",
+  "type": "internal",
+  "config": null,
+  "version": 0,
+  "created": 1426260091149,
+  "active": true,
+  "identityZoneId": "testzone1",
+  "last_modified": 1426260091149
+}

--- a/cloudfoundry-client/src/main/java/org/cloudfoundry/RequestHeader.java
+++ b/cloudfoundry-client/src/main/java/org/cloudfoundry/RequestHeader.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2013-2016 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.cloudfoundry;
+
+import com.fasterxml.jackson.annotation.JacksonAnnotationsInside;
+import com.fasterxml.jackson.annotation.JsonIgnore;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * An annotation indicating that a method represents a request header
+ */
+@Target(ElementType.METHOD)
+@Retention(RetentionPolicy.RUNTIME)
+@JsonIgnore
+@JacksonAnnotationsInside
+public @interface RequestHeader {
+
+    /**
+     * Returns the name of the request header
+     *
+     * @return the name of the request header
+     */
+    String value();
+
+}

--- a/cloudfoundry-client/src/main/java/org/cloudfoundry/uaa/UaaClient.java
+++ b/cloudfoundry-client/src/main/java/org/cloudfoundry/uaa/UaaClient.java
@@ -17,6 +17,7 @@
 package org.cloudfoundry.uaa;
 
 import org.cloudfoundry.uaa.accesstokenadministration.AccessTokenAdministration;
+import org.cloudfoundry.uaa.identityproviders.IdentityProviders;
 import org.cloudfoundry.uaa.identityzonemanagement.IdentityZoneManagement;
 
 /**
@@ -30,6 +31,13 @@ public interface UaaClient {
      * @return the UAA Access Token Administration Client API
      */
     AccessTokenAdministration accessTokenAdministration();
+
+    /**
+     * Main entry point to the UAA Identity Providers Client API
+     *
+     * @return the UAA Identity Providers Client API
+     */
+    IdentityProviders identityProviders();
 
     /**
      * Main entry point to the UAA Identity Zone Management Client API

--- a/cloudfoundry-client/src/main/java/org/cloudfoundry/uaa/identityproviders/IdentityProviders.java
+++ b/cloudfoundry-client/src/main/java/org/cloudfoundry/uaa/identityproviders/IdentityProviders.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2013-2016 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.cloudfoundry.uaa.identityproviders;
+
+import reactor.core.publisher.Mono;
+
+/**
+ * Main entry point to the UAA Identity Providers Client API
+ */
+public interface IdentityProviders {
+
+    /**
+     * Makes the <a href="https://github.com/cloudfoundry/uaa/blob/master/docs/UAA-APIs.rst#identity-provider-api-identity-providers">Create Identity Provider</a> request
+     *
+     * @param request the Create Identity Provider request
+     * @return the response from the Create Identity Provider request
+     */
+    Mono<CreateIdentityProviderResponse> create(CreateIdentityProviderRequest request);
+
+}

--- a/cloudfoundry-client/src/main/lombok/org/cloudfoundry/uaa/identityproviders/AbstractIdentityProvider.java
+++ b/cloudfoundry-client/src/main/lombok/org/cloudfoundry/uaa/identityproviders/AbstractIdentityProvider.java
@@ -1,0 +1,130 @@
+/*
+ * Copyright 2013-2016 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.cloudfoundry.uaa.identityproviders;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.Data;
+
+/**
+ * The entity response payload for Identity Provider
+ */
+@Data
+public abstract class AbstractIdentityProvider {
+
+    /**
+     * The active flag
+     *
+     * @param active the active flag
+     * @return the active flag
+     */
+    private final Boolean active;
+
+    /**
+     * The config of the identity provider in a JSON format.
+     *
+     * @param config the config
+     * @return the config
+     */
+    private final String config;
+
+    /**
+     * The creation date of the identity zone provider.
+     *
+     * @param createdAt the creation date
+     * @return the creation date
+     */
+    private final Long createdAt;
+
+    /**
+     * The id of the identity provider.
+     *
+     * @param id the id
+     * @return the id
+     */
+    private final String id;
+
+    /**
+     * The id of the zone for this identity provider.
+     *
+     * @param identityZoneId the identity zone id
+     * @return the identity zone id
+     */
+    private final String identityZoneId;
+
+    /**
+     * The name of the identity provider.
+     *
+     * @param name the name
+     * @return the name
+     */
+    private final String name;
+
+    /**
+     * The origin key of the identity provider.
+     *
+     * @param originKey the origin key
+     * @return the origin key
+     */
+    private final String originKey;
+
+    /**
+     * The type of the identity provider. Must be either "saml", "ldap" or "internal".
+     *
+     * @param type the type
+     * @return the type
+     */
+    private final String type;
+
+    /**
+     * The last modification date of the identity zone provider.
+     *
+     * @param updatedAt the last modification date
+     * @return the last modification date
+     */
+    private final Long updatedAt;
+
+    /**
+     * The version of the identity zone provider.
+     *
+     * @param version the version
+     * @return the version
+     */
+    private final Integer version;
+
+    AbstractIdentityProvider(@JsonProperty("active") Boolean active,
+                             @JsonProperty("config") String config,
+                             @JsonProperty("created") Long createdAt,
+                             @JsonProperty("id") String id,
+                             @JsonProperty("identityZoneId") String identityZoneId,
+                             @JsonProperty("name") String name,
+                             @JsonProperty("originKey") String originKey,
+                             @JsonProperty("type") String type,
+                             @JsonProperty("last_modified") Long updatedAt,
+                             @JsonProperty("version") Integer version) {
+        this.active = active;
+        this.config = config;
+        this.createdAt = createdAt;
+        this.id = id;
+        this.identityZoneId = identityZoneId;
+        this.name = name;
+        this.originKey = originKey;
+        this.type = type;
+        this.updatedAt = updatedAt;
+        this.version = version;
+    }
+
+}

--- a/cloudfoundry-client/src/main/lombok/org/cloudfoundry/uaa/identityproviders/CreateIdentityProviderRequest.java
+++ b/cloudfoundry-client/src/main/lombok/org/cloudfoundry/uaa/identityproviders/CreateIdentityProviderRequest.java
@@ -1,0 +1,137 @@
+/*
+ * Copyright 2013-2016 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.cloudfoundry.uaa.identityproviders;
+
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.Builder;
+import lombok.Data;
+import lombok.Getter;
+import org.cloudfoundry.RequestHeader;
+import org.cloudfoundry.Validatable;
+import org.cloudfoundry.ValidationResult;
+
+/**
+ * The request payload for the create identity provider operation
+ */
+@Data
+public final class CreateIdentityProviderRequest implements Validatable {
+
+    /**
+     * The active flag
+     *
+     * @param active the active flag
+     * @return the active flag
+     */
+    @Getter(onMethod = @__(@JsonProperty("active")))
+    private final Boolean active;
+
+    /**
+     * The config of the identity provider in a JSON format.
+     *
+     * @param config the config
+     * @return the config
+     */
+    @Getter(onMethod = @__(@JsonProperty("config")))
+    private final String config;
+
+    /**
+     * The identity zone id
+     *
+     * @param identityZoneId the identity zone id
+     * @return the identity zone id
+     */
+    @Getter(onMethod = @__(@RequestHeader("X-Identity-Zone-Id")))
+    private final String identityZoneId;
+
+    /**
+     * The name of the identity provider.
+     *
+     * @param name the name
+     * @return the name
+     */
+    @Getter(onMethod = @__(@JsonProperty("name")))
+    private final String name;
+
+    /**
+     * The origin key of the identity provider.
+     *
+     * @param originKey the origin key
+     * @return the origin key
+     */
+    @Getter(onMethod = @__(@JsonProperty("originKey")))
+    private final String originKey;
+
+    /**
+     * The type of the identity provider. Must be either "saml", "ldap" or "internal".
+     *
+     * @param type the type
+     * @return the type
+     */
+    @Getter(onMethod = @__(@JsonProperty("type")))
+    private final String type;
+
+    /**
+     * The version of the identity zone provider.
+     *
+     * @param version the version
+     * @return the version
+     */
+    @Getter(onMethod = @__(@JsonProperty("version")))
+    private final Integer version;
+
+    @Builder
+    CreateIdentityProviderRequest(Boolean active,
+                                  String config,
+                                  String identityZoneId,
+                                  String name,
+                                  String originKey,
+                                  String type,
+                                  Integer version) {
+        this.active = active;
+        this.config = config;
+        this.identityZoneId = identityZoneId;
+        this.name = name;
+        this.originKey = originKey;
+        this.type = type;
+        this.version = version;
+    }
+
+    @Override
+    public ValidationResult isValid() {
+        ValidationResult.ValidationResultBuilder builder = ValidationResult.builder();
+
+        if (this.identityZoneId == null) {
+            builder.message("identity zone id must be specified");
+        }
+
+        if (this.name == null) {
+            builder.message("name must be specified");
+        }
+
+        if (this.originKey == null) {
+            builder.message("origin key must be specified");
+        }
+
+        if (this.type == null) {
+            builder.message("type must be specified");
+        }
+
+        return builder.build();
+    }
+
+}

--- a/cloudfoundry-client/src/main/lombok/org/cloudfoundry/uaa/identityproviders/CreateIdentityProviderResponse.java
+++ b/cloudfoundry-client/src/main/lombok/org/cloudfoundry/uaa/identityproviders/CreateIdentityProviderResponse.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2013-2016 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.cloudfoundry.uaa.identityproviders;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.Builder;
+import lombok.Data;
+import lombok.EqualsAndHashCode;
+import lombok.ToString;
+
+/**
+ * The response from the create identity provider request
+ */
+@Data
+@EqualsAndHashCode(callSuper = true)
+@ToString(callSuper = true)
+public final class CreateIdentityProviderResponse extends AbstractIdentityProvider {
+
+    @Builder
+    CreateIdentityProviderResponse(@JsonProperty("active") Boolean active,
+                                   @JsonProperty("config") String config,
+                                   @JsonProperty("created") Long createdAt,
+                                   @JsonProperty("id") String id,
+                                   @JsonProperty("identityZoneId") String identityZoneId,
+                                   @JsonProperty("name") String name,
+                                   @JsonProperty("originKey") String originKey,
+                                   @JsonProperty("type") String type,
+                                   @JsonProperty("last_modified") Long updatedAt,
+                                   @JsonProperty("version") Integer version) {
+        super(active, config, createdAt, id, identityZoneId, name, originKey, type, updatedAt, version);
+    }
+
+}

--- a/cloudfoundry-client/src/test/java/org/cloudfoundry/uaa/identityproviders/CreateIdentityProviderRequestTest.java
+++ b/cloudfoundry-client/src/test/java/org/cloudfoundry/uaa/identityproviders/CreateIdentityProviderRequestTest.java
@@ -1,0 +1,93 @@
+/*
+ * Copyright 2013-2016 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.cloudfoundry.uaa.identityproviders;
+
+import org.cloudfoundry.ValidationResult;
+import org.junit.Test;
+
+import static org.cloudfoundry.ValidationResult.Status.INVALID;
+import static org.cloudfoundry.ValidationResult.Status.VALID;
+import static org.junit.Assert.assertEquals;
+
+public final class CreateIdentityProviderRequestTest {
+
+    @Test
+    public void isNotValidNoIdentityZoneId() {
+        ValidationResult result = CreateIdentityProviderRequest.builder()
+            .originKey("test-origin-key")
+            .name("test-name")
+            .type("test-type")
+            .build()
+            .isValid();
+
+        assertEquals(INVALID, result.getStatus());
+        assertEquals("identity zone id must be specified", result.getMessages().get(0));
+    }
+
+    @Test
+    public void isNotValidNoName() {
+        ValidationResult result = CreateIdentityProviderRequest.builder()
+            .identityZoneId("test-identity-zone-id")
+            .originKey("test-origin-key")
+            .type("test-type")
+            .build()
+            .isValid();
+
+        assertEquals(INVALID, result.getStatus());
+        assertEquals("name must be specified", result.getMessages().get(0));
+    }
+
+    @Test
+    public void isNotValidNoOriginKey() {
+        ValidationResult result = CreateIdentityProviderRequest.builder()
+            .identityZoneId("test-identity-zone-id")
+            .name("test-name")
+            .type("test-type")
+            .build()
+            .isValid();
+
+        assertEquals(INVALID, result.getStatus());
+        assertEquals("origin key must be specified", result.getMessages().get(0));
+    }
+
+    @Test
+    public void isNotValidNoType() {
+        ValidationResult result = CreateIdentityProviderRequest.builder()
+            .identityZoneId("test-identity-zone-id")
+            .name("test-name")
+            .originKey("test-origin-key")
+            .build()
+            .isValid();
+
+        assertEquals(INVALID, result.getStatus());
+        assertEquals("type must be specified", result.getMessages().get(0));
+    }
+
+    @Test
+    public void isValid() {
+        ValidationResult result = CreateIdentityProviderRequest.builder()
+            .identityZoneId("test-identity-zone-id")
+            .name("test-name")
+            .originKey("test-origin-key")
+            .type("test-type")
+            .build()
+            .isValid();
+
+        assertEquals(VALID, result.getStatus());
+    }
+
+}


### PR DESCRIPTION
This change adds the api to create an identity provider (```POST /identity-providers```)
See [this story](https://www.pivotaltracker.com/projects/816799/stories/114246037)

@nebhale : Few remarks
- according to doc ```config``` is said to be required but looking at the example and the code [here](https://github.com/cloudfoundry/uaa/blob/master/model/src/main/java/org/cloudfoundry/identity/uaa/provider/IdentityProvider.java) we see that it accepts ```null``` config
- field ```identityZoneId``` is set by a header. Any idea of annotation to specify it?
- I named the interface ```IdentityProviders```. Maybe the interface ```IdentityZoneManagement``` should be renamed to  ```IdentityZones```  ? Otherwise I should rename ```IdentityProviderManagerment```. If so please let me know I will rework this story.