### PR TITLE
Get Application Usage Event

### DIFF
--- a/cloudfoundry-client-spring/src/main/lombok/org/cloudfoundry/spring/client/v2/applicationusageevents/SpringApplicationUsageEvents.java
+++ b/cloudfoundry-client-spring/src/main/lombok/org/cloudfoundry/spring/client/v2/applicationusageevents/SpringApplicationUsageEvents.java
@@ -18,6 +18,8 @@ package org.cloudfoundry.spring.client.v2.applicationusageevents;
 
 import lombok.ToString;
 import org.cloudfoundry.client.v2.applicationusageevents.ApplicationUsageEvents;
+import org.cloudfoundry.client.v2.applicationusageevents.GetApplicationUsageEventRequest;
+import org.cloudfoundry.client.v2.applicationusageevents.GetApplicationUsageEventResponse;
 import org.cloudfoundry.client.v2.applicationusageevents.ListApplicationUsageEventsRequest;
 import org.cloudfoundry.client.v2.applicationusageevents.ListApplicationUsageEventsResponse;
 import org.cloudfoundry.spring.util.AbstractSpringOperations;
@@ -43,6 +45,11 @@ public final class SpringApplicationUsageEvents extends AbstractSpringOperations
      */
     public SpringApplicationUsageEvents(RestOperations restOperations, URI root, SchedulerGroup schedulerGroup) {
         super(restOperations, root, schedulerGroup);
+    }
+
+    @Override
+    public Mono<GetApplicationUsageEventResponse> get(GetApplicationUsageEventRequest request) {
+        return get(request, GetApplicationUsageEventResponse.class, builder -> builder.pathSegment("v2", "app_usage_events", request.getApplicationUsageEventId()));
     }
 
     @Override

--- a/cloudfoundry-client-spring/src/main/lombok/org/cloudfoundry/spring/client/v2/serviceusageevents/SpringServiceUsageEvents.java
+++ b/cloudfoundry-client-spring/src/main/lombok/org/cloudfoundry/spring/client/v2/serviceusageevents/SpringServiceUsageEvents.java
@@ -17,8 +17,8 @@
 package org.cloudfoundry.spring.client.v2.serviceusageevents;
 
 import lombok.ToString;
-import org.cloudfoundry.client.v2.serviceusageevents.GetServiceUsageEventsRequest;
-import org.cloudfoundry.client.v2.serviceusageevents.GetServiceUsageEventsResponse;
+import org.cloudfoundry.client.v2.serviceusageevents.GetServiceUsageEventRequest;
+import org.cloudfoundry.client.v2.serviceusageevents.GetServiceUsageEventResponse;
 import org.cloudfoundry.client.v2.serviceusageevents.ListServiceUsageEventsRequest;
 import org.cloudfoundry.client.v2.serviceusageevents.ListServiceUsageEventsResponse;
 import org.cloudfoundry.client.v2.serviceusageevents.PurgeAndReseedServiceUsageEventsRequest;
@@ -50,8 +50,8 @@ public final class SpringServiceUsageEvents extends AbstractSpringOperations imp
     }
 
     @Override
-    public Mono<GetServiceUsageEventsResponse> get(GetServiceUsageEventsRequest request) {
-        return get(request, GetServiceUsageEventsResponse.class, builder -> builder.pathSegment("v2", "service_usage_events", request.getServiceUsageEventId()));
+    public Mono<GetServiceUsageEventResponse> get(GetServiceUsageEventRequest request) {
+        return get(request, GetServiceUsageEventResponse.class, builder -> builder.pathSegment("v2", "service_usage_events", request.getServiceUsageEventId()));
     }
 
     @Override

--- a/cloudfoundry-client-spring/src/test/java/org/cloudfoundry/spring/client/v2/applicationusageevents/SpringApplicationUsageEventsTest.java
+++ b/cloudfoundry-client-spring/src/test/java/org/cloudfoundry/spring/client/v2/applicationusageevents/SpringApplicationUsageEventsTest.java
@@ -19,6 +19,8 @@ package org.cloudfoundry.spring.client.v2.applicationusageevents;
 import org.cloudfoundry.client.v2.Resource;
 import org.cloudfoundry.client.v2.applicationusageevents.ApplicationUsageEventEntity;
 import org.cloudfoundry.client.v2.applicationusageevents.ApplicationUsageEventResource;
+import org.cloudfoundry.client.v2.applicationusageevents.GetApplicationUsageEventRequest;
+import org.cloudfoundry.client.v2.applicationusageevents.GetApplicationUsageEventResponse;
 import org.cloudfoundry.client.v2.applicationusageevents.ListApplicationUsageEventsRequest;
 import org.cloudfoundry.client.v2.applicationusageevents.ListApplicationUsageEventsResponse;
 import org.cloudfoundry.spring.AbstractApiTest;
@@ -28,6 +30,61 @@ import static org.springframework.http.HttpMethod.GET;
 import static org.springframework.http.HttpStatus.OK;
 
 public final class SpringApplicationUsageEventsTest {
+
+    public static final class Get extends AbstractApiTest<GetApplicationUsageEventRequest, GetApplicationUsageEventResponse> {
+
+        private SpringApplicationUsageEvents applicationUsageEvents = new SpringApplicationUsageEvents(this.restTemplate, this.root, PROCESSOR_GROUP);
+
+        @Override
+        protected GetApplicationUsageEventRequest getInvalidRequest() {
+            return GetApplicationUsageEventRequest.builder().build();
+        }
+
+        @Override
+        protected RequestContext getRequestContext() {
+            return new RequestContext()
+                .method(GET).path("/v2/app_usage_events/caac0ed4-febf-48a4-951f-c0a7fadf6a68")
+                .status(OK)
+                .responsePayload("fixtures/client/v2/app_usage_events/GET_{id}_response.json");
+        }
+
+        @Override
+        protected GetApplicationUsageEventResponse getResponse() {
+            return GetApplicationUsageEventResponse.builder()
+                .metadata(Resource.Metadata.builder()
+                    .createdAt("2016-03-17T21:41:21Z")
+                    .id("caac0ed4-febf-48a4-951f-c0a7fadf6a68")
+                    .url("/v2/app_usage_events/caac0ed4-febf-48a4-951f-c0a7fadf6a68")
+                    .build())
+                .entity(ApplicationUsageEventEntity.builder()
+                    .applicationId("guid-8cdd38d1-2c13-46a5-8f5e-e91a6cc4b060")
+                    .applicationName("name-1103")
+                    .buildpackId("guid-1ffac859-4635-41fd-91bb-3ba07768a5ec")
+                    .buildpackName("name-1105")
+                    .instanceCount(1)
+                    .memoryInMbPerInstances(564)
+                    .organizationId("guid-1ed968f6-a9f7-469b-a04f-ed1ebc2df1e7")
+                    .packageState("STAGED")
+                    .processType("web")
+                    .spaceId("guid-9c4485f6-7579-45da-8c07-f62e1bc8c499")
+                    .spaceName("name-1104")
+                    .state("STARTED")
+                    .build())
+                .build();
+        }
+
+        @Override
+        protected GetApplicationUsageEventRequest getValidRequest() throws Exception {
+            return GetApplicationUsageEventRequest.builder()
+                .applicationUsageEventId("caac0ed4-febf-48a4-951f-c0a7fadf6a68")
+                .build();
+        }
+
+        @Override
+        protected Mono<GetApplicationUsageEventResponse> invoke(GetApplicationUsageEventRequest request) {
+            return this.applicationUsageEvents.get(request);
+        }
+    }
 
     public static final class List extends AbstractApiTest<ListApplicationUsageEventsRequest, ListApplicationUsageEventsResponse> {
 

--- a/cloudfoundry-client-spring/src/test/java/org/cloudfoundry/spring/client/v2/serviceusageevents/SpringServiceUsageEventsTest.java
+++ b/cloudfoundry-client-spring/src/test/java/org/cloudfoundry/spring/client/v2/serviceusageevents/SpringServiceUsageEventsTest.java
@@ -17,13 +17,13 @@
 package org.cloudfoundry.spring.client.v2.serviceusageevents;
 
 import org.cloudfoundry.client.v2.Resource;
-import org.cloudfoundry.client.v2.serviceusageevents.GetServiceUsageEventsRequest;
-import org.cloudfoundry.client.v2.serviceusageevents.GetServiceUsageEventsResponse;
+import org.cloudfoundry.client.v2.serviceusageevents.GetServiceUsageEventRequest;
+import org.cloudfoundry.client.v2.serviceusageevents.GetServiceUsageEventResponse;
 import org.cloudfoundry.client.v2.serviceusageevents.ListServiceUsageEventsRequest;
 import org.cloudfoundry.client.v2.serviceusageevents.ListServiceUsageEventsResponse;
 import org.cloudfoundry.client.v2.serviceusageevents.PurgeAndReseedServiceUsageEventsRequest;
 import org.cloudfoundry.client.v2.serviceusageevents.ServiceUsageEventResource;
-import org.cloudfoundry.client.v2.serviceusageevents.ServiceUsageEventsEntity;
+import org.cloudfoundry.client.v2.serviceusageevents.ServiceUsageEventEntity;
 import org.cloudfoundry.spring.AbstractApiTest;
 import reactor.core.publisher.Mono;
 
@@ -34,13 +34,13 @@ import static org.springframework.http.HttpStatus.OK;
 
 public final class SpringServiceUsageEventsTest {
 
-    public static final class Get extends AbstractApiTest<GetServiceUsageEventsRequest, GetServiceUsageEventsResponse> {
+    public static final class Get extends AbstractApiTest<GetServiceUsageEventRequest, GetServiceUsageEventResponse> {
 
         private final SpringServiceUsageEvents serviceUsageEvents = new SpringServiceUsageEvents(this.restTemplate, this.root, PROCESSOR_GROUP);
 
         @Override
-        protected GetServiceUsageEventsRequest getInvalidRequest() {
-            return GetServiceUsageEventsRequest.builder().build();
+        protected GetServiceUsageEventRequest getInvalidRequest() {
+            return GetServiceUsageEventRequest.builder().build();
         }
 
         @Override
@@ -52,14 +52,14 @@ public final class SpringServiceUsageEventsTest {
         }
 
         @Override
-        protected GetServiceUsageEventsResponse getResponse() {
-            return GetServiceUsageEventsResponse.builder()
+        protected GetServiceUsageEventResponse getResponse() {
+            return GetServiceUsageEventResponse.builder()
                 .metadata(Resource.Metadata.builder()
                     .createdAt("2015-07-27T22:43:30Z")
                     .id("9470627d-0488-4d9a-8564-f97571487893")
                     .url("/v2/service_usage_events/9470627d-0488-4d9a-8564-f97571487893")
                     .build())
-                .entity(ServiceUsageEventsEntity.builder()
+                .entity(ServiceUsageEventEntity.builder()
                     .state("CREATED")
                     .organizationId("guid-3f19bc03-d183-4189-bdeb-9f33468181da")
                     .spaceId("guid-d565b0c4-3c38-41dd-a102-1c113c759fbf")
@@ -76,14 +76,14 @@ public final class SpringServiceUsageEventsTest {
         }
 
         @Override
-        protected GetServiceUsageEventsRequest getValidRequest() throws Exception {
-            return GetServiceUsageEventsRequest.builder()
+        protected GetServiceUsageEventRequest getValidRequest() throws Exception {
+            return GetServiceUsageEventRequest.builder()
                 .serviceUsageEventId("9470627d-0488-4d9a-8564-f97571487893")
                 .build();
         }
 
         @Override
-        protected Mono<GetServiceUsageEventsResponse> invoke(GetServiceUsageEventsRequest request) {
+        protected Mono<GetServiceUsageEventResponse> invoke(GetServiceUsageEventRequest request) {
             return this.serviceUsageEvents.get(request);
         }
     }
@@ -116,7 +116,7 @@ public final class SpringServiceUsageEventsTest {
                         .id("0c9c59b8-3462-4acf-be39-aa987f087146")
                         .url("/v2/service_usage_events/0c9c59b8-3462-4acf-be39-aa987f087146")
                         .build())
-                    .entity(ServiceUsageEventsEntity.builder()
+                    .entity(ServiceUsageEventEntity.builder()
                         .state("CREATED")
                         .organizationId("guid-4dd5a051-3460-4246-a842-1dc2d5983c51")
                         .spaceId("guid-76bd662b-fd5b-4b5c-a393-d65e67f99d53")

--- a/cloudfoundry-client-spring/src/test/resources/fixtures/client/v2/app_usage_events/GET_{id}_response.json
+++ b/cloudfoundry-client-spring/src/test/resources/fixtures/client/v2/app_usage_events/GET_{id}_response.json
@@ -1,0 +1,25 @@
+{
+  "metadata": {
+    "guid": "caac0ed4-febf-48a4-951f-c0a7fadf6a68",
+    "url": "/v2/app_usage_events/caac0ed4-febf-48a4-951f-c0a7fadf6a68",
+    "created_at": "2016-03-17T21:41:21Z"
+  },
+  "entity": {
+    "state": "STARTED",
+    "memory_in_mb_per_instance": 564,
+    "instance_count": 1,
+    "app_guid": "guid-8cdd38d1-2c13-46a5-8f5e-e91a6cc4b060",
+    "app_name": "name-1103",
+    "space_guid": "guid-9c4485f6-7579-45da-8c07-f62e1bc8c499",
+    "space_name": "name-1104",
+    "org_guid": "guid-1ed968f6-a9f7-469b-a04f-ed1ebc2df1e7",
+    "buildpack_guid": "guid-1ffac859-4635-41fd-91bb-3ba07768a5ec",
+    "buildpack_name": "name-1105",
+    "package_state": "STAGED",
+    "parent_app_guid": null,
+    "parent_app_name": null,
+    "process_type": "web",
+    "task_name": null,
+    "task_guid": null
+  }
+}

--- a/cloudfoundry-client/src/main/java/org/cloudfoundry/client/v2/applicationusageevents/ApplicationUsageEvents.java
+++ b/cloudfoundry-client/src/main/java/org/cloudfoundry/client/v2/applicationusageevents/ApplicationUsageEvents.java
@@ -24,6 +24,14 @@ import reactor.core.publisher.Mono;
 public interface ApplicationUsageEvents {
 
     /**
+     * Makes the <a href="http://apidocs.cloudfoundry.org/latest-release/app_usage_events/retrieve_a_particular_app_usage_event.html">Get an Application Usage Event</a> request
+     *
+     * @param request the Get Application Usage Event request
+     * @return the response from the Get all Application Usage Event request
+     */
+    Mono<GetApplicationUsageEventResponse> get(GetApplicationUsageEventRequest request);
+
+    /**
      * Makes the <a href="http://apidocs.cloudfoundry.org/latest-release/app_usage_events/list_all_app_usage_events.html">List all Application Usage Events</a> request
      *
      * @param request the List all Application Usage Events request

--- a/cloudfoundry-client/src/main/java/org/cloudfoundry/client/v2/serviceinstances/ServiceInstances.java
+++ b/cloudfoundry-client/src/main/java/org/cloudfoundry/client/v2/serviceinstances/ServiceInstances.java
@@ -24,8 +24,7 @@ import reactor.core.publisher.Mono;
 public interface ServiceInstances {
 
     /**
-     * Makes the <a href="http://apidocs.cloudfoundry.org/latest-release/service_instances/binding_a_service_instance_to_a_route_%28experimental%29.html">Bind Service Instance To a Route
-     * (experimental)</a> request
+     * Makes the <a href="http://apidocs.cloudfoundry.org/233/service_instances/binding_a_service_instance_to_a_route.html">Bind Service Instance To a Route</a> request
      *
      * @param request the Bind Service Instance To Route request
      * @return the response from the Bind Service Instance To Route request

--- a/cloudfoundry-client/src/main/java/org/cloudfoundry/client/v2/serviceusageevents/ServiceUsageEvents.java
+++ b/cloudfoundry-client/src/main/java/org/cloudfoundry/client/v2/serviceusageevents/ServiceUsageEvents.java
@@ -30,7 +30,7 @@ public interface ServiceUsageEvents {
      * @param request the Get Service Usage Events
      * @return the response from the Get Service Usage Events request
      */
-    Mono<GetServiceUsageEventsResponse> get(GetServiceUsageEventsRequest request);
+    Mono<GetServiceUsageEventResponse> get(GetServiceUsageEventRequest request);
 
     /**
      * Makes the <a href="http://apidocs.cloudfoundry.org/latest-release/service_usage_events/list_service_usage_events.html">List Service Usage Events</a> request

--- a/cloudfoundry-client/src/main/lombok/org/cloudfoundry/client/v2/applicationusageevents/GetApplicationUsageEventRequest.java
+++ b/cloudfoundry-client/src/main/lombok/org/cloudfoundry/client/v2/applicationusageevents/GetApplicationUsageEventRequest.java
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package org.cloudfoundry.client.v2.serviceusageevents;
+package org.cloudfoundry.client.v2.applicationusageevents;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import lombok.Builder;
@@ -24,31 +24,31 @@ import org.cloudfoundry.Validatable;
 import org.cloudfoundry.ValidationResult;
 
 /**
- * The request payload for the Get Service Usage Events operation
+ * The request payload for the Get Application Usage Events operation
  */
 @Data
-public final class GetServiceUsageEventsRequest implements Validatable {
+public final class GetApplicationUsageEventRequest implements Validatable {
 
     /**
      * The service usage event id
      *
-     * @param serviceUsageEventId the service usage event id
+     * @param applicationUsageEventId the service usage event id
      * @return the service usage event id
      */
     @Getter(onMethod = @__(@JsonIgnore))
-    private final String serviceUsageEventId;
+    private final String applicationUsageEventId;
 
     @Builder
-    GetServiceUsageEventsRequest(String serviceUsageEventId) {
-        this.serviceUsageEventId = serviceUsageEventId;
+    GetApplicationUsageEventRequest(String applicationUsageEventId) {
+        this.applicationUsageEventId = applicationUsageEventId;
     }
 
     @Override
     public ValidationResult isValid() {
         ValidationResult.ValidationResultBuilder builder = ValidationResult.builder();
 
-        if (this.serviceUsageEventId == null) {
-            builder.message("service usage event id must be specified");
+        if (this.applicationUsageEventId == null) {
+            builder.message("application usage event id must be specified");
         }
 
         return builder.build();

--- a/cloudfoundry-client/src/main/lombok/org/cloudfoundry/client/v2/applicationusageevents/GetApplicationUsageEventResponse.java
+++ b/cloudfoundry-client/src/main/lombok/org/cloudfoundry/client/v2/applicationusageevents/GetApplicationUsageEventResponse.java
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package org.cloudfoundry.client.v2.serviceusageevents;
+package org.cloudfoundry.client.v2.applicationusageevents;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.Builder;
@@ -24,16 +24,16 @@ import lombok.ToString;
 import org.cloudfoundry.client.v2.Resource;
 
 /**
- * The resource response payload for the Get Service Usage Events Response
+ * The resource response payload for the Get Application Usage Events Response
  */
 @Data
 @EqualsAndHashCode(callSuper = true)
 @ToString(callSuper = true)
-public final class GetServiceUsageEventsResponse extends Resource<ServiceUsageEventsEntity> {
+public final class GetApplicationUsageEventResponse extends Resource<ApplicationUsageEventEntity> {
 
     @Builder
-    GetServiceUsageEventsResponse(@JsonProperty("entity") ServiceUsageEventsEntity entity,
-                                  @JsonProperty("metadata") Metadata metadata) {
+    GetApplicationUsageEventResponse(@JsonProperty("entity") ApplicationUsageEventEntity entity,
+                                     @JsonProperty("metadata") Metadata metadata) {
         super(entity, metadata);
     }
 

--- a/cloudfoundry-client/src/main/lombok/org/cloudfoundry/client/v2/serviceusageevents/GetServiceUsageEventRequest.java
+++ b/cloudfoundry-client/src/main/lombok/org/cloudfoundry/client/v2/serviceusageevents/GetServiceUsageEventRequest.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright 2013-2016 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.cloudfoundry.client.v2.serviceusageevents;
+
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import lombok.Builder;
+import lombok.Data;
+import lombok.Getter;
+import org.cloudfoundry.Validatable;
+import org.cloudfoundry.ValidationResult;
+
+/**
+ * The request payload for the Get Service Usage Events operation
+ */
+@Data
+public final class GetServiceUsageEventRequest implements Validatable {
+
+    /**
+     * The service usage event id
+     *
+     * @param serviceUsageEventId the service usage event id
+     * @return the service usage event id
+     */
+    @Getter(onMethod = @__(@JsonIgnore))
+    private final String serviceUsageEventId;
+
+    @Builder
+    GetServiceUsageEventRequest(String serviceUsageEventId) {
+        this.serviceUsageEventId = serviceUsageEventId;
+    }
+
+    @Override
+    public ValidationResult isValid() {
+        ValidationResult.ValidationResultBuilder builder = ValidationResult.builder();
+
+        if (this.serviceUsageEventId == null) {
+            builder.message("service usage event id must be specified");
+        }
+
+        return builder.build();
+    }
+
+}

--- a/cloudfoundry-client/src/main/lombok/org/cloudfoundry/client/v2/serviceusageevents/GetServiceUsageEventResponse.java
+++ b/cloudfoundry-client/src/main/lombok/org/cloudfoundry/client/v2/serviceusageevents/GetServiceUsageEventResponse.java
@@ -24,16 +24,16 @@ import lombok.ToString;
 import org.cloudfoundry.client.v2.Resource;
 
 /**
- * The resource response payload for Service Usage Events
+ * The resource response payload for the Get Service Usage Events Response
  */
 @Data
 @EqualsAndHashCode(callSuper = true)
 @ToString(callSuper = true)
-public final class ServiceUsageEventResource extends Resource<ServiceUsageEventEntity> {
+public final class GetServiceUsageEventResponse extends Resource<ServiceUsageEventEntity> {
 
     @Builder
-    ServiceUsageEventResource(@JsonProperty("entity") ServiceUsageEventEntity entity,
-                              @JsonProperty("metadata") Metadata metadata) {
+    GetServiceUsageEventResponse(@JsonProperty("entity") ServiceUsageEventEntity entity,
+                                 @JsonProperty("metadata") Metadata metadata) {
         super(entity, metadata);
     }
 

--- a/cloudfoundry-client/src/main/lombok/org/cloudfoundry/client/v2/serviceusageevents/ServiceUsageEventEntity.java
+++ b/cloudfoundry-client/src/main/lombok/org/cloudfoundry/client/v2/serviceusageevents/ServiceUsageEventEntity.java
@@ -24,7 +24,7 @@ import lombok.Data;
  * The entity response payload for Service Usage Events
  */
 @Data
-public final class ServiceUsageEventsEntity {
+public final class ServiceUsageEventEntity {
 
     /**
      * The organization id
@@ -115,17 +115,17 @@ public final class ServiceUsageEventsEntity {
     private final String state;
 
     @Builder
-    ServiceUsageEventsEntity(@JsonProperty("org_guid") String organizationId,
-                             @JsonProperty("service_guid") String serviceId,
-                             @JsonProperty("service_instance_guid") String serviceInstanceId,
-                             @JsonProperty("service_instance_name") String serviceInstanceName,
-                             @JsonProperty("service_instance_type") String serviceInstanceType,
-                             @JsonProperty("service_label") String serviceLabel,
-                             @JsonProperty("service_plan_guid") String servicePlanId,
-                             @JsonProperty("service_plan_name") String servicePlanName,
-                             @JsonProperty("space_guid") String spaceId,
-                             @JsonProperty("space_name") String spaceName,
-                             @JsonProperty("state") String state) {
+    ServiceUsageEventEntity(@JsonProperty("org_guid") String organizationId,
+                            @JsonProperty("service_guid") String serviceId,
+                            @JsonProperty("service_instance_guid") String serviceInstanceId,
+                            @JsonProperty("service_instance_name") String serviceInstanceName,
+                            @JsonProperty("service_instance_type") String serviceInstanceType,
+                            @JsonProperty("service_label") String serviceLabel,
+                            @JsonProperty("service_plan_guid") String servicePlanId,
+                            @JsonProperty("service_plan_name") String servicePlanName,
+                            @JsonProperty("space_guid") String spaceId,
+                            @JsonProperty("space_name") String spaceName,
+                            @JsonProperty("state") String state) {
         this.organizationId = organizationId;
         this.serviceId = serviceId;
         this.serviceInstanceId = serviceInstanceId;

--- a/cloudfoundry-client/src/test/java/org/cloudfoundry/client/v2/applicationusageevents/GetApplicationUsageEventRequestTest.java
+++ b/cloudfoundry-client/src/test/java/org/cloudfoundry/client/v2/applicationusageevents/GetApplicationUsageEventRequestTest.java
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package org.cloudfoundry.client.v2.serviceusageevents;
+package org.cloudfoundry.client.v2.applicationusageevents;
 
 import org.cloudfoundry.ValidationResult;
 import org.junit.Test;
@@ -23,26 +23,26 @@ import static org.cloudfoundry.ValidationResult.Status.INVALID;
 import static org.cloudfoundry.ValidationResult.Status.VALID;
 import static org.junit.Assert.assertEquals;
 
-public final class GetServiceUsageEventsRequestTest {
+public final class GetApplicationUsageEventRequestTest {
 
     @Test
-    public void isValid() {
-        ValidationResult result = GetServiceUsageEventsRequest.builder()
-            .serviceUsageEventId("test-service-usage-event-id")
-            .build()
-            .isValid();
-
-        assertEquals(VALID, result.getStatus());
-    }
-
-    @Test
-    public void isValidNoId() {
-        ValidationResult result = GetServiceUsageEventsRequest.builder()
+    public void isNotValidNoId() {
+        ValidationResult result = GetApplicationUsageEventRequest.builder()
             .build()
             .isValid();
 
         assertEquals(INVALID, result.getStatus());
-        assertEquals("service usage event id must be specified", result.getMessages().get(0));
+        assertEquals("application usage event id must be specified", result.getMessages().get(0));
+    }
+
+    @Test
+    public void isValid() {
+        ValidationResult result = GetApplicationUsageEventRequest.builder()
+            .applicationUsageEventId("test-application-usage-event-id")
+            .build()
+            .isValid();
+
+        assertEquals(VALID, result.getStatus());
     }
 
 }

--- a/cloudfoundry-client/src/test/java/org/cloudfoundry/client/v2/serviceusageevents/GetServiceUsageEventRequestTest.java
+++ b/cloudfoundry-client/src/test/java/org/cloudfoundry/client/v2/serviceusageevents/GetServiceUsageEventRequestTest.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2013-2016 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.cloudfoundry.client.v2.serviceusageevents;
+
+import org.cloudfoundry.ValidationResult;
+import org.junit.Test;
+
+import static org.cloudfoundry.ValidationResult.Status.INVALID;
+import static org.cloudfoundry.ValidationResult.Status.VALID;
+import static org.junit.Assert.assertEquals;
+
+public final class GetServiceUsageEventRequestTest {
+
+    @Test
+    public void isNotValidNoId() {
+        ValidationResult result = GetServiceUsageEventRequest.builder()
+            .build()
+            .isValid();
+
+        assertEquals(INVALID, result.getStatus());
+        assertEquals("service usage event id must be specified", result.getMessages().get(0));
+    }
+
+    @Test
+    public void isValid() {
+        ValidationResult result = GetServiceUsageEventRequest.builder()
+            .serviceUsageEventId("test-service-usage-event-id")
+            .build()
+            .isValid();
+
+        assertEquals(VALID, result.getStatus());
+    }
+
+}


### PR DESCRIPTION
This change adds the api to get an application usage event (`GET /v2/app_usage_events/:guid`See [this story](https://www.pivotaltracker.com/projects/816799/stories/101516696)
@nebhale : I fixed a naming issue in `serviceusageevents`:

* GetServiceUsageEvent**s**Response => GetServiceUsageEventResponse
* GetServiceUsageEvent**s**Request => GetServiceUsageEventRequest 
* ServiceUsageEvent**s**Entity => GetServiceUsageEventEntity

I also fixed a bad url in the *ServiceInstances* api I spotted few days ago.