### PR TITLE
Set Running Security Group

### DIFF
--- a/cloudfoundry-client-spring/src/main/lombok/org/cloudfoundry/spring/client/v2/securitygroups/SpringSecurityGroups.java
+++ b/cloudfoundry-client-spring/src/main/lombok/org/cloudfoundry/spring/client/v2/securitygroups/SpringSecurityGroups.java
@@ -21,6 +21,8 @@ import org.cloudfoundry.client.v2.securitygroups.DeleteSecurityGroupRunningDefau
 import org.cloudfoundry.client.v2.securitygroups.ListSecurityGroupRunningDefaultsRequest;
 import org.cloudfoundry.client.v2.securitygroups.ListSecurityGroupRunningDefaultsResponse;
 import org.cloudfoundry.client.v2.securitygroups.SecurityGroups;
+import org.cloudfoundry.client.v2.securitygroups.SetSecurityGroupRunningDefaultRequest;
+import org.cloudfoundry.client.v2.securitygroups.SetSecurityGroupRunningDefaultResponse;
 import org.cloudfoundry.spring.util.AbstractSpringOperations;
 import org.springframework.web.client.RestOperations;
 import reactor.core.publisher.Mono;
@@ -53,6 +55,11 @@ public class SpringSecurityGroups extends AbstractSpringOperations implements Se
     @Override
     public Mono<ListSecurityGroupRunningDefaultsResponse> listRunningDefaults(ListSecurityGroupRunningDefaultsRequest request) {
         return get(request, ListSecurityGroupRunningDefaultsResponse.class, builder -> builder.pathSegment("v2", "config", "running_security_groups"));
+    }
+
+    @Override
+    public Mono<SetSecurityGroupRunningDefaultResponse> setRunningDefault(SetSecurityGroupRunningDefaultRequest request) {
+        return put(request, SetSecurityGroupRunningDefaultResponse.class, builder -> builder.pathSegment("v2", "config", "running_security_groups", request.getSecurityGroupRunningDefaultId()));
     }
 
 }

--- a/cloudfoundry-client-spring/src/test/java/org/cloudfoundry/spring/client/v2/securitygroups/SpringSecurityGroupsTest.java
+++ b/cloudfoundry-client-spring/src/test/java/org/cloudfoundry/spring/client/v2/securitygroups/SpringSecurityGroupsTest.java
@@ -22,11 +22,14 @@ import org.cloudfoundry.client.v2.securitygroups.ListSecurityGroupRunningDefault
 import org.cloudfoundry.client.v2.securitygroups.ListSecurityGroupRunningDefaultsResponse;
 import org.cloudfoundry.client.v2.securitygroups.SecurityGroupEntity;
 import org.cloudfoundry.client.v2.securitygroups.SecurityGroupResource;
+import org.cloudfoundry.client.v2.securitygroups.SetSecurityGroupRunningDefaultRequest;
+import org.cloudfoundry.client.v2.securitygroups.SetSecurityGroupRunningDefaultResponse;
 import org.cloudfoundry.spring.AbstractApiTest;
 import reactor.core.publisher.Mono;
 
 import static org.springframework.http.HttpMethod.DELETE;
 import static org.springframework.http.HttpMethod.GET;
+import static org.springframework.http.HttpMethod.PUT;
 import static org.springframework.http.HttpStatus.NO_CONTENT;
 import static org.springframework.http.HttpStatus.OK;
 
@@ -117,6 +120,59 @@ public final class SpringSecurityGroupsTest {
         @Override
         protected Mono<ListSecurityGroupRunningDefaultsResponse> invoke(ListSecurityGroupRunningDefaultsRequest request) {
             return this.securityGroups.listRunningDefaults(request);
+        }
+
+    }
+
+    public static final class Set extends AbstractApiTest<SetSecurityGroupRunningDefaultRequest, SetSecurityGroupRunningDefaultResponse> {
+
+        private final SpringSecurityGroups securityGroups = new SpringSecurityGroups(this.restTemplate, this.root, PROCESSOR_GROUP);
+
+        @Override
+        protected SetSecurityGroupRunningDefaultRequest getInvalidRequest() {
+            return SetSecurityGroupRunningDefaultRequest.builder().build();
+        }
+
+        @Override
+        protected RequestContext getRequestContext() {
+            return new RequestContext()
+                .method(PUT).path("/v2/config/running_security_groups/test-security-group-default-id")
+                .status(OK)
+                .responsePayload("fixtures/client/v2/config/PUT_{id}_running_security_groups_response.json");
+        }
+
+        @Override
+        protected SetSecurityGroupRunningDefaultResponse getResponse() {
+            return SetSecurityGroupRunningDefaultResponse.builder()
+                .metadata(Resource.Metadata.builder()
+                    .createdAt("2016-04-06T00:17:17Z")
+                    .id("9aa7ab9c-997f-4f87-be50-87105521881a")
+                    .url("/v2/config/running_security_groups/9aa7ab9c-997f-4f87-be50-87105521881a")
+                    .updatedAt("2016-04-06T00:17:17Z")
+                    .build())
+                .entity(SecurityGroupEntity.builder()
+                    .name("name-109")
+                    .rule(SecurityGroupEntity.RuleEntity.builder()
+                        .destination("198.41.191.47/1")
+                        .ports("8080")
+                        .protocol("udp")
+                        .build())
+                    .runningDefault(true)
+                    .stagingDefault(false)
+                    .build())
+                .build();
+        }
+
+        @Override
+        protected SetSecurityGroupRunningDefaultRequest getValidRequest() throws Exception {
+            return SetSecurityGroupRunningDefaultRequest.builder()
+                .securityGroupRunningDefaultId("test-security-group-default-id")
+                .build();
+        }
+
+        @Override
+        protected Mono<SetSecurityGroupRunningDefaultResponse> invoke(SetSecurityGroupRunningDefaultRequest request) {
+            return this.securityGroups.setRunningDefault(request);
         }
 
     }

--- a/cloudfoundry-client-spring/src/test/resources/fixtures/client/v2/config/PUT_{id}_running_security_groups_response.json
+++ b/cloudfoundry-client-spring/src/test/resources/fixtures/client/v2/config/PUT_{id}_running_security_groups_response.json
@@ -1,0 +1,20 @@
+{
+  "metadata": {
+    "guid": "9aa7ab9c-997f-4f87-be50-87105521881a",
+    "url": "/v2/config/running_security_groups/9aa7ab9c-997f-4f87-be50-87105521881a",
+    "created_at": "2016-04-06T00:17:17Z",
+    "updated_at": "2016-04-06T00:17:17Z"
+  },
+  "entity": {
+    "name": "name-109",
+    "rules": [
+      {
+        "protocol": "udp",
+        "ports": "8080",
+        "destination": "198.41.191.47/1"
+      }
+    ],
+    "running_default": true,
+    "staging_default": false
+  }
+}

--- a/cloudfoundry-client/src/main/java/org/cloudfoundry/client/v2/securitygroups/SecurityGroups.java
+++ b/cloudfoundry-client/src/main/java/org/cloudfoundry/client/v2/securitygroups/SecurityGroups.java
@@ -38,4 +38,13 @@ public interface SecurityGroups {
      */
     Mono<ListSecurityGroupRunningDefaultsResponse> listRunningDefaults(ListSecurityGroupRunningDefaultsRequest request);
 
+    /**
+        * Makes the <a href="http://apidocs.cloudfoundry.org/latest-release/security_group_running_defaults/set_a_security_group_as_a_default_for_running_apps.html">Set a Security Group as a default for running Apps</a>
+        * request.
+    *
+        * @param request the list running security groups request
+    * @return the response from the list running security groups request
+    */
+    Mono<SetSecurityGroupRunningDefaultResponse> setRunningDefault(SetSecurityGroupRunningDefaultRequest request);
+
 }

--- a/cloudfoundry-client/src/main/lombok/org/cloudfoundry/client/v2/securitygroups/SetSecurityGroupRunningDefaultRequest.java
+++ b/cloudfoundry-client/src/main/lombok/org/cloudfoundry/client/v2/securitygroups/SetSecurityGroupRunningDefaultRequest.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright 2013-2016 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.cloudfoundry.client.v2.securitygroups;
+
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import lombok.Builder;
+import lombok.Data;
+import lombok.Getter;
+import org.cloudfoundry.Validatable;
+import org.cloudfoundry.ValidationResult;
+
+/**
+ * The request payload for the Set Security Group Running Default operation
+ */
+@Data
+public final class SetSecurityGroupRunningDefaultRequest implements Validatable {
+
+    /**
+     * The security group running default id
+     *
+     * @param securityGroupRunningDefaultId the security group running default id
+     * @return the security group running default id
+     */
+    @Getter(onMethod = @__(@JsonIgnore))
+    private final String securityGroupRunningDefaultId;
+
+    @Builder
+    SetSecurityGroupRunningDefaultRequest(String securityGroupRunningDefaultId) {
+        this.securityGroupRunningDefaultId = securityGroupRunningDefaultId;
+    }
+
+    @Override
+    public ValidationResult isValid() {
+        ValidationResult.ValidationResultBuilder builder = ValidationResult.builder();
+
+        if (this.securityGroupRunningDefaultId == null) {
+            builder.message("security group running default id must be specified");
+        }
+
+        return builder.build();
+    }
+
+}

--- a/cloudfoundry-client/src/main/lombok/org/cloudfoundry/client/v2/securitygroups/SetSecurityGroupRunningDefaultResponse.java
+++ b/cloudfoundry-client/src/main/lombok/org/cloudfoundry/client/v2/securitygroups/SetSecurityGroupRunningDefaultResponse.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2013-2016 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.cloudfoundry.client.v2.securitygroups;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.Builder;
+import lombok.Data;
+import lombok.EqualsAndHashCode;
+import lombok.ToString;
+
+/**
+ * The response payload for the Set Running Security Group operation
+ */
+@Data
+@EqualsAndHashCode(callSuper = true)
+@ToString(callSuper = true)
+public final class SetSecurityGroupRunningDefaultResponse extends AbstractSecurityGroupResource {
+
+    @Builder
+    SetSecurityGroupRunningDefaultResponse(@JsonProperty("entity") SecurityGroupEntity entity,
+                                           @JsonProperty("metadata") Metadata metadata) {
+        super(entity, metadata);
+    }
+
+}

--- a/cloudfoundry-client/src/test/java/org/cloudfoundry/client/v2/securitygroups/SetSecurityGroupRunningDefaultRequestTest.java
+++ b/cloudfoundry-client/src/test/java/org/cloudfoundry/client/v2/securitygroups/SetSecurityGroupRunningDefaultRequestTest.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2013-2016 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.cloudfoundry.client.v2.securitygroups;
+
+import org.cloudfoundry.ValidationResult;
+import org.junit.Test;
+
+import static org.cloudfoundry.ValidationResult.Status.INVALID;
+import static org.cloudfoundry.ValidationResult.Status.VALID;
+import static org.junit.Assert.assertEquals;
+
+public final class SetSecurityGroupRunningDefaultRequestTest {
+
+    @Test
+    public void isNotValidNoId() {
+        ValidationResult result = DeleteSecurityGroupRunningDefaultRequest.builder()
+            .build()
+            .isValid();
+
+        assertEquals(INVALID, result.getStatus());
+        assertEquals("security group running default id must be specified", result.getMessages().get(0));
+    }
+
+    @Test
+    public void isValid() {
+        ValidationResult result = DeleteSecurityGroupRunningDefaultRequest.builder()
+            .securityGroupRunningDefaultId("test-security-group-default-id")
+            .build()
+            .isValid();
+
+        assertEquals(VALID, result.getStatus());
+    }
+
+}


### PR DESCRIPTION
This change adds the api to set a running security group as default for Running Applications (`PUT /v2/config/running_security_groups/:guid`)
See [this story](https://www.pivotaltracker.com/projects/816799/stories/101522640)
@nebhale what do you think of renaming the functions:
1. `deleteRunningDefault` :arrow_right: `deleteRunningSecurityGroup`
2. `listRunningDefaults` :arrow_right:  `listRunningSecurityGroups`
Therefore the `setRunningDefault` may be named `setRunningSecurityGroupAsDefault`