### PR TITLE
Retrieve a particular Route Mapping

### DIFF
--- a/cloudfoundry-client-spring/src/main/lombok/org/cloudfoundry/spring/client/v2/routemappings/SpringRouteMappings.java
+++ b/cloudfoundry-client-spring/src/main/lombok/org/cloudfoundry/spring/client/v2/routemappings/SpringRouteMappings.java
@@ -21,6 +21,8 @@ import org.cloudfoundry.client.v2.routemappings.CreateRouteMappingRequest;
 import org.cloudfoundry.client.v2.routemappings.CreateRouteMappingResponse;
 import org.cloudfoundry.client.v2.routemappings.DeleteRouteMappingRequest;
 import org.cloudfoundry.client.v2.routemappings.DeleteRouteMappingResponse;
+import org.cloudfoundry.client.v2.routemappings.GetRouteMappingRequest;
+import org.cloudfoundry.client.v2.routemappings.GetRouteMappingResponse;
 import org.cloudfoundry.client.v2.routemappings.ListRouteMappingsRequest;
 import org.cloudfoundry.client.v2.routemappings.ListRouteMappingsResponse;
 import org.cloudfoundry.client.v2.routemappings.RouteMappings;
@@ -61,6 +63,11 @@ public final class SpringRouteMappings extends AbstractSpringOperations implemen
             builder.pathSegment("v2", "route_mappings", request.getRouteMappingId());
             QueryBuilder.augment(builder, request);
         });
+    }
+
+    @Override
+    public Mono<GetRouteMappingResponse> get(GetRouteMappingRequest request) {
+        return get(request, GetRouteMappingResponse.class, builder -> builder.pathSegment("v2", "route_mappings", request.getRouteMappingId()));
     }
 
     @Override

--- a/cloudfoundry-client-spring/src/test/java/org/cloudfoundry/spring/client/v2/routemappings/SpringRouteMappingsTest.java
+++ b/cloudfoundry-client-spring/src/test/java/org/cloudfoundry/spring/client/v2/routemappings/SpringRouteMappingsTest.java
@@ -22,6 +22,8 @@ import org.cloudfoundry.client.v2.routemappings.CreateRouteMappingRequest;
 import org.cloudfoundry.client.v2.routemappings.CreateRouteMappingResponse;
 import org.cloudfoundry.client.v2.routemappings.DeleteRouteMappingRequest;
 import org.cloudfoundry.client.v2.routemappings.DeleteRouteMappingResponse;
+import org.cloudfoundry.client.v2.routemappings.GetRouteMappingRequest;
+import org.cloudfoundry.client.v2.routemappings.GetRouteMappingResponse;
 import org.cloudfoundry.client.v2.routemappings.ListRouteMappingsRequest;
 import org.cloudfoundry.client.v2.routemappings.ListRouteMappingsResponse;
 import org.cloudfoundry.client.v2.routemappings.RouteMappingEntity;
@@ -169,6 +171,55 @@ public final class SpringRouteMappingsTest {
         @Override
         protected Mono<DeleteRouteMappingResponse> invoke(DeleteRouteMappingRequest request) {
             return this.routeMappings.delete(request);
+        }
+
+    }
+
+    public static final class Get extends AbstractApiTest<GetRouteMappingRequest, GetRouteMappingResponse> {
+
+        private final SpringRouteMappings routeMappings = new SpringRouteMappings(this.restTemplate, this.root, PROCESSOR_GROUP);
+
+        @Override
+        protected GetRouteMappingRequest getInvalidRequest() {
+            return GetRouteMappingRequest.builder().build();
+        }
+
+        @Override
+        protected RequestContext getRequestContext() {
+            return new RequestContext()
+                .method(GET).path("/v2/route_mappings/test-route-mapping-id")
+                .status(OK)
+                .responsePayload("fixtures/client/v2/route_mappings/GET_{id}_response.json");
+        }
+
+        @Override
+        protected GetRouteMappingResponse getResponse() {
+            return GetRouteMappingResponse.builder()
+                .metadata(Resource.Metadata.builder()
+                    .createdAt("2016-04-06T00:17:40Z")
+                    .id("304bead7-ad5a-4f6e-a093-f2a85d30c54a")
+                    .url("/v2/route_mappings/304bead7-ad5a-4f6e-a093-f2a85d30c54a")
+                    .build())
+                .entity(RouteMappingEntity.builder()
+                    .applicationId("65489f49-f437-431a-8f58-c118ce08d83a")
+                    .applicationPort(8888)
+                    .routeId("c7ce0cac-f1d6-405c-83fd-c2d75513eb23")
+                    .applicationUrl("/v2/apps/65489f49-f437-431a-8f58-c118ce08d83a")
+                    .routeUrl("/v2/routes/c7ce0cac-f1d6-405c-83fd-c2d75513eb23")
+                    .build())
+                .build();
+        }
+
+        @Override
+        protected GetRouteMappingRequest getValidRequest() throws Exception {
+            return GetRouteMappingRequest.builder()
+                .routeMappingId("test-route-mapping-id")
+                .build();
+        }
+
+        @Override
+        protected Mono<GetRouteMappingResponse> invoke(GetRouteMappingRequest request) {
+            return this.routeMappings.get(request);
         }
 
     }

--- a/cloudfoundry-client-spring/src/test/resources/fixtures/client/v2/route_mappings/GET_{id}_response.json
+++ b/cloudfoundry-client-spring/src/test/resources/fixtures/client/v2/route_mappings/GET_{id}_response.json
@@ -1,0 +1,15 @@
+{
+  "metadata": {
+    "guid": "304bead7-ad5a-4f6e-a093-f2a85d30c54a",
+    "url": "/v2/route_mappings/304bead7-ad5a-4f6e-a093-f2a85d30c54a",
+    "created_at": "2016-04-06T00:17:40Z",
+    "updated_at": null
+  },
+  "entity": {
+    "app_port": 8888,
+    "app_guid": "65489f49-f437-431a-8f58-c118ce08d83a",
+    "route_guid": "c7ce0cac-f1d6-405c-83fd-c2d75513eb23",
+    "app_url": "/v2/apps/65489f49-f437-431a-8f58-c118ce08d83a",
+    "route_url": "/v2/routes/c7ce0cac-f1d6-405c-83fd-c2d75513eb23"
+  }
+}

--- a/cloudfoundry-client/src/main/java/org/cloudfoundry/client/v2/routemappings/RouteMappings.java
+++ b/cloudfoundry-client/src/main/java/org/cloudfoundry/client/v2/routemappings/RouteMappings.java
@@ -40,6 +40,14 @@ public interface RouteMappings {
     Mono<DeleteRouteMappingResponse> delete(DeleteRouteMappingRequest request);
 
     /**
+     * Makes the <a href="http://apidocs.cloudfoundry.org/latest-release/routes_mapping/retrieve_a_particular_route_mapping.html">Retrieve a particular Route Mapping</a> request
+     *
+     * @param request the Get Route Mapping request
+     * @return the response from the Get Route Mapping request
+     */
+    Mono<GetRouteMappingResponse> get(GetRouteMappingRequest request);
+
+    /**
      * Makes the <a href="http://apidocs.cloudfoundry.org/latest-release/routes_mapping/list_all_route_mappings.html">List Route Mappings</a> request
      *
      * @param request the List Route Mappings request

--- a/cloudfoundry-client/src/main/lombok/org/cloudfoundry/client/v2/routemappings/GetRouteMappingRequest.java
+++ b/cloudfoundry-client/src/main/lombok/org/cloudfoundry/client/v2/routemappings/GetRouteMappingRequest.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright 2013-2016 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.cloudfoundry.client.v2.routemappings;
+
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import lombok.Builder;
+import lombok.Data;
+import lombok.Getter;
+import org.cloudfoundry.Validatable;
+import org.cloudfoundry.ValidationResult;
+
+/**
+ * The request payload for the Get Route Mapping operation
+ */
+@Data
+public final class GetRouteMappingRequest implements Validatable {
+
+    /**
+     * The route mapping id
+     *
+     * @param routeMappingId the route mapping id
+     * @return the route mapping id
+     */
+    @Getter(onMethod = @__(@JsonIgnore))
+    private final String routeMappingId;
+
+    @Builder
+    GetRouteMappingRequest(String routeMappingId) {
+        this.routeMappingId = routeMappingId;
+    }
+
+    @Override
+    public ValidationResult isValid() {
+        ValidationResult.ValidationResultBuilder builder = ValidationResult.builder();
+
+        if (this.routeMappingId == null) {
+            builder.message("route mapping id must be specified");
+        }
+
+        return builder.build();
+    }
+
+}

--- a/cloudfoundry-client/src/main/lombok/org/cloudfoundry/client/v2/routemappings/GetRouteMappingResponse.java
+++ b/cloudfoundry-client/src/main/lombok/org/cloudfoundry/client/v2/routemappings/GetRouteMappingResponse.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2013-2016 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.cloudfoundry.client.v2.routemappings;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.Builder;
+import lombok.Data;
+import lombok.EqualsAndHashCode;
+import lombok.ToString;
+
+/**
+ * The response payload for the Get a Route Mapping operation
+ */
+@Data
+@EqualsAndHashCode(callSuper = true)
+@ToString(callSuper = true)
+public final class GetRouteMappingResponse extends AbstractRouteMappingResource {
+
+    @Builder
+    GetRouteMappingResponse(@JsonProperty("entity") RouteMappingEntity entity,
+                            @JsonProperty("metadata") Metadata metadata) {
+
+        super(entity, metadata);
+    }
+
+}

--- a/cloudfoundry-client/src/test/java/org/cloudfoundry/client/v2/routemappings/GetRouteMappingRequestTest.java
+++ b/cloudfoundry-client/src/test/java/org/cloudfoundry/client/v2/routemappings/GetRouteMappingRequestTest.java
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package org.cloudfoundry.client.v2.privatedomains;
+package org.cloudfoundry.client.v2.routemappings;
 
 import org.cloudfoundry.ValidationResult;
 import org.junit.Test;
@@ -23,22 +23,22 @@ import static org.cloudfoundry.ValidationResult.Status.INVALID;
 import static org.cloudfoundry.ValidationResult.Status.VALID;
 import static org.junit.Assert.assertEquals;
 
-public final class GetPrivateDomainRequestTest {
+public final class GetRouteMappingRequestTest {
 
     @Test
     public void isNotValidNoId() {
-        ValidationResult result = GetPrivateDomainRequest.builder()
+        ValidationResult result = GetRouteMappingRequest.builder()
             .build()
             .isValid();
 
         assertEquals(INVALID, result.getStatus());
-        assertEquals("private domain id must be specified", result.getMessages().get(0));
+        assertEquals("route mapping id must be specified", result.getMessages().get(0));
     }
 
     @Test
     public void isValid() {
-        ValidationResult result = GetPrivateDomainRequest.builder()
-            .privateDomainId("test-private-domain-id")
+        ValidationResult result = GetRouteMappingRequest.builder()
+            .routeMappingId("test-route-mapping-id")
             .build()
             .isValid();
 


### PR DESCRIPTION
This change adds the api to retrieve a particular route mapping (`GET /v2/route_mappings/:guid`)
See [this story](https://www.pivotaltracker.com/n/projects/816799/stories/116555681)