### PR TITLE
Create buildpack operation

### DIFF
--- a/cloudfoundry-operations/src/main/java/org/cloudfoundry/operations/buildpacks/Buildpacks.java
+++ b/cloudfoundry-operations/src/main/java/org/cloudfoundry/operations/buildpacks/Buildpacks.java
@@ -16,12 +16,22 @@
 
 package org.cloudfoundry.operations.buildpacks;
 
+import org.cloudfoundry.client.v2.buildpacks.CreateBuildpackRequest;
 import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
 
 /**
  * Main entry point to the Cloud Foundry Buildpacks Operations API
  */
 public interface Buildpacks {
+
+    /**
+     * Create a new Buildpack
+     *
+     * @param request The Create Buildpack request
+     * @return a completion indicator
+     */
+    Mono<Void> create(CreateBuildpackRequest request);
 
     /**
      * Lists the buildpacks

--- a/cloudfoundry-operations/src/main/java/org/cloudfoundry/operations/buildpacks/Buildpacks.java
+++ b/cloudfoundry-operations/src/main/java/org/cloudfoundry/operations/buildpacks/Buildpacks.java
@@ -16,7 +16,6 @@
 
 package org.cloudfoundry.operations.buildpacks;
 
-import org.cloudfoundry.client.v2.buildpacks.CreateBuildpackRequest;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 

--- a/cloudfoundry-operations/src/main/java/org/cloudfoundry/operations/buildpacks/DefaultBuildpacks.java
+++ b/cloudfoundry-operations/src/main/java/org/cloudfoundry/operations/buildpacks/DefaultBuildpacks.java
@@ -19,10 +19,8 @@ package org.cloudfoundry.operations.buildpacks;
 import org.cloudfoundry.client.CloudFoundryClient;
 import org.cloudfoundry.client.v2.buildpacks.BuildpackEntity;
 import org.cloudfoundry.client.v2.buildpacks.BuildpackResource;
-import org.cloudfoundry.client.v2.buildpacks.CreateBuildpackRequest;
 import org.cloudfoundry.client.v2.buildpacks.CreateBuildpackResponse;
 import org.cloudfoundry.client.v2.buildpacks.ListBuildpacksRequest;
-import org.cloudfoundry.util.ExceptionUtils;
 import org.cloudfoundry.util.PaginationUtils;
 import org.cloudfoundry.util.ResourceUtils;
 import org.cloudfoundry.util.ValidationUtils;
@@ -41,9 +39,7 @@ public final class DefaultBuildpacks implements Buildpacks {
     public Mono<Void> create(CreateBuildpackRequest request) {
         return ValidationUtils
             .validate(request)
-            .then(request1 -> validateAdditionalArguments(request1.getFilename(), request1.getPosition()))
-            .then(message -> ExceptionUtils.illegalArgument(message))
-            .otherwiseIfEmpty(requestCreateBuildpack(this.cloudFoundryClient, request))
+            .then(request1 -> requestCreateBuildpack(this.cloudFoundryClient, request1.getBuildpack(), request1.getPath(), request1.getPosition(), request1.getEnable()))
             .after();
     }
 
@@ -53,9 +49,15 @@ public final class DefaultBuildpacks implements Buildpacks {
             .map(DefaultBuildpacks::toBuildpackResource);
     }
 
-    private static Mono<CreateBuildpackResponse> requestCreateBuildpack(CloudFoundryClient cloudFoundryClient, CreateBuildpackRequest request){
+    private static Mono<CreateBuildpackResponse> requestCreateBuildpack(CloudFoundryClient cloudFoundryClient, String buildpack, String path, Integer position, Boolean enable) {
         return cloudFoundryClient.buildpacks()
-            .create(request);
+            .create(org.cloudfoundry.client.v2.buildpacks.CreateBuildpackRequest
+                .builder()
+                .name(buildpack)
+                .filename(path)
+                .position(position)
+                .enabled(enable)
+                .build());
     }
 
     private static Flux<BuildpackResource> requestBuildpacks(CloudFoundryClient cloudFoundryClient) {
@@ -77,16 +79,6 @@ public final class DefaultBuildpacks implements Buildpacks {
             .name(entity.getName())
             .position(entity.getPosition())
             .build();
-    }
-
-    private static Mono<String> validateAdditionalArguments(String filename, Integer position){
-        return filename == null ?
-            (position == null ?
-                Mono.just("Filename must be specified and position must be specified") :
-                Mono.just("Filename must be specified"))
-            : (position == null ?
-                Mono.just("Position must be specified") :
-                Mono.empty());
     }
 
 }

--- a/cloudfoundry-operations/src/main/lombok/org/cloudfoundry/operations/buildpacks/CreateBuildpackRequest.java
+++ b/cloudfoundry-operations/src/main/lombok/org/cloudfoundry/operations/buildpacks/CreateBuildpackRequest.java
@@ -1,0 +1,90 @@
+/*
+ * Copyright 2013-2016 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.cloudfoundry.operations.buildpacks;
+
+import lombok.Builder;
+import lombok.Data;
+import org.cloudfoundry.Validatable;
+import org.cloudfoundry.ValidationResult;
+
+/**
+ * The request options for the create buildpack operation
+ */
+@Data
+public class CreateBuildpackRequest implements Validatable {
+
+    /**
+     * The buildpack name
+     *
+     * @param buildpack the buildpack name
+     * @return the buildpack name
+     */
+    private final String buildpack;
+
+    /**
+     * The buildpack path
+     *
+     * @param path the buildpack path
+     * @return the buildpack path
+     */
+    private final String path;
+
+    /**
+     * The buildpack position
+     *
+     * @param position the buildpack position
+     * @return the buildpack position
+     */
+    private final Integer position;
+
+    /**
+     * Enables the buildpack to be used for staging
+     * Default value is true
+     *
+     * @param enable the enable option indicating whether the buildpack is used for staging
+     * @return the enable option
+     */
+    private Boolean enable;
+
+
+    @Builder
+    CreateBuildpackRequest(String buildpack, String path, Integer position, Boolean enable) {
+        this.buildpack = buildpack;
+        this.path = path;
+        this.position = position;
+        this.enable = (enable != null ? enable : true);
+    }
+
+    @Override
+    public ValidationResult isValid() {
+        ValidationResult.ValidationResultBuilder builder = ValidationResult.builder();
+
+        if (this.buildpack == null) {
+            builder.message("buildpack must be specified");
+        }
+
+        if (this.path == null) {
+            builder.message("path must be specified");
+        }
+
+        if (this.position == null) {
+            builder.message("position must be specified");
+        }
+
+        return builder.build();
+    }
+}

--- a/cloudfoundry-operations/src/test/java/org/cloudfoundry/operations/buildpacks/CreateBuildpackRequestTest.java
+++ b/cloudfoundry-operations/src/test/java/org/cloudfoundry/operations/buildpacks/CreateBuildpackRequestTest.java
@@ -17,19 +17,23 @@
 package org.cloudfoundry.operations.buildpacks;
 
 import org.cloudfoundry.ValidationResult;
-import org.cloudfoundry.client.v2.buildpacks.CreateBuildpackRequest;
 import org.junit.Test;
 
 import static org.cloudfoundry.ValidationResult.Status.INVALID;
 import static org.cloudfoundry.ValidationResult.Status.VALID;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
 
 public class CreateBuildpackRequestTest {
 
     @Test
     public void isValid() {
+
         ValidationResult result = CreateBuildpackRequest.builder()
-            .name("test-go-buildpack")
+            .buildpack("test-go-buildpack")
+            .path("https://github.com/cloudfoundry/go-buildpack")
+            .position(1)
+            .enable(true)
             .build()
             .isValid();
 
@@ -37,13 +41,85 @@ public class CreateBuildpackRequestTest {
     }
 
     @Test
-    public void isValidNoName() {
+    public void isValidDefaultEnable() {
+
+        CreateBuildpackRequest buildpackRequest = CreateBuildpackRequest.builder()
+            .buildpack("test-go-buildpack")
+            .path("https://github.com/cloudfoundry/go-buildpack")
+            .position(1)
+            .build();
+        ValidationResult result = buildpackRequest.isValid();
+
+        assertTrue(buildpackRequest.getEnable() == true);
+        assertEquals(VALID, result.getStatus());
+    }
+
+    @Test
+    public void isValidDisabledBuildpack() {
+
+        CreateBuildpackRequest buildpackRequest = CreateBuildpackRequest.builder()
+            .buildpack("test-go-buildpack")
+            .path("https://github.com/cloudfoundry/go-buildpack")
+            .position(1)
+            .enable(false)
+            .build();
+        ValidationResult result = buildpackRequest.isValid();
+
+        assertTrue(buildpackRequest.getEnable() == false);
+        assertEquals(VALID, result.getStatus());
+    }
+
+    @Test
+    public void isInValid() {
         ValidationResult result = CreateBuildpackRequest.builder()
             .build()
             .isValid();
 
         assertEquals(INVALID, result.getStatus());
-        assertEquals("name must be specified", result.getMessages().get(0));
+        assertTrue(result.getMessages().size() == 3);
+        assertEquals("buildpack must be specified", result.getMessages().get(0));
+        assertEquals("path must be specified", result.getMessages().get(1));
+        assertEquals("position must be specified", result.getMessages().get(2));
     }
+
+    @Test
+    public void isInValidNoBuildpack() {
+        ValidationResult result = CreateBuildpackRequest.builder()
+            .path("https://github.com/cloudfoundry/go-buildpack")
+            .position(1)
+            .build()
+            .isValid();
+
+        assertEquals(INVALID, result.getStatus());
+        assertTrue(result.getMessages().size() == 1);
+        assertEquals("buildpack must be specified", result.getMessages().get(0));
+    }
+
+    @Test
+    public void isInValidNoPath() {
+        ValidationResult result = CreateBuildpackRequest.builder()
+            .buildpack("test-go-buildpack")
+            .position(1)
+            .build()
+            .isValid();
+
+        assertEquals(INVALID, result.getStatus());
+        assertTrue(result.getMessages().size() == 1);
+        assertEquals("path must be specified", result.getMessages().get(0));
+    }
+
+    @Test
+    public void isInValidNoPosition() {
+        ValidationResult result = CreateBuildpackRequest.builder()
+            .buildpack("test-go-buildpack")
+            .path("https://github.com/cloudfoundry/go-buildpack")
+            .build()
+            .isValid();
+
+        assertEquals(INVALID, result.getStatus());
+        assertTrue(result.getMessages().size() == 1);
+        assertEquals("position must be specified", result.getMessages().get(0));
+    }
+
 
 }

--- a/cloudfoundry-operations/src/test/java/org/cloudfoundry/operations/buildpacks/CreateBuildpackRequestTest.java
+++ b/cloudfoundry-operations/src/test/java/org/cloudfoundry/operations/buildpacks/CreateBuildpackRequestTest.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2013-2016 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.cloudfoundry.operations.buildpacks;
+
+import org.cloudfoundry.ValidationResult;
+import org.cloudfoundry.client.v2.buildpacks.CreateBuildpackRequest;
+import org.junit.Test;
+
+import static org.cloudfoundry.ValidationResult.Status.INVALID;
+import static org.cloudfoundry.ValidationResult.Status.VALID;
+import static org.junit.Assert.assertEquals;
+
+public class CreateBuildpackRequestTest {
+
+    @Test
+    public void isValid() {
+        ValidationResult result = CreateBuildpackRequest.builder()
+            .name("test-go-buildpack")
+            .build()
+            .isValid();
+
+        assertEquals(VALID, result.getStatus());
+    }
+
+    @Test
+    public void isValidNoName() {
+        ValidationResult result = CreateBuildpackRequest.builder()
+            .build()
+            .isValid();
+
+        assertEquals(INVALID, result.getStatus());
+        assertEquals("name must be specified", result.getMessages().get(0));
+    }
+
+}


### PR DESCRIPTION
The change adds the operation for create-builpack. 

In the REST client, the buildpack creation api needs only the name and the remaining arguments are optional but in CF cli, name, filename and position arguments are mandatory for calling the create-buildpack, so I have done the additional validation check in the create operation method.

Let me know whether this is fine or we can add the mandatory arguments check in the CreateBuildRequest itself.