### PR TITLE
List Buildpacks

### DIFF
--- a/cloudfoundry-client-spring/src/main/lombok/org/cloudfoundry/spring/client/SpringCloudFoundryClient.java
+++ b/cloudfoundry-client-spring/src/main/lombok/org/cloudfoundry/spring/client/SpringCloudFoundryClient.java
@@ -24,6 +24,7 @@ import lombok.ToString;
 import org.cloudfoundry.client.CloudFoundryClient;
 import org.cloudfoundry.client.v2.applications.ApplicationsV2;
 import org.cloudfoundry.client.v2.applicationusageevents.ApplicationUsageEvents;
+import org.cloudfoundry.client.v2.buildpacks.Buildpacks;
 import org.cloudfoundry.client.v2.domains.Domains;
 import org.cloudfoundry.client.v2.environmentvariablegroups.EnvironmentVariableGroups;
 import org.cloudfoundry.client.v2.events.Events;
@@ -56,6 +57,7 @@ import org.cloudfoundry.client.v3.processes.Processes;
 import org.cloudfoundry.client.v3.tasks.Tasks;
 import org.cloudfoundry.spring.client.v2.applications.SpringApplicationsV2;
 import org.cloudfoundry.spring.client.v2.applicationusageevents.SpringApplicationUsageEvents;
+import org.cloudfoundry.spring.client.v2.buildpacks.SpringBuildpacks;
 import org.cloudfoundry.spring.client.v2.domains.SpringDomains;
 import org.cloudfoundry.spring.client.v2.environmentvariablegroups.SpringEnvironmentVariableGroups;
 import org.cloudfoundry.spring.client.v2.events.SpringEvents;
@@ -118,6 +120,8 @@ public final class SpringCloudFoundryClient implements CloudFoundryClient {
     private final ApplicationsV2 applicationsV2;
 
     private final ApplicationsV3 applicationsV3;
+
+    private final Buildpacks buildpacks;
 
     private final ConnectionContext connectionContext;
 
@@ -199,6 +203,7 @@ public final class SpringCloudFoundryClient implements CloudFoundryClient {
         this.applicationUsageEvents = new SpringApplicationUsageEvents(restOperations, root, schedulerGroup);
         this.applicationsV2 = new SpringApplicationsV2(restOperations, root, schedulerGroup);
         this.applicationsV3 = new SpringApplicationsV3(restOperations, root, schedulerGroup);
+        this.buildpacks = new SpringBuildpacks(restOperations, root, schedulerGroup);
         this.domains = new SpringDomains(restOperations, root, schedulerGroup);
         this.droplets = new SpringDroplets(restOperations, root, schedulerGroup);
         this.environmentVariableGroups = new SpringEnvironmentVariableGroups(restOperations, root, schedulerGroup);
@@ -259,6 +264,11 @@ public final class SpringCloudFoundryClient implements CloudFoundryClient {
     @Override
     public ApplicationsV3 applicationsV3() {
         return this.applicationsV3;
+    }
+
+    @Override
+    public Buildpacks buildpacks() {
+        return this.buildpacks;
     }
 
     @Override

--- a/cloudfoundry-client-spring/src/main/lombok/org/cloudfoundry/spring/client/v2/buildpacks/SpringBuildpacks.java
+++ b/cloudfoundry-client-spring/src/main/lombok/org/cloudfoundry/spring/client/v2/buildpacks/SpringBuildpacks.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright 2013-2016 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.cloudfoundry.spring.client.v2.buildpacks;
+
+import lombok.ToString;
+import org.cloudfoundry.client.v2.buildpacks.Buildpacks;
+import org.cloudfoundry.client.v2.buildpacks.ListBuildpacksRequest;
+import org.cloudfoundry.client.v2.buildpacks.ListBuildpacksResponse;
+import org.cloudfoundry.spring.client.v2.FilterBuilder;
+import org.cloudfoundry.spring.util.AbstractSpringOperations;
+import org.cloudfoundry.spring.util.QueryBuilder;
+import org.springframework.web.client.RestOperations;
+import reactor.core.publisher.Mono;
+import reactor.core.publisher.SchedulerGroup;
+
+/**
+ * The Spring-based implementation of {@link Buildpacks}
+ */
+@ToString(callSuper = true)
+public final class SpringBuildpacks extends AbstractSpringOperations implements Buildpacks {
+
+    /**
+     * Creates an instance
+     *
+     * @param restOperations the {@link RestOperations } to use to communicate with the server
+     * @param root           the root URI of the server.  Typically something like {@code https://api.run.pivotal.io}.
+     * @param schedulerGroup The group to use when making requests
+     */
+    public SpringBuildpacks(RestOperations restOperations, java.net.URI root, SchedulerGroup schedulerGroup) {
+        super(restOperations, root, schedulerGroup);
+    }
+
+    @Override
+    public Mono<ListBuildpacksResponse> list(ListBuildpacksRequest request) {
+        return get(request, ListBuildpacksResponse.class, builder -> {
+            builder.pathSegment("v2", "buildpacks");
+            FilterBuilder.augment(builder, request);
+            QueryBuilder.augment(builder, request);
+        });
+    }
+
+}

--- a/cloudfoundry-client-spring/src/test/java/org/cloudfoundry/spring/client/SpringCloudFoundryClientTest.java
+++ b/cloudfoundry-client-spring/src/test/java/org/cloudfoundry/spring/client/SpringCloudFoundryClientTest.java
@@ -44,6 +44,11 @@ public final class SpringCloudFoundryClientTest extends AbstractRestTest {
     }
 
     @Test
+    public void buildpacks() {
+        assertNotNull(this.client.buildpacks());
+    }
+
+    @Test
     public void domains() {
         assertNotNull(this.client.domains());
     }

--- a/cloudfoundry-client-spring/src/test/java/org/cloudfoundry/spring/client/v2/buildpacks/SpringBuildpacksTest.java
+++ b/cloudfoundry-client-spring/src/test/java/org/cloudfoundry/spring/client/v2/buildpacks/SpringBuildpacksTest.java
@@ -1,0 +1,114 @@
+/*
+ * Copyright 2013-2016 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.cloudfoundry.spring.client.v2.buildpacks;
+
+import org.cloudfoundry.client.v2.Resource;
+import org.cloudfoundry.client.v2.buildpacks.BuildpackEntity;
+import org.cloudfoundry.client.v2.buildpacks.BuildpackResource;
+import org.cloudfoundry.client.v2.buildpacks.ListBuildpacksRequest;
+import org.cloudfoundry.client.v2.buildpacks.ListBuildpacksResponse;
+import org.cloudfoundry.spring.AbstractApiTest;
+import reactor.core.publisher.Mono;
+
+import static org.springframework.http.HttpMethod.GET;
+import static org.springframework.http.HttpStatus.OK;
+
+public final class SpringBuildpacksTest {
+
+    public static final class List extends AbstractApiTest<ListBuildpacksRequest, ListBuildpacksResponse> {
+
+        private SpringBuildpacks buildpacks = new SpringBuildpacks(this.restTemplate, this.root, PROCESSOR_GROUP);
+
+        @Override
+        protected ListBuildpacksRequest getInvalidRequest() {
+            return null;
+        }
+
+        @Override
+        protected RequestContext getRequestContext() {
+            return new RequestContext()
+                .method(GET).path("/v2/buildpacks?q=name%20IN%20test-name&page=-1")
+                .status(OK)
+                .responsePayload("fixtures/client/v2/buildpacks/GET_response.json");
+        }
+
+        @Override
+        protected ListBuildpacksResponse getResponse() {
+            return ListBuildpacksResponse.builder()
+                .totalResults(3)
+                .totalPages(1)
+                .resource(BuildpackResource.builder()
+                    .metadata(Resource.Metadata.builder()
+                        .id("45203d32-475b-4d55-9d34-3ffc935edd49")
+                        .url("/v2/buildpacks/45203d32-475b-4d55-9d34-3ffc935edd49")
+                        .createdAt("2016-03-17T21:41:28Z")
+                        .build())
+                    .entity(BuildpackEntity.builder()
+                        .enabled(true)
+                        .filename("name-2308")
+                        .locked(false)
+                        .name("name_1")
+                        .position(1)
+                        .build())
+                    .build())
+                .resource(BuildpackResource.builder()
+                    .metadata(Resource.Metadata.builder()
+                        .id("1aeb95ef-7058-495c-b260-dea2e8efb976")
+                        .url("/v2/buildpacks/1aeb95ef-7058-495c-b260-dea2e8efb976")
+                        .createdAt("2016-03-17T21:41:28Z")
+                        .build())
+                    .entity(BuildpackEntity.builder()
+                        .enabled(true)
+                        .filename("name-2309")
+                        .locked(false)
+                        .name("name_2")
+                        .position(2)
+                        .build())
+                    .build())
+                .resource(BuildpackResource.builder()
+                    .metadata(Resource.Metadata.builder()
+                        .id("4dd0046a-7a54-4f57-a31f-06d7e57eb463")
+                        .url("/v2/buildpacks/4dd0046a-7a54-4f57-a31f-06d7e57eb463")
+                        .createdAt("2016-03-17T21:41:28Z")
+                        .build())
+                    .entity(BuildpackEntity.builder()
+                        .enabled(true)
+                        .filename("name-2310")
+                        .locked(false)
+                        .name("name_3")
+                        .position(3)
+                        .build())
+                    .build())
+                .build();
+        }
+
+        @Override
+        protected ListBuildpacksRequest getValidRequest() throws Exception {
+            return ListBuildpacksRequest.builder()
+                .name("test-name")
+                .page(-1)
+                .build();
+        }
+
+        @Override
+        protected Mono<ListBuildpacksResponse> invoke(ListBuildpacksRequest request) {
+            return this.buildpacks.list(request);
+        }
+
+    }
+
+}

--- a/cloudfoundry-client-spring/src/test/resources/fixtures/client/v2/buildpacks/GET_response.json
+++ b/cloudfoundry-client-spring/src/test/resources/fixtures/client/v2/buildpacks/GET_response.json
@@ -1,0 +1,53 @@
+{
+  "total_results": 3,
+  "total_pages": 1,
+  "prev_url": null,
+  "next_url": null,
+  "resources": [
+    {
+      "metadata": {
+        "guid": "45203d32-475b-4d55-9d34-3ffc935edd49",
+        "url": "/v2/buildpacks/45203d32-475b-4d55-9d34-3ffc935edd49",
+        "created_at": "2016-03-17T21:41:28Z",
+        "updated_at": null
+      },
+      "entity": {
+        "name": "name_1",
+        "position": 1,
+        "enabled": true,
+        "locked": false,
+        "filename": "name-2308"
+      }
+    },
+    {
+      "metadata": {
+        "guid": "1aeb95ef-7058-495c-b260-dea2e8efb976",
+        "url": "/v2/buildpacks/1aeb95ef-7058-495c-b260-dea2e8efb976",
+        "created_at": "2016-03-17T21:41:28Z",
+        "updated_at": null
+      },
+      "entity": {
+        "name": "name_2",
+        "position": 2,
+        "enabled": true,
+        "locked": false,
+        "filename": "name-2309"
+      }
+    },
+    {
+      "metadata": {
+        "guid": "4dd0046a-7a54-4f57-a31f-06d7e57eb463",
+        "url": "/v2/buildpacks/4dd0046a-7a54-4f57-a31f-06d7e57eb463",
+        "created_at": "2016-03-17T21:41:28Z",
+        "updated_at": null
+      },
+      "entity": {
+        "name": "name_3",
+        "position": 3,
+        "enabled": true,
+        "locked": false,
+        "filename": "name-2310"
+      }
+    }
+  ]
+}

--- a/cloudfoundry-client/src/main/java/org/cloudfoundry/client/CloudFoundryClient.java
+++ b/cloudfoundry-client/src/main/java/org/cloudfoundry/client/CloudFoundryClient.java
@@ -18,6 +18,7 @@ package org.cloudfoundry.client;
 
 import org.cloudfoundry.client.v2.applications.ApplicationsV2;
 import org.cloudfoundry.client.v2.applicationusageevents.ApplicationUsageEvents;
+import org.cloudfoundry.client.v2.buildpacks.Buildpacks;
 import org.cloudfoundry.client.v2.domains.Domains;
 import org.cloudfoundry.client.v2.environmentvariablegroups.EnvironmentVariableGroups;
 import org.cloudfoundry.client.v2.events.Events;
@@ -80,6 +81,13 @@ public interface CloudFoundryClient {
      * @return the Cloud Foundry Application V3 Client API
      */
     ApplicationsV3 applicationsV3();
+
+    /**
+     * Main entry point to the Cloud Foundry Buildpacks V2 Client API
+     *
+     * @return the Cloud Foundry Buildpacks Client API
+     */
+    Buildpacks buildpacks();
 
     /**
      * Main entry point to the Cloud Foundry Domains Client API

--- a/cloudfoundry-client/src/main/java/org/cloudfoundry/client/v2/buildpacks/Buildpacks.java
+++ b/cloudfoundry-client/src/main/java/org/cloudfoundry/client/v2/buildpacks/Buildpacks.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2013-2016 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.cloudfoundry.client.v2.buildpacks;
+
+import reactor.core.publisher.Mono;
+
+/**
+ * Main entry point to the Cloud Foundry Buildpacks Client API
+ */
+public interface Buildpacks {
+
+    /**
+     * Makes the <a href="http://apidocs.cloudfoundry.org/latest-release/buildpacks/list_all_buildpacks.html">List all Buildpacks</a> request
+     *
+     * @param request the List all Buildpacks request
+     * @return the response from the List all Buildpacks request
+     */
+    Mono<ListBuildpacksResponse> list(ListBuildpacksRequest request);
+
+}

--- a/cloudfoundry-client/src/main/lombok/org/cloudfoundry/client/v2/buildpacks/BuildpackEntity.java
+++ b/cloudfoundry-client/src/main/lombok/org/cloudfoundry/client/v2/buildpacks/BuildpackEntity.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2013-2016 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.cloudfoundry.client.v2.buildpacks;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.Builder;
+import lombok.Data;
+
+/**
+ * The entity response payload for the buildpack resource
+ */
+@Data
+public final class BuildpackEntity {
+
+    private final Boolean enabled;
+
+    private final String filename;
+
+    private final Boolean locked;
+
+    private final String name;
+
+    private final Integer position;
+
+    @Builder
+    BuildpackEntity(@JsonProperty("enabled") Boolean enabled,
+                    @JsonProperty("filename") String filename,
+                    @JsonProperty("locked") Boolean locked,
+                    @JsonProperty("name") String name,
+                    @JsonProperty("position") Integer position) {
+        this.enabled = enabled;
+        this.filename = filename;
+        this.locked = locked;
+        this.name = name;
+        this.position = position;
+    }
+
+}

--- a/cloudfoundry-client/src/main/lombok/org/cloudfoundry/client/v2/buildpacks/BuildpackResource.java
+++ b/cloudfoundry-client/src/main/lombok/org/cloudfoundry/client/v2/buildpacks/BuildpackResource.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2013-2016 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.cloudfoundry.client.v2.buildpacks;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.Builder;
+import lombok.Data;
+import lombok.EqualsAndHashCode;
+import lombok.ToString;
+import org.cloudfoundry.client.v2.Resource;
+
+/**
+ * Buildpacks in responses
+ */
+@Data
+@EqualsAndHashCode(callSuper = true)
+@ToString(callSuper = true)
+public final class BuildpackResource extends Resource<BuildpackEntity> {
+
+    @Builder
+    BuildpackResource(@JsonProperty("entity") BuildpackEntity entity,
+                      @JsonProperty("metadata") Resource.Metadata metadata) {
+        super(entity, metadata);
+    }
+
+}

--- a/cloudfoundry-client/src/main/lombok/org/cloudfoundry/client/v2/buildpacks/ListBuildpacksRequest.java
+++ b/cloudfoundry-client/src/main/lombok/org/cloudfoundry/client/v2/buildpacks/ListBuildpacksRequest.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright 2013-2016 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.cloudfoundry.client.v2.buildpacks;
+
+import lombok.Builder;
+import lombok.Data;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.Singular;
+import lombok.ToString;
+import org.cloudfoundry.Validatable;
+import org.cloudfoundry.ValidationResult;
+import org.cloudfoundry.client.v2.InFilterParameter;
+import org.cloudfoundry.client.v2.PaginatedRequest;
+
+import java.util.List;
+
+/**
+ * The request payload for the List buildpacks operation
+ */
+@Data
+@EqualsAndHashCode(callSuper = true)
+@ToString(callSuper = true)
+public final class ListBuildpacksRequest extends PaginatedRequest implements Validatable {
+
+    /**
+     * The names
+     *
+     * @param names the names
+     * @return the names
+     */
+    @Getter(onMethod = @__(@InFilterParameter("name")))
+    private final List<String> names;
+
+    @Builder
+    ListBuildpacksRequest(OrderDirection orderDirection, Integer page, Integer resultsPerPage,
+                          @Singular List<String> names) {
+        super(orderDirection, page, resultsPerPage);
+        this.names = names;
+    }
+
+    @Override
+    public ValidationResult isValid() {
+        return ValidationResult.builder().build();
+    }
+
+}

--- a/cloudfoundry-client/src/main/lombok/org/cloudfoundry/client/v2/buildpacks/ListBuildpacksResponse.java
+++ b/cloudfoundry-client/src/main/lombok/org/cloudfoundry/client/v2/buildpacks/ListBuildpacksResponse.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2013-2016 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.cloudfoundry.client.v2.buildpacks;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.Builder;
+import lombok.Data;
+import lombok.EqualsAndHashCode;
+import lombok.Singular;
+import lombok.ToString;
+import org.cloudfoundry.client.v2.PaginatedResponse;
+
+import java.util.List;
+
+/**
+ * The response payload for the List Buildpacks operation
+ */
+@Data
+@EqualsAndHashCode(callSuper = true)
+@ToString(callSuper = true)
+public final class ListBuildpacksResponse extends PaginatedResponse<BuildpackResource> {
+
+    @Builder
+    ListBuildpacksResponse(@JsonProperty("next_url") String nextUrl,
+                           @JsonProperty("prev_url") String previousUrl,
+                           @JsonProperty("resources") @Singular List<BuildpackResource> resources,
+                           @JsonProperty("total_pages") Integer totalPages,
+                           @JsonProperty("total_results") Integer totalResults) {
+        super(nextUrl, previousUrl, resources, totalPages, totalResults);
+    }
+
+}

--- a/cloudfoundry-client/src/test/java/org/cloudfoundry/client/v2/buildpacks/ListBuildpacksRequestTest.java
+++ b/cloudfoundry-client/src/test/java/org/cloudfoundry/client/v2/buildpacks/ListBuildpacksRequestTest.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2013-2016 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.cloudfoundry.client.v2.buildpacks;
+
+import org.cloudfoundry.ValidationResult;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+
+public final class ListBuildpacksRequestTest {
+
+    @Test
+    public void isValid() {
+        assertEquals(ValidationResult.Status.VALID,
+            ListBuildpacksRequest.builder().build().isValid().getStatus());
+    }
+
+}


### PR DESCRIPTION
This change adds the api to list buildpacks (`GET /v2/buildpacks`)
See [this story](http://apidocs.cloudfoundry.org/233/buildpacks/list_all_buildpacks.html)