### PR TITLE
Create Identity Zone Client

### DIFF
--- a/cloudfoundry-client-spring/src/main/lombok/org/cloudfoundry/spring/uaa/SpringUaaClient.java
+++ b/cloudfoundry-client-spring/src/main/lombok/org/cloudfoundry/spring/uaa/SpringUaaClient.java
@@ -24,7 +24,7 @@ import org.cloudfoundry.client.v2.info.GetInfoRequest;
 import org.cloudfoundry.client.v2.info.GetInfoResponse;
 import org.cloudfoundry.spring.client.SpringCloudFoundryClient;
 import org.cloudfoundry.spring.uaa.accesstokenadministration.SpringAccessTokenAdministration;
-import org.cloudfoundry.spring.uaa.identityzonemanagement.SpringIdentityZoneManagement;
+import org.cloudfoundry.spring.uaa.identityzones.SpringIdentityZones;
 import org.cloudfoundry.spring.util.SchedulerGroupBuilder;
 import org.cloudfoundry.spring.util.network.ConnectionContext;
 import org.cloudfoundry.spring.util.network.FallbackHttpMessageConverter;
@@ -32,7 +32,7 @@ import org.cloudfoundry.spring.util.network.OAuth2RestTemplateBuilder;
 import org.cloudfoundry.spring.util.network.SslCertificateTruster;
 import org.cloudfoundry.uaa.UaaClient;
 import org.cloudfoundry.uaa.accesstokenadministration.AccessTokenAdministration;
-import org.cloudfoundry.uaa.identityzonemanagement.IdentityZoneManagement;
+import org.cloudfoundry.uaa.identityzones.IdentityZones;
 import org.springframework.security.oauth2.client.OAuth2RestOperations;
 import org.springframework.web.client.RestOperations;
 import reactor.core.publisher.Mono;
@@ -51,11 +51,11 @@ public final class SpringUaaClient implements UaaClient {
 
     private final SpringAccessTokenAdministration accessTokenAdministration;
 
-    private final SpringIdentityZoneManagement identityZoneManagement;
+    private final SpringIdentityZones identityZones;
 
     SpringUaaClient(RestOperations restOperations, URI root, SchedulerGroup schedulerGroup) {
         this.accessTokenAdministration = new SpringAccessTokenAdministration(restOperations, root, schedulerGroup);
-        this.identityZoneManagement = new SpringIdentityZoneManagement(restOperations, root, schedulerGroup);
+        this.identityZones = new SpringIdentityZones(restOperations, root, schedulerGroup);
     }
 
     @Builder
@@ -71,8 +71,8 @@ public final class SpringUaaClient implements UaaClient {
     }
 
     @Override
-    public IdentityZoneManagement identityZoneManagement() {
-        return this.identityZoneManagement;
+    public IdentityZones identityZones() {
+        return this.identityZones;
     }
 
     private static OAuth2RestOperations getRestOperations(ConnectionContext connectionContext) {

--- a/cloudfoundry-client-spring/src/main/lombok/org/cloudfoundry/spring/uaa/identityzones/SpringIdentityZones.java
+++ b/cloudfoundry-client-spring/src/main/lombok/org/cloudfoundry/spring/uaa/identityzones/SpringIdentityZones.java
@@ -14,21 +14,22 @@
  * limitations under the License.
  */
 
-package org.cloudfoundry.spring.uaa.identityzonemanagement;
+package org.cloudfoundry.spring.uaa.identityzones;
 
 import lombok.ToString;
 import org.cloudfoundry.spring.util.AbstractSpringOperations;
-import org.cloudfoundry.uaa.identityzonemanagement.CreateIdentityZoneRequest;
-import org.cloudfoundry.uaa.identityzonemanagement.CreateIdentityZoneResponse;
-import org.cloudfoundry.uaa.identityzonemanagement.DeleteIdentityZoneRequest;
-import org.cloudfoundry.uaa.identityzonemanagement.DeleteIdentityZoneResponse;
-import org.cloudfoundry.uaa.identityzonemanagement.GetIdentityZoneRequest;
-import org.cloudfoundry.uaa.identityzonemanagement.GetIdentityZoneResponse;
-import org.cloudfoundry.uaa.identityzonemanagement.IdentityZoneManagement;
-import org.cloudfoundry.uaa.identityzonemanagement.ListIdentityZoneRequest;
-import org.cloudfoundry.uaa.identityzonemanagement.ListIdentityZoneResponse;
-import org.cloudfoundry.uaa.identityzonemanagement.UpdateIdentityZoneRequest;
-import org.cloudfoundry.uaa.identityzonemanagement.UpdateIdentityZoneResponse;
+import org.cloudfoundry.uaa.identityzones.CreateIdentityZoneClientRequest;
+import org.cloudfoundry.uaa.identityzones.CreateIdentityZoneRequest;
+import org.cloudfoundry.uaa.identityzones.CreateIdentityZoneResponse;
+import org.cloudfoundry.uaa.identityzones.DeleteIdentityZoneRequest;
+import org.cloudfoundry.uaa.identityzones.DeleteIdentityZoneResponse;
+import org.cloudfoundry.uaa.identityzones.GetIdentityZoneRequest;
+import org.cloudfoundry.uaa.identityzones.GetIdentityZoneResponse;
+import org.cloudfoundry.uaa.identityzones.IdentityZones;
+import org.cloudfoundry.uaa.identityzones.ListIdentityZoneRequest;
+import org.cloudfoundry.uaa.identityzones.ListIdentityZoneResponse;
+import org.cloudfoundry.uaa.identityzones.UpdateIdentityZoneRequest;
+import org.cloudfoundry.uaa.identityzones.UpdateIdentityZoneResponse;
 import org.springframework.web.client.RestOperations;
 import reactor.core.publisher.Mono;
 import reactor.core.publisher.SchedulerGroup;
@@ -36,10 +37,10 @@ import reactor.core.publisher.SchedulerGroup;
 import java.net.URI;
 
 /**
- * The Spring-based implementation of {@link IdentityZoneManagement}
+ * The Spring-based implementation of {@link IdentityZones}
  */
 @ToString(callSuper = true)
-public final class SpringIdentityZoneManagement extends AbstractSpringOperations implements IdentityZoneManagement {
+public final class SpringIdentityZones extends AbstractSpringOperations implements IdentityZones {
 
     /**
      * Creates an instance
@@ -48,13 +49,18 @@ public final class SpringIdentityZoneManagement extends AbstractSpringOperations
      * @param root           the root URI of the server.  Typically something like {@code https://uaa.run.pivotal.io}.
      * @param schedulerGroup The group to use when making requests
      */
-    public SpringIdentityZoneManagement(RestOperations restOperations, URI root, SchedulerGroup schedulerGroup) {
+    public SpringIdentityZones(RestOperations restOperations, URI root, SchedulerGroup schedulerGroup) {
         super(restOperations, root, schedulerGroup);
     }
 
     @Override
     public Mono<CreateIdentityZoneResponse> create(CreateIdentityZoneRequest request) {
         return post(request, CreateIdentityZoneResponse.class, builder -> builder.pathSegment("identity-zones"));
+    }
+
+    @Override
+    public Mono<Void> createClient(CreateIdentityZoneClientRequest request) {
+        return post(request, Void.class, builder -> builder.pathSegment("identity-zones", request.getIdentityZoneId(), "clients"));
     }
 
     @Override

--- a/cloudfoundry-client-spring/src/test/java/org/cloudfoundry/spring/uaa/SpringUaaClientTest.java
+++ b/cloudfoundry-client-spring/src/test/java/org/cloudfoundry/spring/uaa/SpringUaaClientTest.java
@@ -31,8 +31,8 @@ public final class SpringUaaClientTest extends AbstractRestTest {
     }
 
     @Test
-    public void identityZoneManagement() {
-        assertNotNull(this.client.identityZoneManagement());
+    public void identityZones() {
+        assertNotNull(this.client.identityZones());
     }
 
 }

--- a/cloudfoundry-client-spring/src/test/java/org/cloudfoundry/spring/uaa/identityzones/SpringIdentityZonesTest.java
+++ b/cloudfoundry-client-spring/src/test/java/org/cloudfoundry/spring/uaa/identityzones/SpringIdentityZonesTest.java
@@ -14,20 +14,21 @@
  * limitations under the License.
  */
 
-package org.cloudfoundry.spring.uaa.identityzonemanagement;
+package org.cloudfoundry.spring.uaa.identityzones;
 
 import org.cloudfoundry.spring.AbstractApiTest;
-import org.cloudfoundry.uaa.identityzonemanagement.CreateIdentityZoneRequest;
-import org.cloudfoundry.uaa.identityzonemanagement.CreateIdentityZoneResponse;
-import org.cloudfoundry.uaa.identityzonemanagement.DeleteIdentityZoneRequest;
-import org.cloudfoundry.uaa.identityzonemanagement.DeleteIdentityZoneResponse;
-import org.cloudfoundry.uaa.identityzonemanagement.GetIdentityZoneRequest;
-import org.cloudfoundry.uaa.identityzonemanagement.GetIdentityZoneResponse;
-import org.cloudfoundry.uaa.identityzonemanagement.IdentityZone;
-import org.cloudfoundry.uaa.identityzonemanagement.ListIdentityZoneRequest;
-import org.cloudfoundry.uaa.identityzonemanagement.ListIdentityZoneResponse;
-import org.cloudfoundry.uaa.identityzonemanagement.UpdateIdentityZoneRequest;
-import org.cloudfoundry.uaa.identityzonemanagement.UpdateIdentityZoneResponse;
+import org.cloudfoundry.uaa.identityzones.CreateIdentityZoneClientRequest;
+import org.cloudfoundry.uaa.identityzones.CreateIdentityZoneRequest;
+import org.cloudfoundry.uaa.identityzones.CreateIdentityZoneResponse;
+import org.cloudfoundry.uaa.identityzones.DeleteIdentityZoneRequest;
+import org.cloudfoundry.uaa.identityzones.DeleteIdentityZoneResponse;
+import org.cloudfoundry.uaa.identityzones.GetIdentityZoneRequest;
+import org.cloudfoundry.uaa.identityzones.GetIdentityZoneResponse;
+import org.cloudfoundry.uaa.identityzones.IdentityZone;
+import org.cloudfoundry.uaa.identityzones.ListIdentityZoneRequest;
+import org.cloudfoundry.uaa.identityzones.ListIdentityZoneResponse;
+import org.cloudfoundry.uaa.identityzones.UpdateIdentityZoneRequest;
+import org.cloudfoundry.uaa.identityzones.UpdateIdentityZoneResponse;
 import reactor.core.publisher.Mono;
 
 import static org.springframework.http.HttpMethod.DELETE;
@@ -37,11 +38,11 @@ import static org.springframework.http.HttpMethod.PUT;
 import static org.springframework.http.HttpStatus.CREATED;
 import static org.springframework.http.HttpStatus.OK;
 
-public final class SpringIdentityZoneManagementTest {
+public final class SpringIdentityZonesTest {
 
     public static final class Create extends AbstractApiTest<CreateIdentityZoneRequest, CreateIdentityZoneResponse> {
 
-        private final SpringIdentityZoneManagement identityZoneManagement = new SpringIdentityZoneManagement(this.restTemplate, this.root, PROCESSOR_GROUP);
+        private final SpringIdentityZones identityZoneManagement = new SpringIdentityZones(this.restTemplate, this.root, PROCESSOR_GROUP);
 
         @Override
         protected CreateIdentityZoneRequest getInvalidRequest() {
@@ -85,9 +86,50 @@ public final class SpringIdentityZoneManagementTest {
         }
     }
 
+    public static final class CreateClient extends AbstractApiTest<CreateIdentityZoneClientRequest, Void> {
+
+        private final SpringIdentityZones identityZoneManagement = new SpringIdentityZones(this.restTemplate, this.root, PROCESSOR_GROUP);
+
+        @Override
+        protected CreateIdentityZoneClientRequest getInvalidRequest() {
+            return CreateIdentityZoneClientRequest.builder().build();
+        }
+
+        @Override
+        protected RequestContext getRequestContext() {
+            return new RequestContext()
+                .method(POST).path("/identity-zones/test-zone-id/clients")
+                .requestPayload("fixtures/uaa/identity-zones/POST_{id}_clients_request.json")
+                .status(CREATED);
+        }
+
+        @Override
+        protected Void getResponse() {
+            return null;
+        }
+
+        @Override
+        protected CreateIdentityZoneClientRequest getValidRequest() throws Exception {
+            return CreateIdentityZoneClientRequest.builder()
+                .identityZoneId("test-zone-id")
+                .allowedProvider("uaa")
+                .authority("uaa.resource")
+                .authorizedGrantType("authorization_code")
+                .clientId("limited-client")
+                .clientSecret("limited-client-secret")
+                .scope("openid")
+                .build();
+        }
+
+        @Override
+        protected Mono<Void> invoke(CreateIdentityZoneClientRequest request) {
+            return this.identityZoneManagement.createClient(request);
+        }
+    }
+
     public static final class Delete extends AbstractApiTest<DeleteIdentityZoneRequest, DeleteIdentityZoneResponse> {
 
-        private final SpringIdentityZoneManagement identityZoneManagement = new SpringIdentityZoneManagement(this.restTemplate, this.root, PROCESSOR_GROUP);
+        private final SpringIdentityZones identityZoneManagement = new SpringIdentityZones(this.restTemplate, this.root, PROCESSOR_GROUP);
 
         @Override
         protected DeleteIdentityZoneRequest getInvalidRequest() {
@@ -130,7 +172,7 @@ public final class SpringIdentityZoneManagementTest {
 
     public static final class Get extends AbstractApiTest<GetIdentityZoneRequest, GetIdentityZoneResponse> {
 
-        private final SpringIdentityZoneManagement identityZoneManagement = new SpringIdentityZoneManagement(this.restTemplate, this.root, PROCESSOR_GROUP);
+        private final SpringIdentityZones identityZoneManagement = new SpringIdentityZones(this.restTemplate, this.root, PROCESSOR_GROUP);
 
         @Override
         protected GetIdentityZoneRequest getInvalidRequest() {
@@ -173,7 +215,7 @@ public final class SpringIdentityZoneManagementTest {
 
     public static final class List extends AbstractApiTest<ListIdentityZoneRequest, ListIdentityZoneResponse> {
 
-        private final SpringIdentityZoneManagement identityZoneManagement = new SpringIdentityZoneManagement(this.restTemplate, this.root, PROCESSOR_GROUP);
+        private final SpringIdentityZones identityZoneManagement = new SpringIdentityZones(this.restTemplate, this.root, PROCESSOR_GROUP);
 
         @Override
         protected ListIdentityZoneRequest getInvalidRequest() {
@@ -225,7 +267,7 @@ public final class SpringIdentityZoneManagementTest {
 
     public static final class Update extends AbstractApiTest<UpdateIdentityZoneRequest, UpdateIdentityZoneResponse> {
 
-        private final SpringIdentityZoneManagement identityZoneManagement = new SpringIdentityZoneManagement(this.restTemplate, this.root, PROCESSOR_GROUP);
+        private final SpringIdentityZones identityZoneManagement = new SpringIdentityZones(this.restTemplate, this.root, PROCESSOR_GROUP);
 
         @Override
         protected UpdateIdentityZoneRequest getInvalidRequest() {

--- a/cloudfoundry-client-spring/src/test/resources/fixtures/uaa/identity-zones/POST_{id}_clients_request.json
+++ b/cloudfoundry-client-spring/src/test/resources/fixtures/uaa/identity-zones/POST_{id}_clients_request.json
@@ -1,0 +1,16 @@
+{
+  "allowedproviders": [
+    "uaa"
+  ],
+  "authorities": [
+    "uaa.resource"
+  ],
+  "authorized_grant_types": [
+    "authorization_code"
+  ],
+  "client_id": "limited-client",
+  "client_secret": "limited-client-secret",
+  "scope": [
+    "openid"
+  ]
+}

--- a/cloudfoundry-client/src/main/java/org/cloudfoundry/uaa/UaaClient.java
+++ b/cloudfoundry-client/src/main/java/org/cloudfoundry/uaa/UaaClient.java
@@ -17,7 +17,7 @@
 package org.cloudfoundry.uaa;
 
 import org.cloudfoundry.uaa.accesstokenadministration.AccessTokenAdministration;
-import org.cloudfoundry.uaa.identityzonemanagement.IdentityZoneManagement;
+import org.cloudfoundry.uaa.identityzones.IdentityZones;
 
 /**
  * Main entry point to the UAA Client API
@@ -32,10 +32,10 @@ public interface UaaClient {
     AccessTokenAdministration accessTokenAdministration();
 
     /**
-     * Main entry point to the UAA Identity Zone Management Client API
+     * Main entry point to the UAA Identity Zones Client API
      *
-     * @return the UAA Identity Zone Management Client API
+     * @return the UAA Identity Zones Client API
      */
-    IdentityZoneManagement identityZoneManagement();
+    IdentityZones identityZones();
 
 }

--- a/cloudfoundry-client/src/main/java/org/cloudfoundry/uaa/identityzones/IdentityZones.java
+++ b/cloudfoundry-client/src/main/java/org/cloudfoundry/uaa/identityzones/IdentityZones.java
@@ -14,14 +14,14 @@
  * limitations under the License.
  */
 
-package org.cloudfoundry.uaa.identityzonemanagement;
+package org.cloudfoundry.uaa.identityzones;
 
 import reactor.core.publisher.Mono;
 
 /**
- * Main entry point to the UAA Identity Zone Management Client API
+ * Main entry point to the UAA Identity Zones Client API
  */
-public interface IdentityZoneManagement {
+public interface IdentityZones {
 
     /**
      * Makes the <a href="https://github.com/cloudfoundry/uaa/blob/master/docs/UAA-APIs.rst#create-or-update-identity-zones-post-or-put-identity-zones">Create Identity Zone</a> request
@@ -30,6 +30,14 @@ public interface IdentityZoneManagement {
      * @return the response from the Create Identity Zone request
      */
     Mono<CreateIdentityZoneResponse> create(CreateIdentityZoneRequest request);
+
+    /**
+     * Makes the <a href="https://github.com/cloudfoundry/uaa/blob/master/docs/UAA-APIs.rst#identity-zone-clients-api-identity-zones-clients">Create Identity Zone Client</a> request
+     *
+     * @param request the Create Identity Zone Client request
+     * @return the response from the Create Identity Zone Client request
+     */
+    Mono<Void> createClient(CreateIdentityZoneClientRequest request);
 
     /**
      * Makes the <a href="https://github.com/cloudfoundry/uaa/blob/master/docs/UAA-APIs.rst#delete-single-identity-zone-delete-identity-zones-identityzoneid">Delete the Identity Zone</a> request

--- a/cloudfoundry-client/src/main/lombok/org/cloudfoundry/uaa/identityzones/AbstractIdentityZone.java
+++ b/cloudfoundry-client/src/main/lombok/org/cloudfoundry/uaa/identityzones/AbstractIdentityZone.java
@@ -14,20 +14,24 @@
  * limitations under the License.
  */
 
-package org.cloudfoundry.uaa.identityzonemanagement;
+package org.cloudfoundry.uaa.identityzones;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
-import lombok.Builder;
 import lombok.Data;
-import lombok.Getter;
-import org.cloudfoundry.Validatable;
-import org.cloudfoundry.ValidationResult;
 
 /**
- * The request payload for the create identity zone operation
+ * The entity response payload for Identity Zone
  */
 @Data
-public final class CreateIdentityZoneRequest implements Validatable {
+public abstract class AbstractIdentityZone {
+
+    /**
+     * The creation date of the identity zone.
+     *
+     * @param createdAt the creation date
+     * @return the creation date
+     */
+    private final Long createdAt;
 
     /**
      * The description of the identity zone.
@@ -35,16 +39,14 @@ public final class CreateIdentityZoneRequest implements Validatable {
      * @param description the description
      * @return the description
      */
-    @Getter(onMethod = @__(@JsonProperty("description")))
     private final String description;
 
     /**
-     * The id of the identity zone. When not provided, an identifier will be generated
+     * The id of the identity zone.
      *
      * @param identityZoneId the identity zone id
      * @return the identity zone id
      */
-    @Getter(onMethod = @__(@JsonProperty("id")))
     private final String identityZoneId;
 
     /**
@@ -53,17 +55,23 @@ public final class CreateIdentityZoneRequest implements Validatable {
      * @param name the name
      * @return the name
      */
-    @Getter(onMethod = @__(@JsonProperty("name")))
     private final String name;
 
     /**
-     * The unique subdomain. It will be converted into lowercase upon creation.
+     * The unique sub domain. It will be converted into lowercase upon creation.
      *
-     * @param subdomain the subdomain
-     * @return the subdomain
+     * @param subdomain the sub domain
+     * @return the sub domain
      */
-    @Getter(onMethod = @__(@JsonProperty("subdomain")))
     private final String subdomain;
+
+    /**
+     * The last modification date of the identity zone.
+     *
+     * @param updatedAt the last modification date
+     * @return the last modification date
+     */
+    private final Long updatedAt;
 
     /**
      * The version of the identity zone.
@@ -71,35 +79,22 @@ public final class CreateIdentityZoneRequest implements Validatable {
      * @param version the version
      * @return the version
      */
-    @Getter(onMethod = @__(@JsonProperty("version")))
     private final Integer version;
 
-    @Builder
-    CreateIdentityZoneRequest(String description,
-                              String identityZoneId,
-                              String name,
-                              String subdomain,
-                              Integer version) {
+    AbstractIdentityZone(@JsonProperty("created") Long createdAt,
+                         @JsonProperty("description") String description,
+                         @JsonProperty("id") String identityZoneId,
+                         @JsonProperty("name") String name,
+                         @JsonProperty("subdomain") String subdomain,
+                         @JsonProperty("last_modified") Long updatedAt,
+                         @JsonProperty("version") Integer version) {
+        this.createdAt = createdAt;
         this.description = description;
         this.identityZoneId = identityZoneId;
         this.name = name;
         this.subdomain = subdomain;
+        this.updatedAt = updatedAt;
         this.version = version;
-    }
-
-    @Override
-    public ValidationResult isValid() {
-        ValidationResult.ValidationResultBuilder builder = ValidationResult.builder();
-
-        if (this.name == null) {
-            builder.message("name must be specified");
-        }
-
-        if (this.subdomain == null) {
-            builder.message("sub domain must be specified");
-        }
-
-        return builder.build();
     }
 
 }

--- a/cloudfoundry-client/src/main/lombok/org/cloudfoundry/uaa/identityzones/CreateIdentityZoneClientRequest.java
+++ b/cloudfoundry-client/src/main/lombok/org/cloudfoundry/uaa/identityzones/CreateIdentityZoneClientRequest.java
@@ -1,0 +1,199 @@
+/*
+ * Copyright 2013-2016 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.cloudfoundry.uaa.identityzones;
+
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.Builder;
+import lombok.Data;
+import lombok.Getter;
+import lombok.Singular;
+import org.cloudfoundry.Validatable;
+import org.cloudfoundry.ValidationResult;
+
+import java.util.List;
+
+import static com.fasterxml.jackson.annotation.JsonInclude.Include.NON_EMPTY;
+
+/**
+ * The request payload for the create identity zone client operation
+ */
+@Data
+public final class CreateIdentityZoneClientRequest implements Validatable {
+
+    /**
+     * The access token validity.
+     *
+     * @param accessTokenValidity the access token validity
+     * @return the access token validity
+     */
+    @Getter(onMethod = @__(@JsonProperty("access_token_validity")))
+    private final Integer accessTokenValidity;
+
+    /**
+     * The allowed providers.
+     *
+     * @param allowedProviders the allowed providers
+     * @return the allowed providers
+     */
+    @Getter(onMethod = @__(@JsonProperty("allowedproviders")))
+    private final List<String> allowedProviders;
+
+    /**
+     * The authorities.
+     *
+     * @param authorities the authorities
+     * @return the authorities
+     */
+    @Getter(onMethod = @__(@JsonProperty("authorities")))
+    private final List<String> authorities;
+
+    /**
+     * The authorized grant types.
+     *
+     * @param authorizedGrantTypes the authorized grant types
+     * @return the authorized grant types
+     */
+    @Getter(onMethod = @__(@JsonProperty("authorized_grant_types")))
+    private final List<String> authorizedGrantTypes;
+
+    /**
+     * The auto approves
+     *
+     * @param autoApproves the auto approves
+     * @return the auto approves
+     */
+    @Getter(onMethod = @__({@JsonProperty("autoapprove"), @JsonInclude(NON_EMPTY)}))
+    private final List<String> autoApproves;
+
+    /**
+     * The client id.
+     *
+     * @param clientId the client id
+     * @return the client id
+     */
+    @Getter(onMethod = @__(@JsonProperty("client_id")))
+    private final String clientId;
+
+    /**
+     * The client secret.
+     *
+     * @param clientSecret the client secret
+     * @return the client secret
+     */
+    @Getter(onMethod = @__(@JsonProperty("client_secret")))
+    private final String clientSecret;
+
+    /**
+     * The identity zone id.
+     *
+     * @param identityZoneId the identity zone id
+     * @return the identity zone id
+     */
+    @Getter(onMethod = @__(@JsonIgnore))
+    private final String identityZoneId;
+
+    /**
+     * The redirect uri.
+     *
+     * @param redirectUri the redirect uri
+     * @return the redirect uri
+     */
+    @Getter(onMethod = @__(@JsonProperty("redirect_uri")))
+    private final String redirectUri;
+
+    /**
+     * The refresh token validity.
+     *
+     * @param refreshTokenValidity the refresh token validity
+     * @return the refresh token validity
+     */
+    @Getter(onMethod = @__(@JsonProperty("refresh_token_validity")))
+    private final Integer refreshTokenValidity;
+
+    /**
+     * The scopes.
+     *
+     * @param scopes the scopes
+     * @return the scopes
+     */
+    @Getter(onMethod = @__(@JsonProperty("scope")))
+    private final List<String> scopes;
+
+    @Builder
+    CreateIdentityZoneClientRequest(Integer accessTokenValidity,
+                                    @Singular List<String> allowedProviders,
+                                    @Singular List<String> authorities,
+                                    @Singular List<String> authorizedGrantTypes,
+                                    @Singular List<String> autoApproves,
+                                    String clientId,
+                                    String clientSecret,
+                                    String identityZoneId,
+                                    String redirectUri,
+                                    Integer refreshTokenValidity,
+                                    @Singular List<String> scopes) {
+        this.accessTokenValidity = accessTokenValidity;
+        this.allowedProviders = allowedProviders;
+        this.authorities = authorities;
+        this.authorizedGrantTypes = authorizedGrantTypes;
+        this.autoApproves = autoApproves;
+        this.clientId = clientId;
+        this.clientSecret = clientSecret;
+        this.identityZoneId = identityZoneId;
+        this.redirectUri = redirectUri;
+        this.refreshTokenValidity = refreshTokenValidity;
+        this.scopes = scopes;
+    }
+
+    @Override
+    public ValidationResult isValid() {
+        ValidationResult.ValidationResultBuilder builder = ValidationResult.builder();
+
+        if (this.identityZoneId == null) {
+            builder.message("identity zone id must be specified");
+        }
+
+        if (this.clientId == null) {
+            builder.message("client id must be specified");
+        }
+
+        if (this.clientSecret == null) {
+            builder.message("client secret must be specified");
+        }
+
+        if (this.authorizedGrantTypes == null || this.authorizedGrantTypes.isEmpty()) {
+            builder.message("authorized grant types must be specified");
+        }
+
+        if (this.scopes == null || this.scopes.isEmpty()) {
+            builder.message("scopes must be specified");
+        }
+
+        if (this.authorities == null || this.authorities.isEmpty()) {
+            builder.message("authorities must be specified");
+        }
+
+        if (this.allowedProviders == null || this.allowedProviders.isEmpty()) {
+            builder.message("allowed providers must be specified");
+        }
+
+        return builder.build();
+    }
+
+}
+

--- a/cloudfoundry-client/src/main/lombok/org/cloudfoundry/uaa/identityzones/CreateIdentityZoneRequest.java
+++ b/cloudfoundry-client/src/main/lombok/org/cloudfoundry/uaa/identityzones/CreateIdentityZoneRequest.java
@@ -14,24 +14,20 @@
  * limitations under the License.
  */
 
-package org.cloudfoundry.uaa.identityzonemanagement;
+package org.cloudfoundry.uaa.identityzones;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.Builder;
 import lombok.Data;
+import lombok.Getter;
+import org.cloudfoundry.Validatable;
+import org.cloudfoundry.ValidationResult;
 
 /**
- * The entity response payload for Identity Zone
+ * The request payload for the create identity zone operation
  */
 @Data
-public abstract class AbstractIdentityZone {
-
-    /**
-     * The creation date of the identity zone.
-     *
-     * @param createdAt the creation date
-     * @return the creation date
-     */
-    private final Long createdAt;
+public final class CreateIdentityZoneRequest implements Validatable {
 
     /**
      * The description of the identity zone.
@@ -39,14 +35,16 @@ public abstract class AbstractIdentityZone {
      * @param description the description
      * @return the description
      */
+    @Getter(onMethod = @__(@JsonProperty("description")))
     private final String description;
 
     /**
-     * The id of the identity zone.
+     * The id of the identity zone. When not provided, an identifier will be generated
      *
      * @param identityZoneId the identity zone id
      * @return the identity zone id
      */
+    @Getter(onMethod = @__(@JsonProperty("id")))
     private final String identityZoneId;
 
     /**
@@ -55,23 +53,17 @@ public abstract class AbstractIdentityZone {
      * @param name the name
      * @return the name
      */
+    @Getter(onMethod = @__(@JsonProperty("name")))
     private final String name;
 
     /**
-     * The unique sub domain. It will be converted into lowercase upon creation.
+     * The unique subdomain. It will be converted into lowercase upon creation.
      *
-     * @param subdomain the sub domain
-     * @return the sub domain
+     * @param subdomain the subdomain
+     * @return the subdomain
      */
+    @Getter(onMethod = @__(@JsonProperty("subdomain")))
     private final String subdomain;
-
-    /**
-     * The last modification date of the identity zone.
-     *
-     * @param updatedAt the last modification date
-     * @return the last modification date
-     */
-    private final Long updatedAt;
 
     /**
      * The version of the identity zone.
@@ -79,22 +71,35 @@ public abstract class AbstractIdentityZone {
      * @param version the version
      * @return the version
      */
+    @Getter(onMethod = @__(@JsonProperty("version")))
     private final Integer version;
 
-    AbstractIdentityZone(@JsonProperty("created") Long createdAt,
-                         @JsonProperty("description") String description,
-                         @JsonProperty("id") String identityZoneId,
-                         @JsonProperty("name") String name,
-                         @JsonProperty("subdomain") String subdomain,
-                         @JsonProperty("last_modified") Long updatedAt,
-                         @JsonProperty("version") Integer version) {
-        this.createdAt = createdAt;
+    @Builder
+    CreateIdentityZoneRequest(String description,
+                              String identityZoneId,
+                              String name,
+                              String subdomain,
+                              Integer version) {
         this.description = description;
         this.identityZoneId = identityZoneId;
         this.name = name;
         this.subdomain = subdomain;
-        this.updatedAt = updatedAt;
         this.version = version;
+    }
+
+    @Override
+    public ValidationResult isValid() {
+        ValidationResult.ValidationResultBuilder builder = ValidationResult.builder();
+
+        if (this.name == null) {
+            builder.message("name must be specified");
+        }
+
+        if (this.subdomain == null) {
+            builder.message("sub domain must be specified");
+        }
+
+        return builder.build();
     }
 
 }

--- a/cloudfoundry-client/src/main/lombok/org/cloudfoundry/uaa/identityzones/CreateIdentityZoneResponse.java
+++ b/cloudfoundry-client/src/main/lombok/org/cloudfoundry/uaa/identityzones/CreateIdentityZoneResponse.java
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package org.cloudfoundry.uaa.identityzonemanagement;
+package org.cloudfoundry.uaa.identityzones;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.Builder;
@@ -23,21 +23,21 @@ import lombok.EqualsAndHashCode;
 import lombok.ToString;
 
 /**
- * The resource response payload for Identity Zones
+ * The response from the create identity zone request
  */
 @Data
 @EqualsAndHashCode(callSuper = true)
 @ToString(callSuper = true)
-public final class IdentityZone extends AbstractIdentityZone {
+public final class CreateIdentityZoneResponse extends AbstractIdentityZone {
 
     @Builder
-    IdentityZone(@JsonProperty("created") Long createdAt,
-                 @JsonProperty("description") String description,
-                 @JsonProperty("id") String identityZoneId,
-                 @JsonProperty("name") String name,
-                 @JsonProperty("subdomain") String subdomain,
-                 @JsonProperty("last_modified") Long updatedAt,
-                 @JsonProperty("version") Integer version) {
+    CreateIdentityZoneResponse(@JsonProperty("created") Long createdAt,
+                               @JsonProperty("description") String description,
+                               @JsonProperty("id") String identityZoneId,
+                               @JsonProperty("name") String name,
+                               @JsonProperty("subdomain") String subdomain,
+                               @JsonProperty("last_modified") Long updatedAt,
+                               @JsonProperty("version") Integer version) {
 
         super(createdAt, description, identityZoneId, name, subdomain, updatedAt, version);
     }

--- a/cloudfoundry-client/src/main/lombok/org/cloudfoundry/uaa/identityzones/DeleteIdentityZoneRequest.java
+++ b/cloudfoundry-client/src/main/lombok/org/cloudfoundry/uaa/identityzones/DeleteIdentityZoneRequest.java
@@ -14,26 +14,45 @@
  * limitations under the License.
  */
 
-package org.cloudfoundry.uaa.identityzonemanagement;
+package org.cloudfoundry.uaa.identityzones;
 
+
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import lombok.Builder;
 import lombok.Data;
+import lombok.Getter;
 import org.cloudfoundry.Validatable;
 import org.cloudfoundry.ValidationResult;
 
 /**
- * The request payload for the lis identity zones operation
+ * The request payload for the Delete Identity Zone operation
  */
 @Data
-public final class ListIdentityZoneRequest implements Validatable {
+public final class DeleteIdentityZoneRequest implements Validatable {
+
+    /**
+     * The identity zone id
+     *
+     * @param identityZoneId the identity zone id
+     * @return the identity zone id
+     */
+    @Getter(onMethod = @__(@JsonIgnore))
+    private final String identityZoneId;
 
     @Builder
-    ListIdentityZoneRequest() {
+    DeleteIdentityZoneRequest(String identityZoneId) {
+        this.identityZoneId = identityZoneId;
     }
 
     @Override
     public ValidationResult isValid() {
-        return ValidationResult.builder().build();
+        ValidationResult.ValidationResultBuilder builder = ValidationResult.builder();
+
+        if (this.identityZoneId == null) {
+            builder.message("identity zone id must be specified");
+        }
+
+        return builder.build();
     }
 
 }

--- a/cloudfoundry-client/src/main/lombok/org/cloudfoundry/uaa/identityzones/DeleteIdentityZoneResponse.java
+++ b/cloudfoundry-client/src/main/lombok/org/cloudfoundry/uaa/identityzones/DeleteIdentityZoneResponse.java
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package org.cloudfoundry.uaa.identityzonemanagement;
+package org.cloudfoundry.uaa.identityzones;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.Builder;

--- a/cloudfoundry-client/src/main/lombok/org/cloudfoundry/uaa/identityzones/GetIdentityZoneRequest.java
+++ b/cloudfoundry-client/src/main/lombok/org/cloudfoundry/uaa/identityzones/GetIdentityZoneRequest.java
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package org.cloudfoundry.uaa.identityzonemanagement;
+package org.cloudfoundry.uaa.identityzones;
 
 
 import com.fasterxml.jackson.annotation.JsonIgnore;

--- a/cloudfoundry-client/src/main/lombok/org/cloudfoundry/uaa/identityzones/GetIdentityZoneResponse.java
+++ b/cloudfoundry-client/src/main/lombok/org/cloudfoundry/uaa/identityzones/GetIdentityZoneResponse.java
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package org.cloudfoundry.uaa.identityzonemanagement;
+package org.cloudfoundry.uaa.identityzones;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.Builder;

--- a/cloudfoundry-client/src/main/lombok/org/cloudfoundry/uaa/identityzones/IdentityZone.java
+++ b/cloudfoundry-client/src/main/lombok/org/cloudfoundry/uaa/identityzones/IdentityZone.java
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package org.cloudfoundry.uaa.identityzonemanagement;
+package org.cloudfoundry.uaa.identityzones;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.Builder;
@@ -23,21 +23,21 @@ import lombok.EqualsAndHashCode;
 import lombok.ToString;
 
 /**
- * The response from the update identity zone request
+ * The resource response payload for Identity Zones
  */
 @Data
 @EqualsAndHashCode(callSuper = true)
 @ToString(callSuper = true)
-public final class UpdateIdentityZoneResponse extends AbstractIdentityZone {
+public final class IdentityZone extends AbstractIdentityZone {
 
     @Builder
-    UpdateIdentityZoneResponse(@JsonProperty("created") Long createdAt,
-                               @JsonProperty("description") String description,
-                               @JsonProperty("id") String identityZoneId,
-                               @JsonProperty("name") String name,
-                               @JsonProperty("subdomain") String subdomain,
-                               @JsonProperty("last_modified") Long updatedAt,
-                               @JsonProperty("version") Integer version) {
+    IdentityZone(@JsonProperty("created") Long createdAt,
+                 @JsonProperty("description") String description,
+                 @JsonProperty("id") String identityZoneId,
+                 @JsonProperty("name") String name,
+                 @JsonProperty("subdomain") String subdomain,
+                 @JsonProperty("last_modified") Long updatedAt,
+                 @JsonProperty("version") Integer version) {
 
         super(createdAt, description, identityZoneId, name, subdomain, updatedAt, version);
     }

--- a/cloudfoundry-client/src/main/lombok/org/cloudfoundry/uaa/identityzones/ListIdentityZoneRequest.java
+++ b/cloudfoundry-client/src/main/lombok/org/cloudfoundry/uaa/identityzones/ListIdentityZoneRequest.java
@@ -14,45 +14,26 @@
  * limitations under the License.
  */
 
-package org.cloudfoundry.uaa.identityzonemanagement;
+package org.cloudfoundry.uaa.identityzones;
 
-
-import com.fasterxml.jackson.annotation.JsonIgnore;
 import lombok.Builder;
 import lombok.Data;
-import lombok.Getter;
 import org.cloudfoundry.Validatable;
 import org.cloudfoundry.ValidationResult;
 
 /**
- * The request payload for the Delete Identity Zone operation
+ * The request payload for the lis identity zones operation
  */
 @Data
-public final class DeleteIdentityZoneRequest implements Validatable {
-
-    /**
-     * The identity zone id
-     *
-     * @param identityZoneId the identity zone id
-     * @return the identity zone id
-     */
-    @Getter(onMethod = @__(@JsonIgnore))
-    private final String identityZoneId;
+public final class ListIdentityZoneRequest implements Validatable {
 
     @Builder
-    DeleteIdentityZoneRequest(String identityZoneId) {
-        this.identityZoneId = identityZoneId;
+    ListIdentityZoneRequest() {
     }
 
     @Override
     public ValidationResult isValid() {
-        ValidationResult.ValidationResultBuilder builder = ValidationResult.builder();
-
-        if (this.identityZoneId == null) {
-            builder.message("identity zone id must be specified");
-        }
-
-        return builder.build();
+        return ValidationResult.builder().build();
     }
 
 }

--- a/cloudfoundry-client/src/main/lombok/org/cloudfoundry/uaa/identityzones/ListIdentityZoneResponse.java
+++ b/cloudfoundry-client/src/main/lombok/org/cloudfoundry/uaa/identityzones/ListIdentityZoneResponse.java
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package org.cloudfoundry.uaa.identityzonemanagement;
+package org.cloudfoundry.uaa.identityzones;
 
 
 import com.fasterxml.jackson.annotation.JsonCreator;

--- a/cloudfoundry-client/src/main/lombok/org/cloudfoundry/uaa/identityzones/UpdateIdentityZoneRequest.java
+++ b/cloudfoundry-client/src/main/lombok/org/cloudfoundry/uaa/identityzones/UpdateIdentityZoneRequest.java
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package org.cloudfoundry.uaa.identityzonemanagement;
+package org.cloudfoundry.uaa.identityzones;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;

--- a/cloudfoundry-client/src/main/lombok/org/cloudfoundry/uaa/identityzones/UpdateIdentityZoneResponse.java
+++ b/cloudfoundry-client/src/main/lombok/org/cloudfoundry/uaa/identityzones/UpdateIdentityZoneResponse.java
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package org.cloudfoundry.uaa.identityzonemanagement;
+package org.cloudfoundry.uaa.identityzones;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.Builder;
@@ -23,15 +23,15 @@ import lombok.EqualsAndHashCode;
 import lombok.ToString;
 
 /**
- * The response from the create identity zone request
+ * The response from the update identity zone request
  */
 @Data
 @EqualsAndHashCode(callSuper = true)
 @ToString(callSuper = true)
-public final class CreateIdentityZoneResponse extends AbstractIdentityZone {
+public final class UpdateIdentityZoneResponse extends AbstractIdentityZone {
 
     @Builder
-    CreateIdentityZoneResponse(@JsonProperty("created") Long createdAt,
+    UpdateIdentityZoneResponse(@JsonProperty("created") Long createdAt,
                                @JsonProperty("description") String description,
                                @JsonProperty("id") String identityZoneId,
                                @JsonProperty("name") String name,

--- a/cloudfoundry-client/src/test/java/org/cloudfoundry/uaa/identityzones/CreateIdentityZoneClientRequestTest.java
+++ b/cloudfoundry-client/src/test/java/org/cloudfoundry/uaa/identityzones/CreateIdentityZoneClientRequestTest.java
@@ -1,0 +1,156 @@
+/*
+ * Copyright 2013-2016 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.cloudfoundry.uaa.identityzones;
+
+import org.cloudfoundry.ValidationResult;
+import org.junit.Test;
+
+import static org.cloudfoundry.ValidationResult.Status.INVALID;
+import static org.cloudfoundry.ValidationResult.Status.VALID;
+import static org.junit.Assert.assertEquals;
+
+public final class CreateIdentityZoneClientRequestTest {
+
+    @Test
+    public void isNotValidNoAllowedProvider() {
+        ValidationResult result = CreateIdentityZoneClientRequest.builder()
+            .authorizedGrantType("test-authorized-grant-type")
+            .authority("test-authority")
+            .clientId("test-client-id")
+            .clientSecret("test-client-secret")
+            .identityZoneId("test-identity-zone-id")
+            .scope("test-scope")
+            .build()
+            .isValid();
+
+        assertEquals(INVALID, result.getStatus());
+        assertEquals("allowed providers must be specified", result.getMessages().get(0));
+    }
+
+    @Test
+    public void isNotValidNoAuthority() {
+        ValidationResult result = CreateIdentityZoneClientRequest.builder()
+            .allowedProvider("test-allow-provider")
+            .authorizedGrantType("test-authorized-grant-type")
+            .clientId("test-client-id")
+            .clientSecret("test-client-secret")
+            .identityZoneId("test-identity-zone-id")
+            .scope("test-scope")
+            .build()
+            .isValid();
+
+        assertEquals(INVALID, result.getStatus());
+        assertEquals("authorities must be specified", result.getMessages().get(0));
+    }
+
+    @Test
+    public void isNotValidNoAuthorizedGrantType() {
+        ValidationResult result = CreateIdentityZoneClientRequest.builder()
+            .allowedProvider("test-allow-provider")
+            .authority("test-authority")
+            .clientId("test-client-id")
+            .clientSecret("test-client-secret")
+            .identityZoneId("test-identity-zone-id")
+            .scope("test-scope")
+            .build()
+            .isValid();
+
+        assertEquals(INVALID, result.getStatus());
+        assertEquals("authorized grant types must be specified", result.getMessages().get(0));
+    }
+
+    @Test
+    public void isNotValidNoClientId() {
+        ValidationResult result = CreateIdentityZoneClientRequest.builder()
+            .allowedProvider("test-allow-provider")
+            .authority("test-authority")
+            .authorizedGrantType("test-authorized-grant-type")
+            .clientSecret("test-client-secret")
+            .identityZoneId("test-identity-zone-id")
+            .scope("test-scope")
+            .build()
+            .isValid();
+
+        assertEquals(INVALID, result.getStatus());
+        assertEquals("client id must be specified", result.getMessages().get(0));
+    }
+
+    @Test
+    public void isNotValidNoClientSecret() {
+        ValidationResult result = CreateIdentityZoneClientRequest.builder()
+            .allowedProvider("test-allow-provider")
+            .authority("test-authority")
+            .authorizedGrantType("test-authorized-grant-type")
+            .clientId("test-client-id")
+            .identityZoneId("test-identity-zone-id")
+            .scope("test-scope")
+            .build()
+            .isValid();
+
+        assertEquals(INVALID, result.getStatus());
+        assertEquals("client secret must be specified", result.getMessages().get(0));
+    }
+
+    @Test
+    public void isNotValidNoIdentityZoneId() {
+        ValidationResult result = CreateIdentityZoneClientRequest.builder()
+            .allowedProvider("test-allow-provider")
+            .authority("test-authority")
+            .authorizedGrantType("test-authorized-grant-type")
+            .clientId("test-client-id")
+            .clientSecret("test-client-secret")
+            .scope("test-scope")
+            .build()
+            .isValid();
+
+        assertEquals(INVALID, result.getStatus());
+        assertEquals("identity zone id must be specified", result.getMessages().get(0));
+    }
+
+    @Test
+    public void isNotValidNoScope() {
+        ValidationResult result = CreateIdentityZoneClientRequest.builder()
+            .allowedProvider("test-allow-provider")
+            .authority("test-authority")
+            .authorizedGrantType("test-authorized-grant-type")
+            .clientId("test-client-id")
+            .clientSecret("test-client-secret")
+            .identityZoneId("test-identity-zone-id")
+            .build()
+            .isValid();
+
+        assertEquals(INVALID, result.getStatus());
+        assertEquals("scopes must be specified", result.getMessages().get(0));
+    }
+
+    @Test
+    public void isValid() {
+        ValidationResult result = CreateIdentityZoneClientRequest.builder()
+            .allowedProvider("test-allow-provider")
+            .authority("test-authority")
+            .authorizedGrantType("test-authorized-grant-type")
+            .clientId("test-client-id")
+            .clientSecret("test-client-secret")
+            .identityZoneId("test-identity-zone-id")
+            .scope("test-scope")
+            .build()
+            .isValid();
+
+        assertEquals(VALID, result.getStatus());
+    }
+
+}

--- a/cloudfoundry-client/src/test/java/org/cloudfoundry/uaa/identityzones/CreateIdentityZoneRequestTest.java
+++ b/cloudfoundry-client/src/test/java/org/cloudfoundry/uaa/identityzones/CreateIdentityZoneRequestTest.java
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package org.cloudfoundry.uaa.identityzonemanagement;
+package org.cloudfoundry.uaa.identityzones;
 
 import org.cloudfoundry.ValidationResult;
 import org.junit.Test;
@@ -23,22 +23,35 @@ import static org.cloudfoundry.ValidationResult.Status.INVALID;
 import static org.cloudfoundry.ValidationResult.Status.VALID;
 import static org.junit.Assert.assertEquals;
 
-public final class GetIdentityZoneRequestTest {
+public final class CreateIdentityZoneRequestTest {
 
     @Test
-    public void isNotValidNoId() {
-        ValidationResult result = GetIdentityZoneRequest.builder()
+    public void isNotValidNoName() {
+        ValidationResult result = CreateIdentityZoneRequest.builder()
+            .subdomain("test-sub-domain")
             .build()
             .isValid();
 
         assertEquals(INVALID, result.getStatus());
-        assertEquals("identity zone id must be specified", result.getMessages().get(0));
+        assertEquals("name must be specified", result.getMessages().get(0));
+    }
+
+    @Test
+    public void isNotValidNoSubdomain() {
+        ValidationResult result = CreateIdentityZoneRequest.builder()
+            .name("test-name")
+            .build()
+            .isValid();
+
+        assertEquals(INVALID, result.getStatus());
+        assertEquals("sub domain must be specified", result.getMessages().get(0));
     }
 
     @Test
     public void isValid() {
-        ValidationResult result = GetIdentityZoneRequest.builder()
-            .identityZoneId("test-identity-zone-id")
+        ValidationResult result = CreateIdentityZoneRequest.builder()
+            .name("test-name")
+            .subdomain("test-sub-domain")
             .build()
             .isValid();
 

--- a/cloudfoundry-client/src/test/java/org/cloudfoundry/uaa/identityzones/DeleteIdentityZoneRequestTest.java
+++ b/cloudfoundry-client/src/test/java/org/cloudfoundry/uaa/identityzones/DeleteIdentityZoneRequestTest.java
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package org.cloudfoundry.uaa.identityzonemanagement;
+package org.cloudfoundry.uaa.identityzones;
 
 import org.cloudfoundry.ValidationResult;
 import org.junit.Test;
@@ -23,35 +23,22 @@ import static org.cloudfoundry.ValidationResult.Status.INVALID;
 import static org.cloudfoundry.ValidationResult.Status.VALID;
 import static org.junit.Assert.assertEquals;
 
-public final class CreateIdentityZoneRequestTest {
+public final class DeleteIdentityZoneRequestTest {
 
     @Test
-    public void isNotValidNoName() {
-        ValidationResult result = CreateIdentityZoneRequest.builder()
-            .subdomain("test-sub-domain")
+    public void isNotValidNoId() {
+        ValidationResult result = DeleteIdentityZoneRequest.builder()
             .build()
             .isValid();
 
         assertEquals(INVALID, result.getStatus());
-        assertEquals("name must be specified", result.getMessages().get(0));
-    }
-
-    @Test
-    public void isNotValidNoSubdomain() {
-        ValidationResult result = CreateIdentityZoneRequest.builder()
-            .name("test-name")
-            .build()
-            .isValid();
-
-        assertEquals(INVALID, result.getStatus());
-        assertEquals("sub domain must be specified", result.getMessages().get(0));
+        assertEquals("identity zone id must be specified", result.getMessages().get(0));
     }
 
     @Test
     public void isValid() {
-        ValidationResult result = CreateIdentityZoneRequest.builder()
-            .name("test-name")
-            .subdomain("test-sub-domain")
+        ValidationResult result = DeleteIdentityZoneRequest.builder()
+            .identityZoneId("test-identity-zone-id")
             .build()
             .isValid();
 

--- a/cloudfoundry-client/src/test/java/org/cloudfoundry/uaa/identityzones/GetIdentityZoneRequestTest.java
+++ b/cloudfoundry-client/src/test/java/org/cloudfoundry/uaa/identityzones/GetIdentityZoneRequestTest.java
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package org.cloudfoundry.uaa.identityzonemanagement;
+package org.cloudfoundry.uaa.identityzones;
 
 import org.cloudfoundry.ValidationResult;
 import org.junit.Test;
@@ -23,11 +23,11 @@ import static org.cloudfoundry.ValidationResult.Status.INVALID;
 import static org.cloudfoundry.ValidationResult.Status.VALID;
 import static org.junit.Assert.assertEquals;
 
-public final class DeleteIdentityZoneRequestTest {
+public final class GetIdentityZoneRequestTest {
 
     @Test
     public void isNotValidNoId() {
-        ValidationResult result = DeleteIdentityZoneRequest.builder()
+        ValidationResult result = GetIdentityZoneRequest.builder()
             .build()
             .isValid();
 
@@ -37,7 +37,7 @@ public final class DeleteIdentityZoneRequestTest {
 
     @Test
     public void isValid() {
-        ValidationResult result = DeleteIdentityZoneRequest.builder()
+        ValidationResult result = GetIdentityZoneRequest.builder()
             .identityZoneId("test-identity-zone-id")
             .build()
             .isValid();

--- a/cloudfoundry-client/src/test/java/org/cloudfoundry/uaa/identityzones/ListIdentityZoneRequestTest.java
+++ b/cloudfoundry-client/src/test/java/org/cloudfoundry/uaa/identityzones/ListIdentityZoneRequestTest.java
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package org.cloudfoundry.uaa.identityzonemanagement;
+package org.cloudfoundry.uaa.identityzones;
 
 import org.cloudfoundry.ValidationResult;
 import org.junit.Test;

--- a/cloudfoundry-client/src/test/java/org/cloudfoundry/uaa/identityzones/UpdateIdentityZoneRequestTest.java
+++ b/cloudfoundry-client/src/test/java/org/cloudfoundry/uaa/identityzones/UpdateIdentityZoneRequestTest.java
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package org.cloudfoundry.uaa.identityzonemanagement;
+package org.cloudfoundry.uaa.identityzones;
 
 import org.cloudfoundry.ValidationResult;
 import org.junit.Test;


### PR DESCRIPTION
This change adds the api to create an identity zone client (```POST /identity-zones/{identityZoneId}/clients```)
See [this story](https://www.pivotaltracker.com/projects/816799/stories/115150309)