### PR TITLE
Delete Security Group Running Default

### DIFF
--- a/cloudfoundry-client-spring/src/main/lombok/org/cloudfoundry/spring/client/v2/securitygroups/SpringSecurityGroups.java
+++ b/cloudfoundry-client-spring/src/main/lombok/org/cloudfoundry/spring/client/v2/securitygroups/SpringSecurityGroups.java
@@ -17,6 +17,7 @@
 package org.cloudfoundry.spring.client.v2.securitygroups;
 
 import lombok.ToString;
+import org.cloudfoundry.client.v2.securitygroups.DeleteSecurityGroupRunningDefaultRequest;
 import org.cloudfoundry.client.v2.securitygroups.ListSecurityGroupRunningDefaultsRequest;
 import org.cloudfoundry.client.v2.securitygroups.ListSecurityGroupRunningDefaultsResponse;
 import org.cloudfoundry.client.v2.securitygroups.SecurityGroups;
@@ -42,6 +43,11 @@ public class SpringSecurityGroups extends AbstractSpringOperations implements Se
      */
     public SpringSecurityGroups(RestOperations restOperations, URI root, SchedulerGroup schedulerGroup) {
         super(restOperations, root, schedulerGroup);
+    }
+
+    @Override
+    public Mono<Void> deleteRunningDefault(DeleteSecurityGroupRunningDefaultRequest request) {
+        return delete(request, Void.class, builder -> builder.pathSegment("v2", "config", "running_security_groups", request.getSecurityGroupRunningDefaultId()));
     }
 
     @Override

--- a/cloudfoundry-client-spring/src/test/java/org/cloudfoundry/spring/client/v2/securitygroups/SpringSecurityGroupsTest.java
+++ b/cloudfoundry-client-spring/src/test/java/org/cloudfoundry/spring/client/v2/securitygroups/SpringSecurityGroupsTest.java
@@ -17,6 +17,7 @@
 package org.cloudfoundry.spring.client.v2.securitygroups;
 
 import org.cloudfoundry.client.v2.Resource;
+import org.cloudfoundry.client.v2.securitygroups.DeleteSecurityGroupRunningDefaultRequest;
 import org.cloudfoundry.client.v2.securitygroups.ListSecurityGroupRunningDefaultsRequest;
 import org.cloudfoundry.client.v2.securitygroups.ListSecurityGroupRunningDefaultsResponse;
 import org.cloudfoundry.client.v2.securitygroups.SecurityGroupEntity;
@@ -24,10 +25,47 @@ import org.cloudfoundry.client.v2.securitygroups.SecurityGroupResource;
 import org.cloudfoundry.spring.AbstractApiTest;
 import reactor.core.publisher.Mono;
 
+import static org.springframework.http.HttpMethod.DELETE;
 import static org.springframework.http.HttpMethod.GET;
+import static org.springframework.http.HttpStatus.NO_CONTENT;
 import static org.springframework.http.HttpStatus.OK;
 
 public final class SpringSecurityGroupsTest {
+
+    public static final class Delete extends AbstractApiTest<DeleteSecurityGroupRunningDefaultRequest, Void> {
+
+        private final SpringSecurityGroups securityGroups = new SpringSecurityGroups(this.restTemplate, this.root, PROCESSOR_GROUP);
+
+        @Override
+        protected DeleteSecurityGroupRunningDefaultRequest getInvalidRequest() {
+            return DeleteSecurityGroupRunningDefaultRequest.builder().build();
+        }
+
+        @Override
+        protected RequestContext getRequestContext() {
+            return new RequestContext()
+                .method(DELETE).path("/v2/config/running_security_groups/test-id")
+                .status(NO_CONTENT);
+        }
+
+        @Override
+        protected Void getResponse() {
+            return null;
+        }
+
+        @Override
+        protected DeleteSecurityGroupRunningDefaultRequest getValidRequest() throws Exception {
+            return DeleteSecurityGroupRunningDefaultRequest.builder()
+                .securityGroupRunningDefaultId("test-id")
+                .build();
+        }
+
+        @Override
+        protected Mono<Void> invoke(DeleteSecurityGroupRunningDefaultRequest request) {
+            return this.securityGroups.deleteRunningDefault(request);
+        }
+
+    }
 
     public static final class List extends AbstractApiTest<ListSecurityGroupRunningDefaultsRequest, ListSecurityGroupRunningDefaultsResponse> {
 

--- a/cloudfoundry-client/src/main/java/org/cloudfoundry/client/v2/securitygroups/SecurityGroups.java
+++ b/cloudfoundry-client/src/main/java/org/cloudfoundry/client/v2/securitygroups/SecurityGroups.java
@@ -21,6 +21,15 @@ import reactor.core.publisher.Mono;
 public interface SecurityGroups {
 
     /**
+     * Makes the <a href="http://apidocs.cloudfoundry.org/latest-release/security_group_running_defaults/return_the_security_groups_used_for_running_apps.html">Delete Running Security Group</a>
+     * request.
+     *
+     * @param request the delete running security group request
+     * @return the response from the delete running security group request
+     */
+    Mono<Void> deleteRunningDefault(DeleteSecurityGroupRunningDefaultRequest request);
+
+    /**
      * Makes the <a href="http://apidocs.cloudfoundry.org/latest-release/security_group_running_defaults/return_the_security_groups_used_for_running_apps.html">List Running Security Groups</a>
      * request.
      *

--- a/cloudfoundry-client/src/main/lombok/org/cloudfoundry/client/v2/securitygroups/DeleteSecurityGroupRunningDefaultRequest.java
+++ b/cloudfoundry-client/src/main/lombok/org/cloudfoundry/client/v2/securitygroups/DeleteSecurityGroupRunningDefaultRequest.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright 2013-2016 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.cloudfoundry.client.v2.securitygroups;
+
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import lombok.Builder;
+import lombok.Data;
+import lombok.Getter;
+import org.cloudfoundry.Validatable;
+import org.cloudfoundry.ValidationResult;
+
+/**
+ * The request payload for the Delete Security Group Running Default operation
+ */
+@Data
+public final class DeleteSecurityGroupRunningDefaultRequest implements Validatable {
+
+    /**
+     * The security group running default id
+     *
+     * @param securityGroupRunningDefaultId the security group running default id
+     * @return the security group running default id
+     */
+    @Getter(onMethod = @__(@JsonIgnore))
+    private final String securityGroupRunningDefaultId;
+
+    @Builder
+    DeleteSecurityGroupRunningDefaultRequest(String securityGroupRunningDefaultId) {
+        this.securityGroupRunningDefaultId = securityGroupRunningDefaultId;
+    }
+
+    @Override
+    public ValidationResult isValid() {
+        ValidationResult.ValidationResultBuilder builder = ValidationResult.builder();
+
+        if (this.securityGroupRunningDefaultId == null) {
+            builder.message("security group running default id must be specified");
+        }
+
+        return builder.build();
+    }
+
+}

--- a/cloudfoundry-client/src/test/java/org/cloudfoundry/client/v2/routes/CreateRouteRequestTest.java
+++ b/cloudfoundry-client/src/test/java/org/cloudfoundry/client/v2/routes/CreateRouteRequestTest.java
@@ -26,22 +26,7 @@ import static org.junit.Assert.assertEquals;
 public final class CreateRouteRequestTest {
 
     @Test
-    public void isValid() {
-        ValidationResult result = CreateRouteRequest.builder()
-            .domainId("test-domain-id")
-            .generatePort("test-generate-port")
-            .host("test-host")
-            .path("test-path")
-            .port(10000)
-            .spaceId("test-space-id")
-            .build()
-            .isValid();
-
-        assertEquals(VALID, result.getStatus());
-    }
-
-    @Test
-    public void isValidNoDomainId() {
+    public void isNotValidNoDomainId() {
         ValidationResult result = CreateRouteRequest.builder()
             .generatePort("test-generate-port")
             .host("test-host")
@@ -56,7 +41,7 @@ public final class CreateRouteRequestTest {
     }
 
     @Test
-    public void isValidNoSpaceId() {
+    public void isNotValidNoSpaceId() {
         ValidationResult result = CreateRouteRequest.builder()
             .domainId("test-domain-id")
             .generatePort("test-generate-port")
@@ -68,6 +53,21 @@ public final class CreateRouteRequestTest {
 
         assertEquals(INVALID, result.getStatus());
         assertEquals("space id must be specified", result.getMessages().get(0));
+    }
+
+    @Test
+    public void isValid() {
+        ValidationResult result = CreateRouteRequest.builder()
+            .domainId("test-domain-id")
+            .generatePort("test-generate-port")
+            .host("test-host")
+            .path("test-path")
+            .port(10000)
+            .spaceId("test-space-id")
+            .build()
+            .isValid();
+
+        assertEquals(VALID, result.getStatus());
     }
 
 }

--- a/cloudfoundry-client/src/test/java/org/cloudfoundry/client/v2/securitygroups/DeleteSecurityGroupRunningDefaultRequestTest.java
+++ b/cloudfoundry-client/src/test/java/org/cloudfoundry/client/v2/securitygroups/DeleteSecurityGroupRunningDefaultRequestTest.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2013-2016 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.cloudfoundry.client.v2.securitygroups;
+
+import org.cloudfoundry.ValidationResult;
+import org.junit.Test;
+
+import static org.cloudfoundry.ValidationResult.Status.INVALID;
+import static org.cloudfoundry.ValidationResult.Status.VALID;
+import static org.junit.Assert.assertEquals;
+
+public final class DeleteSecurityGroupRunningDefaultRequestTest {
+
+    @Test
+    public void isNotValidNoId() {
+        ValidationResult result = DeleteSecurityGroupRunningDefaultRequest.builder()
+            .build()
+            .isValid();
+
+        assertEquals(INVALID, result.getStatus());
+        assertEquals("security group running default id must be specified", result.getMessages().get(0));
+    }
+
+    @Test
+    public void isValid() {
+        ValidationResult result = DeleteSecurityGroupRunningDefaultRequest.builder()
+            .securityGroupRunningDefaultId("test-security-group-default-id")
+            .build()
+            .isValid();
+
+        assertEquals(VALID, result.getStatus());
+    }
+
+}


### PR DESCRIPTION
This change adds the api to delete a security group running default (`DELETE /v2/config/running_security_groups/:guid`)
See [this story](https://www.pivotaltracker.com/projects/816799/stories/101522636)