### PR TITLE
Rename Service Operation

### DIFF
--- a/cloudfoundry-operations/src/main/java/org/cloudfoundry/operations/services/Services.java
+++ b/cloudfoundry-operations/src/main/java/org/cloudfoundry/operations/services/Services.java
@@ -71,6 +71,14 @@ public interface Services {
     Flux<ServiceOffering> listServiceOfferings(ListServiceOfferingsRequest request);
 
     /**
+     * Rename a service instance
+     *
+     * @param request the rename service instance request
+     * @return a completion indicator
+     */
+    Mono<Void> renameInstance(RenameServiceInstanceRequest request);
+
+    /**
      * Unbind a service instance from an application
      *
      * @param request the unbind service instance request

--- a/cloudfoundry-operations/src/main/lombok/org/cloudfoundry/operations/services/RenameServiceInstanceRequest.java
+++ b/cloudfoundry-operations/src/main/lombok/org/cloudfoundry/operations/services/RenameServiceInstanceRequest.java
@@ -22,10 +22,10 @@ import org.cloudfoundry.Validatable;
 import org.cloudfoundry.ValidationResult;
 
 /**
- * The request options for the get service instance operation
+ * The request options for the rename service instance operation
  */
 @Data
-public final class GetServiceInstanceRequest implements Validatable {
+public final class RenameServiceInstanceRequest implements Validatable {
 
     /**
      * The name of the service instance
@@ -35,9 +35,19 @@ public final class GetServiceInstanceRequest implements Validatable {
      */
     private final String name;
 
+    /**
+     * The new name of the service instance
+     *
+     * @param newName the new name of the service instance
+     * @return the new name of the service instance
+     */
+    private final String newName;
+
     @Builder
-    GetServiceInstanceRequest(String name) {
+    RenameServiceInstanceRequest(String name,
+                                 String newName) {
         this.name = name;
+        this.newName = newName;
     }
 
     @Override
@@ -45,8 +55,13 @@ public final class GetServiceInstanceRequest implements Validatable {
         ValidationResult.ValidationResultBuilder builder = ValidationResult.builder();
 
         if (this.name == null) {
-            builder.message("service instance name must be specified");
+            builder.message("name must be specified");
         }
+
+        if (this.newName == null) {
+            builder.message("new name must be specified");
+        }
+
 
         return builder.build();
     }

--- a/cloudfoundry-operations/src/test/java/org/cloudfoundry/operations/services/DefaultServicesTest.java
+++ b/cloudfoundry-operations/src/test/java/org/cloudfoundry/operations/services/DefaultServicesTest.java
@@ -43,6 +43,8 @@ import org.cloudfoundry.client.v2.serviceinstances.LastOperation;
 import org.cloudfoundry.client.v2.serviceinstances.ServiceInstanceEntity;
 import org.cloudfoundry.client.v2.serviceinstances.UnionServiceInstanceEntity;
 import org.cloudfoundry.client.v2.serviceinstances.UnionServiceInstanceResource;
+import org.cloudfoundry.client.v2.serviceinstances.UpdateServiceInstanceRequest;
+import org.cloudfoundry.client.v2.serviceinstances.UpdateServiceInstanceResponse;
 import org.cloudfoundry.client.v2.serviceplans.GetServicePlanRequest;
 import org.cloudfoundry.client.v2.serviceplans.GetServicePlanResponse;
 import org.cloudfoundry.client.v2.serviceplans.ListServicePlansRequest;
@@ -556,6 +558,17 @@ public final class DefaultServicesTest {
                     .build()));
     }
 
+    private static void requestRenameServiceInstance(CloudFoundryClient cloudFoundryClient, String serviceInstanceId, String newName) {
+        when(cloudFoundryClient.serviceInstances()
+            .update(UpdateServiceInstanceRequest.builder()
+                .name(newName)
+                .serviceInstanceId(serviceInstanceId)
+                .build()))
+            .thenReturn(Mono
+                .just(fill(UpdateServiceInstanceResponse.builder())
+                    .build()));
+    }
+
     public static final class BindServiceInstance extends AbstractOperationsApiTest<Void> {
 
         private final DefaultServices services = new DefaultServices(this.cloudFoundryClient, Mono.just(TEST_SPACE_ID));
@@ -1059,6 +1072,31 @@ public final class DefaultServicesTest {
             return this.services
                 .listServiceOfferings(ListServiceOfferingsRequest.builder()
                     .serviceName("test-service")
+                    .build());
+        }
+
+    }
+
+    public static final class RenameServiceInstance extends AbstractOperationsApiTest<Void> {
+
+        private final DefaultServices services = new DefaultServices(this.cloudFoundryClient, Mono.just(TEST_SPACE_ID));
+
+        @Before
+        public void setUp() throws Exception {
+            requestListServiceInstances(this.cloudFoundryClient, "test-service-instance-name", TEST_SPACE_ID);
+            requestRenameServiceInstance(this.cloudFoundryClient, "test-service-instance-id", "test-service-instance-new-name");
+        }
+
+        @Override
+        protected void assertions(TestSubscriber<Void> testSubscriber) {
+        }
+
+        @Override
+        protected Mono<Void> invoke() {
+            return this.services
+                .renameInstance(RenameServiceInstanceRequest.builder()
+                    .name("test-service-instance-name")
+                    .newName("test-service-instance-new-name")
                     .build());
         }
 

--- a/cloudfoundry-operations/src/test/java/org/cloudfoundry/operations/services/RenameServiceInstanceRequestTest.java
+++ b/cloudfoundry-operations/src/test/java/org/cloudfoundry/operations/services/RenameServiceInstanceRequestTest.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright 2013-2016 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.cloudfoundry.operations.services;
+
+import org.cloudfoundry.ValidationResult;
+import org.junit.Test;
+
+import static org.cloudfoundry.ValidationResult.Status.INVALID;
+import static org.cloudfoundry.ValidationResult.Status.VALID;
+import static org.junit.Assert.assertEquals;
+
+public final class RenameServiceInstanceRequestTest {
+
+    @Test
+    public void isNotValidNoName() {
+        ValidationResult result = RenameServiceInstanceRequest.builder()
+            .newName("test-service-new-name")
+            .build()
+            .isValid();
+
+        assertEquals(INVALID, result.getStatus());
+        assertEquals("name must be specified", result.getMessages().get(0));
+    }
+
+    @Test
+    public void isNotValidNoNewName() {
+        ValidationResult result = RenameServiceInstanceRequest.builder()
+            .name("test-service-name")
+            .build()
+            .isValid();
+
+        assertEquals(INVALID, result.getStatus());
+        assertEquals("new name must be specified", result.getMessages().get(0));
+    }
+
+    @Test
+    public void isValid() {
+        ValidationResult result = RenameServiceInstanceRequest.builder()
+            .name("test-service-name")
+            .newName("test-service-new-name")
+            .build()
+            .isValid();
+
+        assertEquals(VALID, result.getStatus());
+    }
+
+}


### PR DESCRIPTION
This change adds the operation to rename a service
See [this story](https://www.pivotaltracker.com/projects/816799/stories/106155486)
@nebhale Executing the command of the *cli* with `CF_TRACE=true` shows that it requests the `/v2/services/:guid` with the the `id`got from service plan but does not seem to do anything with it as it only ends with a `PUT` on `/v2/service_instances/:guid`. Hence, I willingly skipped this part. Tell me if I missed anything.