### PR TITLE
Purge and Reseed Application Usage Events

### DIFF
--- a/cloudfoundry-client-spring/src/main/lombok/org/cloudfoundry/spring/client/v2/applicationusageevents/SpringApplicationUsageEvents.java
+++ b/cloudfoundry-client-spring/src/main/lombok/org/cloudfoundry/spring/client/v2/applicationusageevents/SpringApplicationUsageEvents.java
@@ -22,6 +22,7 @@ import org.cloudfoundry.client.v2.applicationusageevents.GetApplicationUsageEven
 import org.cloudfoundry.client.v2.applicationusageevents.GetApplicationUsageEventResponse;
 import org.cloudfoundry.client.v2.applicationusageevents.ListApplicationUsageEventsRequest;
 import org.cloudfoundry.client.v2.applicationusageevents.ListApplicationUsageEventsResponse;
+import org.cloudfoundry.client.v2.applicationusageevents.PurgeAndReseedApplicationUsageEventsRequest;
 import org.cloudfoundry.spring.util.AbstractSpringOperations;
 import org.cloudfoundry.spring.util.QueryBuilder;
 import org.springframework.web.client.RestOperations;
@@ -58,6 +59,11 @@ public final class SpringApplicationUsageEvents extends AbstractSpringOperations
             builder.pathSegment("v2", "app_usage_events");
             QueryBuilder.augment(builder, request);
         });
+    }
+
+    @Override
+    public Mono<Void> purgeAndReseed(PurgeAndReseedApplicationUsageEventsRequest request) {
+        return post(request, Void.class, builder -> builder.pathSegment("v2", "app_usage_events", "destructively_purge_all_and_reseed_started_apps"));
     }
 
 }

--- a/cloudfoundry-client-spring/src/test/java/org/cloudfoundry/spring/client/v2/applicationusageevents/SpringApplicationUsageEventsTest.java
+++ b/cloudfoundry-client-spring/src/test/java/org/cloudfoundry/spring/client/v2/applicationusageevents/SpringApplicationUsageEventsTest.java
@@ -23,10 +23,13 @@ import org.cloudfoundry.client.v2.applicationusageevents.GetApplicationUsageEven
 import org.cloudfoundry.client.v2.applicationusageevents.GetApplicationUsageEventResponse;
 import org.cloudfoundry.client.v2.applicationusageevents.ListApplicationUsageEventsRequest;
 import org.cloudfoundry.client.v2.applicationusageevents.ListApplicationUsageEventsResponse;
+import org.cloudfoundry.client.v2.applicationusageevents.PurgeAndReseedApplicationUsageEventsRequest;
 import org.cloudfoundry.spring.AbstractApiTest;
 import reactor.core.publisher.Mono;
 
 import static org.springframework.http.HttpMethod.GET;
+import static org.springframework.http.HttpMethod.POST;
+import static org.springframework.http.HttpStatus.NO_CONTENT;
 import static org.springframework.http.HttpStatus.OK;
 
 public final class SpringApplicationUsageEventsTest {
@@ -144,6 +147,38 @@ public final class SpringApplicationUsageEventsTest {
         @Override
         protected Mono<ListApplicationUsageEventsResponse> invoke(ListApplicationUsageEventsRequest request) {
             return this.applicationUsageEvents.list(request);
+        }
+    }
+
+    public static final class PurgeAndReseed extends AbstractApiTest<PurgeAndReseedApplicationUsageEventsRequest, Void> {
+
+        private final SpringApplicationUsageEvents applicationUsageEvents = new SpringApplicationUsageEvents(this.restTemplate, this.root, PROCESSOR_GROUP);
+
+        @Override
+        protected PurgeAndReseedApplicationUsageEventsRequest getInvalidRequest() {
+            return null;
+        }
+
+        @Override
+        protected RequestContext getRequestContext() {
+            return new RequestContext()
+                .method(POST).path("/v2/app_usage_events/destructively_purge_all_and_reseed_started_apps")
+                .status(NO_CONTENT);
+        }
+
+        @Override
+        protected Void getResponse() {
+            return null;
+        }
+
+        @Override
+        protected PurgeAndReseedApplicationUsageEventsRequest getValidRequest() throws Exception {
+            return PurgeAndReseedApplicationUsageEventsRequest.builder().build();
+        }
+
+        @Override
+        protected Mono<Void> invoke(PurgeAndReseedApplicationUsageEventsRequest request) {
+            return this.applicationUsageEvents.purgeAndReseed(request);
         }
     }
 

--- a/cloudfoundry-client/src/main/java/org/cloudfoundry/client/v2/applicationusageevents/ApplicationUsageEvents.java
+++ b/cloudfoundry-client/src/main/java/org/cloudfoundry/client/v2/applicationusageevents/ApplicationUsageEvents.java
@@ -39,4 +39,12 @@ public interface ApplicationUsageEvents {
      */
     Mono<ListApplicationUsageEventsResponse> list(ListApplicationUsageEventsRequest request);
 
+    /**
+     * Makes the <a href="http://apidocs.cloudfoundry.org/latest-release/app_usage_events/purge_and_reseed_app_usage_events.html">Purge and Reseed Application Usage Events</a> request
+     *
+     * @param request the Purge and Reseed Application Usage Events
+     * @return the response from the Purge and Reseed Application Usage Events request
+     */
+    Mono<Void> purgeAndReseed(PurgeAndReseedApplicationUsageEventsRequest request);
+
 }

--- a/cloudfoundry-client/src/main/lombok/org/cloudfoundry/client/v2/applicationusageevents/PurgeAndReseedApplicationUsageEventsRequest.java
+++ b/cloudfoundry-client/src/main/lombok/org/cloudfoundry/client/v2/applicationusageevents/PurgeAndReseedApplicationUsageEventsRequest.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2013-2016 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.cloudfoundry.client.v2.applicationusageevents;
+
+import lombok.Builder;
+import lombok.Data;
+import org.cloudfoundry.Validatable;
+import org.cloudfoundry.ValidationResult;
+
+/**
+ * The request payload for the Purge and Reseed Application Usage Events operation
+ */
+@Data
+public final class PurgeAndReseedApplicationUsageEventsRequest implements Validatable {
+
+    @Builder
+    PurgeAndReseedApplicationUsageEventsRequest() {
+    }
+
+    @Override
+    public ValidationResult isValid() {
+        return ValidationResult.builder().build();
+    }
+
+}

--- a/cloudfoundry-client/src/test/java/org/cloudfoundry/client/v2/applicationusageevents/PurgeAndReseedApplicationUsageEventsRequestTest.java
+++ b/cloudfoundry-client/src/test/java/org/cloudfoundry/client/v2/applicationusageevents/PurgeAndReseedApplicationUsageEventsRequestTest.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2013-2016 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.cloudfoundry.client.v2.applicationusageevents;
+
+import org.cloudfoundry.ValidationResult;
+import org.junit.Test;
+
+import static org.cloudfoundry.ValidationResult.Status.VALID;
+import static org.junit.Assert.assertEquals;
+
+public final class PurgeAndReseedApplicationUsageEventsRequestTest {
+
+    @Test
+    public void isValid() {
+        ValidationResult result = PurgeAndReseedApplicationUsageEventsRequest.builder()
+            .build()
+            .isValid();
+
+        assertEquals(VALID, result.getStatus());
+    }
+
+}


### PR DESCRIPTION
This change adds the api to purge and reseed application usage events (`POST /v2/app_usage_events/destructively_purge_all_and_reseed_started_apps`)
See [this story](https://www.pivotaltracker.com/projects/816799/stories/101516692)
