### PR TITLE
Set Security Group Staging Default

### DIFF
--- a/cloudfoundry-client-spring/src/main/lombok/org/cloudfoundry/spring/client/v2/securitygroups/SpringSecurityGroups.java
+++ b/cloudfoundry-client-spring/src/main/lombok/org/cloudfoundry/spring/client/v2/securitygroups/SpringSecurityGroups.java
@@ -25,6 +25,8 @@ import org.cloudfoundry.client.v2.securitygroups.ListSecurityGroupStagingDefault
 import org.cloudfoundry.client.v2.securitygroups.SecurityGroups;
 import org.cloudfoundry.client.v2.securitygroups.SetSecurityGroupRunningDefaultRequest;
 import org.cloudfoundry.client.v2.securitygroups.SetSecurityGroupRunningDefaultResponse;
+import org.cloudfoundry.client.v2.securitygroups.SetSecurityGroupStagingDefaultRequest;
+import org.cloudfoundry.client.v2.securitygroups.SetSecurityGroupStagingDefaultResponse;
 import org.cloudfoundry.spring.util.AbstractSpringOperations;
 import org.cloudfoundry.spring.util.QueryBuilder;
 import org.springframework.web.client.RestOperations;
@@ -76,4 +78,9 @@ public class SpringSecurityGroups extends AbstractSpringOperations implements Se
         return put(request, SetSecurityGroupRunningDefaultResponse.class, builder -> builder.pathSegment("v2", "config", "running_security_groups", request.getSecurityGroupRunningDefaultId()));
     }
 
+    @Override
+    public Mono<SetSecurityGroupStagingDefaultResponse> setStagingDefault(SetSecurityGroupStagingDefaultRequest request) {
+        return put(request, SetSecurityGroupStagingDefaultResponse.class, builder -> builder.pathSegment("v2", "config", "staging_security_groups", request.getSecurityGroupStagingDefaultId()));
+    }
+    
 }

--- a/cloudfoundry-client-spring/src/test/java/org/cloudfoundry/spring/client/v2/securitygroups/SpringSecurityGroupsTest.java
+++ b/cloudfoundry-client-spring/src/test/java/org/cloudfoundry/spring/client/v2/securitygroups/SpringSecurityGroupsTest.java
@@ -26,6 +26,8 @@ import org.cloudfoundry.client.v2.securitygroups.SecurityGroupEntity;
 import org.cloudfoundry.client.v2.securitygroups.SecurityGroupResource;
 import org.cloudfoundry.client.v2.securitygroups.SetSecurityGroupRunningDefaultRequest;
 import org.cloudfoundry.client.v2.securitygroups.SetSecurityGroupRunningDefaultResponse;
+import org.cloudfoundry.client.v2.securitygroups.SetSecurityGroupStagingDefaultRequest;
+import org.cloudfoundry.client.v2.securitygroups.SetSecurityGroupStagingDefaultResponse;
 import org.cloudfoundry.spring.AbstractApiTest;
 import reactor.core.publisher.Mono;
 
@@ -229,6 +231,59 @@ public final class SpringSecurityGroupsTest {
         @Override
         protected Mono<SetSecurityGroupRunningDefaultResponse> invoke(SetSecurityGroupRunningDefaultRequest request) {
             return this.securityGroups.setRunningDefault(request);
+        }
+
+    }
+
+    public static final class SetStaging extends AbstractApiTest<SetSecurityGroupStagingDefaultRequest, SetSecurityGroupStagingDefaultResponse> {
+
+        private final SpringSecurityGroups securityGroups = new SpringSecurityGroups(this.restTemplate, this.root, PROCESSOR_GROUP);
+
+        @Override
+        protected SetSecurityGroupStagingDefaultRequest getInvalidRequest() {
+            return SetSecurityGroupStagingDefaultRequest.builder().build();
+        }
+
+        @Override
+        protected RequestContext getRequestContext() {
+            return new RequestContext()
+                .method(PUT).path("/v2/config/staging_security_groups/test-security-group-default-id")
+                .status(OK)
+                .responsePayload("fixtures/client/v2/config/PUT_{id}_staging_security_groups_response.json");
+        }
+
+        @Override
+        protected SetSecurityGroupStagingDefaultResponse getResponse() {
+            return SetSecurityGroupStagingDefaultResponse.builder()
+                .metadata(Resource.Metadata.builder()
+                    .createdAt("2016-04-16T01:23:52Z")
+                    .id("50165fce-6c41-4c35-a4d8-3858ee217d36")
+                    .url("/v2/config/staging_security_groups/50165fce-6c41-4c35-a4d8-3858ee217d36")
+                    .updatedAt("2016-04-16T01:23:52Z")
+                    .build())
+                .entity(SecurityGroupEntity.builder()
+                    .name("name-567")
+                    .rule(SecurityGroupEntity.RuleEntity.builder()
+                        .destination("198.41.191.47/1")
+                        .ports("8080")
+                        .protocol("udp")
+                        .build())
+                    .runningDefault(false)
+                    .stagingDefault(true)
+                    .build())
+                .build();
+        }
+
+        @Override
+        protected SetSecurityGroupStagingDefaultRequest getValidRequest() throws Exception {
+            return SetSecurityGroupStagingDefaultRequest.builder()
+                .securityGroupStagingDefaultId("test-security-group-default-id")
+                .build();
+        }
+
+        @Override
+        protected Mono<SetSecurityGroupStagingDefaultResponse> invoke(SetSecurityGroupStagingDefaultRequest request) {
+            return this.securityGroups.setStagingDefault(request);
         }
 
     }

--- a/cloudfoundry-client-spring/src/test/resources/fixtures/client/v2/config/PUT_{id}_staging_security_groups_response.json
+++ b/cloudfoundry-client-spring/src/test/resources/fixtures/client/v2/config/PUT_{id}_staging_security_groups_response.json
@@ -1,0 +1,20 @@
+{
+  "metadata": {
+    "guid": "50165fce-6c41-4c35-a4d8-3858ee217d36",
+    "url": "/v2/config/staging_security_groups/50165fce-6c41-4c35-a4d8-3858ee217d36",
+    "created_at": "2016-04-16T01:23:52Z",
+    "updated_at": "2016-04-16T01:23:52Z"
+  },
+  "entity": {
+    "name": "name-567",
+    "rules": [
+      {
+        "protocol": "udp",
+        "ports": "8080",
+        "destination": "198.41.191.47/1"
+      }
+    ],
+    "running_default": false,
+    "staging_default": true
+  }
+}

--- a/cloudfoundry-client/src/main/java/org/cloudfoundry/client/v2/securitygroups/SecurityGroups.java
+++ b/cloudfoundry-client/src/main/java/org/cloudfoundry/client/v2/securitygroups/SecurityGroups.java
@@ -55,4 +55,13 @@ public interface SecurityGroups {
      */
     Mono<SetSecurityGroupRunningDefaultResponse> setRunningDefault(SetSecurityGroupRunningDefaultRequest request);
 
+    /**
+     * Makes the <a href="http://apidocs.cloudfoundry.org/latest-release/security_group_staging_defaults/set_a_security_group_as_a_default_for_staging.html">Set a Security Group as a default for
+     * staging Apps</a> request.
+     *
+     * @param request the list staging security groups request
+     * @return the response from the list staging security groups request
+     */
+    Mono<SetSecurityGroupStagingDefaultResponse> setStagingDefault(SetSecurityGroupStagingDefaultRequest request);
+
 }

--- a/cloudfoundry-client/src/main/lombok/org/cloudfoundry/client/v2/securitygroups/SetSecurityGroupStagingDefaultRequest.java
+++ b/cloudfoundry-client/src/main/lombok/org/cloudfoundry/client/v2/securitygroups/SetSecurityGroupStagingDefaultRequest.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright 2013-2016 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.cloudfoundry.client.v2.securitygroups;
+
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import lombok.Builder;
+import lombok.Data;
+import lombok.Getter;
+import org.cloudfoundry.Validatable;
+import org.cloudfoundry.ValidationResult;
+
+/**
+ * The request payload for the Set Security Group Staging Default operation
+ */
+@Data
+public final class SetSecurityGroupStagingDefaultRequest implements Validatable {
+
+    /**
+     * The security group staging default id
+     *
+     * @param securityGroupRunningDefaultId the security group staging default id
+     * @return the security group staging default id
+     */
+    @Getter(onMethod = @__(@JsonIgnore))
+    private final String securityGroupStagingDefaultId;
+
+    @Builder
+    SetSecurityGroupStagingDefaultRequest(String securityGroupStagingDefaultId) {
+        this.securityGroupStagingDefaultId = securityGroupStagingDefaultId;
+    }
+
+    @Override
+    public ValidationResult isValid() {
+        ValidationResult.ValidationResultBuilder builder = ValidationResult.builder();
+
+        if (this.securityGroupStagingDefaultId == null) {
+            builder.message("security group staging default id must be specified");
+        }
+
+        return builder.build();
+    }
+
+}

--- a/cloudfoundry-client/src/main/lombok/org/cloudfoundry/client/v2/securitygroups/SetSecurityGroupStagingDefaultResponse.java
+++ b/cloudfoundry-client/src/main/lombok/org/cloudfoundry/client/v2/securitygroups/SetSecurityGroupStagingDefaultResponse.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2013-2016 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.cloudfoundry.client.v2.securitygroups;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.Builder;
+import lombok.Data;
+import lombok.EqualsAndHashCode;
+import lombok.ToString;
+
+/**
+ * The response payload for the Set Staging Security Group operation
+ */
+@Data
+@EqualsAndHashCode(callSuper = true)
+@ToString(callSuper = true)
+public final class SetSecurityGroupStagingDefaultResponse extends AbstractSecurityGroupResource {
+
+    @Builder
+    SetSecurityGroupStagingDefaultResponse(@JsonProperty("entity") SecurityGroupEntity entity,
+                                           @JsonProperty("metadata") Metadata metadata) {
+        super(entity, metadata);
+    }
+
+}

--- a/cloudfoundry-client/src/test/java/org/cloudfoundry/client/v2/securitygroups/SetSecurityGroupStagingDefaultRequestTest.java
+++ b/cloudfoundry-client/src/test/java/org/cloudfoundry/client/v2/securitygroups/SetSecurityGroupStagingDefaultRequestTest.java
@@ -23,22 +23,22 @@ import static org.cloudfoundry.ValidationResult.Status.INVALID;
 import static org.cloudfoundry.ValidationResult.Status.VALID;
 import static org.junit.Assert.assertEquals;
 
-public final class SetSecurityGroupRunningDefaultRequestTest {
+public final class SetSecurityGroupStagingDefaultRequestTest {
 
     @Test
     public void isNotValidNoId() {
-        ValidationResult result = SetSecurityGroupRunningDefaultRequest.builder()
+        ValidationResult result = SetSecurityGroupStagingDefaultRequest.builder()
             .build()
             .isValid();
 
         assertEquals(INVALID, result.getStatus());
-        assertEquals("security group running default id must be specified", result.getMessages().get(0));
+        assertEquals("security group staging default id must be specified", result.getMessages().get(0));
     }
 
     @Test
     public void isValid() {
-        ValidationResult result = SetSecurityGroupRunningDefaultRequest.builder()
-            .securityGroupRunningDefaultId("test-security-group-default-id")
+        ValidationResult result = SetSecurityGroupStagingDefaultRequest.builder()
+            .securityGroupStagingDefaultId("test-security-group-default-id")
             .build()
             .isValid();
 


### PR DESCRIPTION
This change adds the api to set a security group staging as default (`PUT /v2/config/staging_security_groups/:guid`)
See [here](https://www.pivotaltracker.com/projects/816799/stories/101522652)