### PR TITLE
Retreieve a particular Buildpack

### DIFF
--- a/cloudfoundry-client-spring/src/main/lombok/org/cloudfoundry/spring/client/v2/buildpacks/SpringBuildpacks.java
+++ b/cloudfoundry-client-spring/src/main/lombok/org/cloudfoundry/spring/client/v2/buildpacks/SpringBuildpacks.java
@@ -22,6 +22,8 @@ import org.cloudfoundry.client.v2.buildpacks.CreateBuildpackRequest;
 import org.cloudfoundry.client.v2.buildpacks.CreateBuildpackResponse;
 import org.cloudfoundry.client.v2.buildpacks.DeleteBuildpackRequest;
 import org.cloudfoundry.client.v2.buildpacks.DeleteBuildpackResponse;
+import org.cloudfoundry.client.v2.buildpacks.GetBuildpackRequest;
+import org.cloudfoundry.client.v2.buildpacks.GetBuildpackResponse;
 import org.cloudfoundry.client.v2.buildpacks.ListBuildpacksRequest;
 import org.cloudfoundry.client.v2.buildpacks.ListBuildpacksResponse;
 import org.cloudfoundry.spring.client.v2.FilterBuilder;
@@ -61,6 +63,11 @@ public final class SpringBuildpacks extends AbstractSpringOperations implements 
             builder.pathSegment("v2", "buildpacks", request.getBuildpackId());
             QueryBuilder.augment(builder, request);
         });
+    }
+
+    @Override
+    public Mono<GetBuildpackResponse> get(GetBuildpackRequest request) {
+        return get(request, GetBuildpackResponse.class, builder -> builder.pathSegment("v2", "buildpacks", request.getBuildpackId()));
     }
 
     @Override

--- a/cloudfoundry-client-spring/src/test/java/org/cloudfoundry/spring/client/v2/buildpacks/SpringBuildpacksTest.java
+++ b/cloudfoundry-client-spring/src/test/java/org/cloudfoundry/spring/client/v2/buildpacks/SpringBuildpacksTest.java
@@ -23,6 +23,8 @@ import org.cloudfoundry.client.v2.buildpacks.CreateBuildpackRequest;
 import org.cloudfoundry.client.v2.buildpacks.CreateBuildpackResponse;
 import org.cloudfoundry.client.v2.buildpacks.DeleteBuildpackRequest;
 import org.cloudfoundry.client.v2.buildpacks.DeleteBuildpackResponse;
+import org.cloudfoundry.client.v2.buildpacks.GetBuildpackRequest;
+import org.cloudfoundry.client.v2.buildpacks.GetBuildpackResponse;
 import org.cloudfoundry.client.v2.buildpacks.ListBuildpacksRequest;
 import org.cloudfoundry.client.v2.buildpacks.ListBuildpacksResponse;
 import org.cloudfoundry.client.v2.job.JobEntity;
@@ -132,6 +134,55 @@ public final class SpringBuildpacksTest {
             return this.buildpacks.delete(request);
         }
 
+    }
+
+    public static final class Get extends AbstractApiTest<GetBuildpackRequest, GetBuildpackResponse> {
+
+        private SpringBuildpacks buildpacks = new SpringBuildpacks(this.restTemplate, this.root, PROCESSOR_GROUP);
+
+        @Override
+        protected GetBuildpackRequest getInvalidRequest() {
+            return GetBuildpackRequest.builder().build();
+        }
+
+        @Override
+        protected RequestContext getRequestContext() {
+            return new RequestContext()
+                .method(GET).path("/v2/buildpacks/test-buildpack-id")
+                .status(OK)
+                .responsePayload("fixtures/client/v2/buildpacks/GET_{id}_response.json");
+        }
+
+        @Override
+        protected GetBuildpackResponse getResponse() {
+            return GetBuildpackResponse.builder()
+                .metadata(Resource.Metadata.builder()
+                    .createdAt("2016-03-17T21:41:28Z")
+                    .id("35d3fa06-08db-4b9e-b2a7-58724a179687")
+                    .url("/v2/buildpacks/35d3fa06-08db-4b9e-b2a7-58724a179687")
+                    .build()
+                )
+                .entity(BuildpackEntity.builder()
+                    .enabled(true)
+                    .filename("name-2302")
+                    .locked(false)
+                    .name("name_1")
+                    .position(1)
+                    .build())
+                .build();
+        }
+
+        @Override
+        protected GetBuildpackRequest getValidRequest() throws Exception {
+            return GetBuildpackRequest.builder()
+                .buildpackId("test-buildpack-id")
+                .build();
+        }
+
+        @Override
+        protected Mono<GetBuildpackResponse> invoke(GetBuildpackRequest request) {
+            return this.buildpacks.get(request);
+        }
     }
 
     public static final class List extends AbstractApiTest<ListBuildpacksRequest, ListBuildpacksResponse> {

--- a/cloudfoundry-client-spring/src/test/resources/fixtures/client/v2/buildpacks/GET_{id}_response.json
+++ b/cloudfoundry-client-spring/src/test/resources/fixtures/client/v2/buildpacks/GET_{id}_response.json
@@ -1,0 +1,15 @@
+{
+  "metadata": {
+    "guid": "35d3fa06-08db-4b9e-b2a7-58724a179687",
+    "url": "/v2/buildpacks/35d3fa06-08db-4b9e-b2a7-58724a179687",
+    "created_at": "2016-03-17T21:41:28Z",
+    "updated_at": null
+  },
+  "entity": {
+    "name": "name_1",
+    "position": 1,
+    "enabled": true,
+    "locked": false,
+    "filename": "name-2302"
+  }
+}

--- a/cloudfoundry-client/src/main/java/org/cloudfoundry/client/v2/buildpacks/Buildpacks.java
+++ b/cloudfoundry-client/src/main/java/org/cloudfoundry/client/v2/buildpacks/Buildpacks.java
@@ -40,6 +40,14 @@ public interface Buildpacks {
     Mono<DeleteBuildpackResponse> delete(DeleteBuildpackRequest request);
 
     /**
+     * Makes the <a href="http://apidocs.cloudfoundry.org/latest-release/buildpacks/retrieve_a_particular_buildpack.html">Retrieve a particular Buildpack</a> request
+     *
+     * @param request the Get Buildpack request
+     * @return the response from the Get Buildpack request
+     */
+    Mono<GetBuildpackResponse> get(GetBuildpackRequest request);
+
+    /**
      * Makes the <a href="http://apidocs.cloudfoundry.org/latest-release/buildpacks/list_all_buildpacks.html">List all Buildpacks</a> request
      *
      * @param request the List all Buildpacks request

--- a/cloudfoundry-client/src/main/lombok/org/cloudfoundry/client/v2/buildpacks/GetBuildpackRequest.java
+++ b/cloudfoundry-client/src/main/lombok/org/cloudfoundry/client/v2/buildpacks/GetBuildpackRequest.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright 2013-2016 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.cloudfoundry.client.v2.buildpacks;
+
+
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import lombok.Builder;
+import lombok.Data;
+import lombok.Getter;
+import org.cloudfoundry.Validatable;
+import org.cloudfoundry.ValidationResult;
+
+/**
+ * The request payload for the Get Buildpack
+ */
+@Data
+public final class GetBuildpackRequest implements Validatable {
+
+    /**
+     * The buildpack id
+     *
+     * @param buildpackId the buildpack id
+     * @return the buildpack id
+     */
+    @Getter(onMethod = @__(@JsonIgnore))
+    private final String buildpackId;
+
+    @Builder
+    GetBuildpackRequest(String buildpackId) {
+        this.buildpackId = buildpackId;
+    }
+
+    @Override
+    public ValidationResult isValid() {
+        ValidationResult.ValidationResultBuilder builder = ValidationResult.builder();
+
+        if (this.buildpackId == null) {
+            builder.message("buildpack id must be specified");
+        }
+
+        return builder.build();
+    }
+
+}

--- a/cloudfoundry-client/src/main/lombok/org/cloudfoundry/client/v2/buildpacks/GetBuildpackResponse.java
+++ b/cloudfoundry-client/src/main/lombok/org/cloudfoundry/client/v2/buildpacks/GetBuildpackResponse.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2013-2016 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.cloudfoundry.client.v2.buildpacks;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.Builder;
+import lombok.Data;
+import lombok.EqualsAndHashCode;
+import lombok.ToString;
+
+/**
+ * The response payload for the Get Buildpack operation
+ */
+@Data
+@EqualsAndHashCode(callSuper = true)
+@ToString(callSuper = true)
+public final class GetBuildpackResponse extends AbstractBuildpackResource {
+
+    @Builder
+    GetBuildpackResponse(@JsonProperty("entity") BuildpackEntity entity,
+                         @JsonProperty("metadata") Metadata metadata) {
+        super(entity, metadata);
+    }
+
+}

--- a/cloudfoundry-client/src/test/java/org/cloudfoundry/client/v2/buildpacks/GetBuildpackRequestTest.java
+++ b/cloudfoundry-client/src/test/java/org/cloudfoundry/client/v2/buildpacks/GetBuildpackRequestTest.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2013-2016 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.cloudfoundry.client.v2.buildpacks;
+
+import org.cloudfoundry.ValidationResult;
+import org.junit.Test;
+
+import static org.cloudfoundry.ValidationResult.Status.INVALID;
+import static org.cloudfoundry.ValidationResult.Status.VALID;
+import static org.junit.Assert.assertEquals;
+
+public final class GetBuildpackRequestTest {
+
+    @Test
+    public void isNotValidNoId() {
+        ValidationResult result = GetBuildpackRequest.builder()
+            .build()
+            .isValid();
+
+        assertEquals(INVALID, result.getStatus());
+        assertEquals("buildpack id must be specified", result.getMessages().get(0));
+    }
+
+    @Test
+    public void isValid() {
+        ValidationResult result = GetBuildpackRequest.builder()
+            .buildpackId("test-buildpack-id")
+            .build()
+            .isValid();
+
+        assertEquals(VALID, result.getStatus());
+    }
+
+}


### PR DESCRIPTION
This change adds the api to retrieve a particular buildpack (`GET /v2/buildpacks/:guid`)
See [here](https://www.pivotaltracker.com/n/projects/816799/stories/101527304)