### PR TITLE
List Running Security Groups

### DIFF
--- a/cloudfoundry-client-spring/src/main/lombok/org/cloudfoundry/spring/client/SpringCloudFoundryClient.java
+++ b/cloudfoundry-client-spring/src/main/lombok/org/cloudfoundry/spring/client/SpringCloudFoundryClient.java
@@ -36,6 +36,7 @@ import org.cloudfoundry.client.v2.organizations.Organizations;
 import org.cloudfoundry.client.v2.privatedomains.PrivateDomains;
 import org.cloudfoundry.client.v2.routemappings.RouteMappings;
 import org.cloudfoundry.client.v2.routes.Routes;
+import org.cloudfoundry.client.v2.runningsecuritygroups.RunningSecurityGroups;
 import org.cloudfoundry.client.v2.servicebindings.ServiceBindings;
 import org.cloudfoundry.client.v2.servicebrokers.ServiceBrokers;
 import org.cloudfoundry.client.v2.serviceinstances.ServiceInstances;
@@ -64,11 +65,12 @@ import org.cloudfoundry.spring.client.v2.events.SpringEvents;
 import org.cloudfoundry.spring.client.v2.featureflags.SpringFeatureFlags;
 import org.cloudfoundry.spring.client.v2.info.SpringInfo;
 import org.cloudfoundry.spring.client.v2.jobs.SpringJobs;
+import org.cloudfoundry.spring.client.v2.organizationquotadefinitions.SpringOrganizationQuotaDefinitions;
 import org.cloudfoundry.spring.client.v2.organizations.SpringOrganizations;
 import org.cloudfoundry.spring.client.v2.privatedomains.SpringPrivateDomains;
-import org.cloudfoundry.spring.client.v2.organizationquotadefinitions.SpringOrganizationQuotaDefinitions;
 import org.cloudfoundry.spring.client.v2.routemappings.SpringRouteMappings;
 import org.cloudfoundry.spring.client.v2.routes.SpringRoutes;
+import org.cloudfoundry.spring.client.v2.runningsecuritygroups.SpringRunningSecurityGroups;
 import org.cloudfoundry.spring.client.v2.servicebindings.SpringServiceBindings;
 import org.cloudfoundry.spring.client.v2.servicebrokers.SpringServiceBrokers;
 import org.cloudfoundry.spring.client.v2.serviceinstances.SpringServiceInstances;
@@ -153,6 +155,8 @@ public final class SpringCloudFoundryClient implements CloudFoundryClient {
 
     private final Routes routes;
 
+    private final RunningSecurityGroups runningSecurityGroups;
+
     private final ServiceBindings serviceBindings;
 
     private final ServiceBrokers serviceBrokers;
@@ -218,6 +222,7 @@ public final class SpringCloudFoundryClient implements CloudFoundryClient {
         this.processes = new SpringProcesses(restOperations, root, schedulerGroup);
         this.routeMappings = new SpringRouteMappings(restOperations, root, schedulerGroup);
         this.routes = new SpringRoutes(restOperations, root, schedulerGroup);
+        this.runningSecurityGroups = new SpringRunningSecurityGroups(restOperations, root, schedulerGroup);
         this.sharedDomains = new SpringSharedDomains(restOperations, root, schedulerGroup);
         this.serviceBindings = new SpringServiceBindings(restOperations, root, schedulerGroup);
         this.serviceBrokers = new SpringServiceBrokers(restOperations, root, schedulerGroup);
@@ -353,6 +358,11 @@ public final class SpringCloudFoundryClient implements CloudFoundryClient {
     @Override
     public Routes routes() {
         return this.routes;
+    }
+
+    @Override
+    public RunningSecurityGroups runningSecurityGroups() {
+        return this.runningSecurityGroups;
     }
 
     @Override

--- a/cloudfoundry-client-spring/src/main/lombok/org/cloudfoundry/spring/client/v2/runningsecuritygroups/SpringRunningSecurityGroups.java
+++ b/cloudfoundry-client-spring/src/main/lombok/org/cloudfoundry/spring/client/v2/runningsecuritygroups/SpringRunningSecurityGroups.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2013-2016 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.cloudfoundry.spring.client.v2.runningsecuritygroups;
+
+import lombok.ToString;
+import org.cloudfoundry.client.v2.runningsecuritygroups.ListRunningSecurityGroupResponse;
+import org.cloudfoundry.client.v2.runningsecuritygroups.ListRunningSecurityGroupsRequest;
+import org.cloudfoundry.client.v2.runningsecuritygroups.RunningSecurityGroups;
+import org.cloudfoundry.spring.util.AbstractSpringOperations;
+import org.springframework.web.client.RestOperations;
+import reactor.core.publisher.Mono;
+import reactor.core.publisher.SchedulerGroup;
+
+import java.net.URI;
+
+/**
+ * The Spring-based implementation of {@link RunningSecurityGroups}
+ */
+@ToString(callSuper = true)
+public class SpringRunningSecurityGroups extends AbstractSpringOperations implements RunningSecurityGroups {
+
+    /**
+     * Creates an instance
+     *
+     * @param restOperations the {@link RestOperations} to use to communicate with the server
+     * @param root           the root URI of the server.  Typically something like {@code https://api.run.pivotal.io}.
+     * @param schedulerGroup The group to use when making requests
+     */
+    public SpringRunningSecurityGroups(RestOperations restOperations, URI root, SchedulerGroup schedulerGroup) {
+        super(restOperations, root, schedulerGroup);
+    }
+
+    @Override
+    public Mono<ListRunningSecurityGroupResponse> list(ListRunningSecurityGroupsRequest request) {
+        return get(request, ListRunningSecurityGroupResponse.class, builder -> builder.pathSegment("v2", "config", "running_security_groups"));
+    }
+
+}

--- a/cloudfoundry-client-spring/src/test/java/org/cloudfoundry/spring/client/SpringCloudFoundryClientTest.java
+++ b/cloudfoundry-client-spring/src/test/java/org/cloudfoundry/spring/client/SpringCloudFoundryClientTest.java
@@ -129,6 +129,11 @@ public final class SpringCloudFoundryClientTest extends AbstractRestTest {
     }
 
     @Test
+    public void runningSecurityGroups() {
+        assertNotNull(this.client.runningSecurityGroups());
+    }
+
+    @Test
     public void serviceBindings() {
         assertNotNull(this.client.serviceBindings());
     }

--- a/cloudfoundry-client-spring/src/test/java/org/cloudfoundry/spring/client/v2/runningsecuritygroups/SpringRunningSecurityGroupsTest.java
+++ b/cloudfoundry-client-spring/src/test/java/org/cloudfoundry/spring/client/v2/runningsecuritygroups/SpringRunningSecurityGroupsTest.java
@@ -1,0 +1,86 @@
+/*
+ * Copyright 2013-2016 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.cloudfoundry.spring.client.v2.runningsecuritygroups;
+
+import org.cloudfoundry.client.v2.Resource;
+import org.cloudfoundry.client.v2.runningsecuritygroups.ListRunningSecurityGroupResponse;
+import org.cloudfoundry.client.v2.runningsecuritygroups.ListRunningSecurityGroupsRequest;
+import org.cloudfoundry.client.v2.securitygroups.SecurityGroupEntity;
+import org.cloudfoundry.client.v2.securitygroups.SecurityGroupResource;
+import org.cloudfoundry.spring.AbstractApiTest;
+import reactor.core.publisher.Mono;
+
+import static org.springframework.http.HttpMethod.GET;
+import static org.springframework.http.HttpStatus.OK;
+
+public final class SpringRunningSecurityGroupsTest {
+
+    public static final class List extends AbstractApiTest<ListRunningSecurityGroupsRequest, ListRunningSecurityGroupResponse> {
+
+        private final SpringRunningSecurityGroups runningSecurityGroups = new SpringRunningSecurityGroups(this.restTemplate, this.root, PROCESSOR_GROUP);
+
+        @Override
+        protected ListRunningSecurityGroupsRequest getInvalidRequest() {
+            return null;
+        }
+
+        @Override
+        protected RequestContext getRequestContext() {
+            return new RequestContext()
+                .method(GET).path("/v2/config/running_security_groups")
+                .status(OK)
+                .responsePayload("fixtures/client/v2/running_security_groups/GET_response.json");
+        }
+
+        @Override
+        protected ListRunningSecurityGroupResponse getResponse() {
+            return ListRunningSecurityGroupResponse.builder()
+                .totalPages(1)
+                .totalResults(1)
+                .resource(SecurityGroupResource.builder()
+                    .metadata(Resource.Metadata.builder()
+                        .createdAt("2016-04-06T00:17:17Z")
+                        .id("1f2f24f8-f68c-4a3b-b51a-8134fe2626d8")
+                        .url("/v2/config/running_security_groups/1f2f24f8-f68c-4a3b-b51a-8134fe2626d8")
+                        .build())
+                    .entity(SecurityGroupEntity.builder()
+                        .name("name-114")
+                        .rule(SecurityGroupEntity.RuleEntity.builder()
+                            .destination("198.41.191.47/1")
+                            .ports("8080")
+                            .protocol("udp")
+                            .build())
+                        .runningDefault(true)
+                        .stagingDefault(false)
+                        .build())
+                    .build())
+                .build();
+        }
+
+        @Override
+        protected ListRunningSecurityGroupsRequest getValidRequest() throws Exception {
+            return ListRunningSecurityGroupsRequest.builder().build();
+        }
+
+        @Override
+        protected Mono<ListRunningSecurityGroupResponse> invoke(ListRunningSecurityGroupsRequest request) {
+            return this.runningSecurityGroups.list(request);
+        }
+
+    }
+
+}

--- a/cloudfoundry-client-spring/src/test/resources/fixtures/client/v2/running_security_groups/GET_response.json
+++ b/cloudfoundry-client-spring/src/test/resources/fixtures/client/v2/running_security_groups/GET_response.json
@@ -1,0 +1,28 @@
+{
+  "total_results": 1,
+  "total_pages": 1,
+  "prev_url": null,
+  "next_url": null,
+  "resources": [
+    {
+      "metadata": {
+        "guid": "1f2f24f8-f68c-4a3b-b51a-8134fe2626d8",
+        "url": "/v2/config/running_security_groups/1f2f24f8-f68c-4a3b-b51a-8134fe2626d8",
+        "created_at": "2016-04-06T00:17:17Z",
+        "updated_at": null
+      },
+      "entity": {
+        "name": "name-114",
+        "rules": [
+          {
+            "protocol": "udp",
+            "ports": "8080",
+            "destination": "198.41.191.47/1"
+          }
+        ],
+        "running_default": true,
+        "staging_default": false
+      }
+    }
+  ]
+}

--- a/cloudfoundry-client/src/main/java/org/cloudfoundry/client/CloudFoundryClient.java
+++ b/cloudfoundry-client/src/main/java/org/cloudfoundry/client/CloudFoundryClient.java
@@ -30,6 +30,7 @@ import org.cloudfoundry.client.v2.organizations.Organizations;
 import org.cloudfoundry.client.v2.privatedomains.PrivateDomains;
 import org.cloudfoundry.client.v2.routemappings.RouteMappings;
 import org.cloudfoundry.client.v2.routes.Routes;
+import org.cloudfoundry.client.v2.runningsecuritygroups.RunningSecurityGroups;
 import org.cloudfoundry.client.v2.servicebindings.ServiceBindings;
 import org.cloudfoundry.client.v2.servicebrokers.ServiceBrokers;
 import org.cloudfoundry.client.v2.serviceinstances.ServiceInstances;
@@ -193,6 +194,13 @@ public interface CloudFoundryClient {
      * @return the Cloud Foundry Routes Client API
      */
     Routes routes();
+
+    /**
+     * Main entry point to the Cloud Foundry Running Security Groups Client API
+     *
+     * @return the Cloud Foundry Running Security Groups Client API
+     */
+    RunningSecurityGroups runningSecurityGroups();
 
     /**
      * Main entry point to the Cloud Foundry Service Bindings Client API

--- a/cloudfoundry-client/src/main/java/org/cloudfoundry/client/v2/runningsecuritygroups/RunningSecurityGroups.java
+++ b/cloudfoundry-client/src/main/java/org/cloudfoundry/client/v2/runningsecuritygroups/RunningSecurityGroups.java
@@ -14,26 +14,19 @@
  * limitations under the License.
  */
 
-package org.cloudfoundry.client.v2.securitygroups;
+package org.cloudfoundry.client.v2.runningsecuritygroups;
 
-import com.fasterxml.jackson.annotation.JsonProperty;
-import lombok.Builder;
-import lombok.Data;
-import lombok.EqualsAndHashCode;
-import lombok.ToString;
+import reactor.core.publisher.Mono;
 
-/**
- * Route Resource in responses
- */
-@Data
-@EqualsAndHashCode(callSuper = true)
-@ToString(callSuper = true)
-public final class SecurityGroupResource extends AbstractSecurityGroupResource {
+public interface RunningSecurityGroups {
 
-    @Builder
-    SecurityGroupResource(@JsonProperty("entity") SecurityGroupEntity entity,
-                          @JsonProperty("metadata") Metadata metadata) {
-        super(entity, metadata);
-    }
+    /**
+     * Makes the <a href="http://apidocs.cloudfoundry.org/latest-release/security_group_running_defaults/return_the_security_groups_used_for_running_apps.html">List Running Security Groups</a>
+     * request.
+     *
+     * @param request the list running security groups request
+     * @return the response from the list running security groups request
+     */
+    Mono<ListRunningSecurityGroupResponse> list(ListRunningSecurityGroupsRequest request);
 
 }

--- a/cloudfoundry-client/src/main/lombok/org/cloudfoundry/client/v2/runningsecuritygroups/ListRunningSecurityGroupResponse.java
+++ b/cloudfoundry-client/src/main/lombok/org/cloudfoundry/client/v2/runningsecuritygroups/ListRunningSecurityGroupResponse.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2013-2016 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.cloudfoundry.client.v2.runningsecuritygroups;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.Builder;
+import lombok.Data;
+import lombok.EqualsAndHashCode;
+import lombok.Singular;
+import lombok.ToString;
+import org.cloudfoundry.client.v2.PaginatedResponse;
+import org.cloudfoundry.client.v2.securitygroups.SecurityGroupResource;
+
+import java.util.List;
+
+/**
+ * The response payload for the List Running Security Groups operation
+ */
+@Data
+@EqualsAndHashCode(callSuper = true)
+@ToString(callSuper = true)
+public final class ListRunningSecurityGroupResponse extends PaginatedResponse<SecurityGroupResource> {
+
+    @Builder
+    ListRunningSecurityGroupResponse(@JsonProperty("next_url") String nextUrl,
+                                     @JsonProperty("prev_url") String previousUrl,
+                                     @JsonProperty("resources") @Singular List<SecurityGroupResource> resources,
+                                     @JsonProperty("total_pages") Integer totalPages,
+                                     @JsonProperty("total_results") Integer totalResults) {
+        super(nextUrl, previousUrl, resources, totalPages, totalResults);
+    }
+
+}

--- a/cloudfoundry-client/src/main/lombok/org/cloudfoundry/client/v2/runningsecuritygroups/ListRunningSecurityGroupsRequest.java
+++ b/cloudfoundry-client/src/main/lombok/org/cloudfoundry/client/v2/runningsecuritygroups/ListRunningSecurityGroupsRequest.java
@@ -14,26 +14,26 @@
  * limitations under the License.
  */
 
-package org.cloudfoundry.client.v2.securitygroups;
+package org.cloudfoundry.client.v2.runningsecuritygroups;
 
-import com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.Builder;
 import lombok.Data;
-import lombok.EqualsAndHashCode;
-import lombok.ToString;
+import org.cloudfoundry.Validatable;
+import org.cloudfoundry.ValidationResult;
 
 /**
- * Route Resource in responses
+ * The request payload for the List Running Security Groups operation
  */
 @Data
-@EqualsAndHashCode(callSuper = true)
-@ToString(callSuper = true)
-public final class SecurityGroupResource extends AbstractSecurityGroupResource {
+public final class ListRunningSecurityGroupsRequest implements Validatable {
 
     @Builder
-    SecurityGroupResource(@JsonProperty("entity") SecurityGroupEntity entity,
-                          @JsonProperty("metadata") Metadata metadata) {
-        super(entity, metadata);
+    ListRunningSecurityGroupsRequest() {
+    }
+
+    @Override
+    public ValidationResult isValid() {
+        return ValidationResult.builder().build();
     }
 
 }

--- a/cloudfoundry-client/src/main/lombok/org/cloudfoundry/client/v2/securitygroups/AbstractSecurityGroupResource.java
+++ b/cloudfoundry-client/src/main/lombok/org/cloudfoundry/client/v2/securitygroups/AbstractSecurityGroupResource.java
@@ -17,10 +17,10 @@
 package org.cloudfoundry.client.v2.securitygroups;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
-import lombok.Builder;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
 import lombok.ToString;
+import org.cloudfoundry.client.v2.Resource;
 
 /**
  * Route Resource in responses
@@ -28,11 +28,10 @@ import lombok.ToString;
 @Data
 @EqualsAndHashCode(callSuper = true)
 @ToString(callSuper = true)
-public final class SecurityGroupResource extends AbstractSecurityGroupResource {
+public abstract class AbstractSecurityGroupResource extends Resource<SecurityGroupEntity> {
 
-    @Builder
-    SecurityGroupResource(@JsonProperty("entity") SecurityGroupEntity entity,
-                          @JsonProperty("metadata") Metadata metadata) {
+    AbstractSecurityGroupResource(@JsonProperty("entity") SecurityGroupEntity entity,
+                                  @JsonProperty("metadata") Metadata metadata) {
         super(entity, metadata);
     }
 

--- a/cloudfoundry-client/src/test/java/org/cloudfoundry/client/v2/runningsecuritygroups/ListRunningSecurityGroupsRequestTest.java
+++ b/cloudfoundry-client/src/test/java/org/cloudfoundry/client/v2/runningsecuritygroups/ListRunningSecurityGroupsRequestTest.java
@@ -14,26 +14,19 @@
  * limitations under the License.
  */
 
-package org.cloudfoundry.client.v2.securitygroups;
+package org.cloudfoundry.client.v2.runningsecuritygroups;
 
-import com.fasterxml.jackson.annotation.JsonProperty;
-import lombok.Builder;
-import lombok.Data;
-import lombok.EqualsAndHashCode;
-import lombok.ToString;
+import org.cloudfoundry.ValidationResult;
+import org.junit.Test;
 
-/**
- * Route Resource in responses
- */
-@Data
-@EqualsAndHashCode(callSuper = true)
-@ToString(callSuper = true)
-public final class SecurityGroupResource extends AbstractSecurityGroupResource {
+import static org.junit.Assert.assertEquals;
 
-    @Builder
-    SecurityGroupResource(@JsonProperty("entity") SecurityGroupEntity entity,
-                          @JsonProperty("metadata") Metadata metadata) {
-        super(entity, metadata);
+public final class ListRunningSecurityGroupsRequestTest {
+
+    @Test
+    public void isValid() {
+        assertEquals(ValidationResult.Status.VALID,
+            ListRunningSecurityGroupsRequest.builder().build().isValid().getStatus());
     }
 
 }


### PR DESCRIPTION
This change adds the api to list running security groups (`GET /v2/config/running_security_groups`)
See [this story](https://www.pivotaltracker.com/projects/816799/stories/101522638)