### PR TITLE
Delete Security Group Staging

### DIFF
--- a/cloudfoundry-client-spring/src/main/lombok/org/cloudfoundry/spring/client/v2/securitygroups/SpringSecurityGroups.java
+++ b/cloudfoundry-client-spring/src/main/lombok/org/cloudfoundry/spring/client/v2/securitygroups/SpringSecurityGroups.java
@@ -18,6 +18,7 @@ package org.cloudfoundry.spring.client.v2.securitygroups;
 
 import lombok.ToString;
 import org.cloudfoundry.client.v2.securitygroups.DeleteSecurityGroupRunningDefaultRequest;
+import org.cloudfoundry.client.v2.securitygroups.DeleteSecurityGroupStagingDefaultRequest;
 import org.cloudfoundry.client.v2.securitygroups.ListSecurityGroupRunningDefaultsRequest;
 import org.cloudfoundry.client.v2.securitygroups.ListSecurityGroupRunningDefaultsResponse;
 import org.cloudfoundry.client.v2.securitygroups.ListSecurityGroupStagingDefaultsRequest;
@@ -53,6 +54,11 @@ public class SpringSecurityGroups extends AbstractSpringOperations implements Se
     @Override
     public Mono<Void> deleteRunningDefault(DeleteSecurityGroupRunningDefaultRequest request) {
         return delete(request, Void.class, builder -> builder.pathSegment("v2", "config", "running_security_groups", request.getSecurityGroupRunningDefaultId()));
+    }
+
+    @Override
+    public Mono<Void> deleteStagingDefault(DeleteSecurityGroupStagingDefaultRequest request) {
+        return delete(request, Void.class, builder -> builder.pathSegment("v2", "config", "staging_security_groups", request.getSecurityGroupStagingDefaultId()));
     }
 
     @Override

--- a/cloudfoundry-client-spring/src/test/java/org/cloudfoundry/spring/client/v2/securitygroups/SpringSecurityGroupsTest.java
+++ b/cloudfoundry-client-spring/src/test/java/org/cloudfoundry/spring/client/v2/securitygroups/SpringSecurityGroupsTest.java
@@ -18,6 +18,7 @@ package org.cloudfoundry.spring.client.v2.securitygroups;
 
 import org.cloudfoundry.client.v2.Resource;
 import org.cloudfoundry.client.v2.securitygroups.DeleteSecurityGroupRunningDefaultRequest;
+import org.cloudfoundry.client.v2.securitygroups.DeleteSecurityGroupStagingDefaultRequest;
 import org.cloudfoundry.client.v2.securitygroups.ListSecurityGroupRunningDefaultsRequest;
 import org.cloudfoundry.client.v2.securitygroups.ListSecurityGroupRunningDefaultsResponse;
 import org.cloudfoundry.client.v2.securitygroups.ListSecurityGroupStagingDefaultsRequest;
@@ -68,6 +69,41 @@ public final class SpringSecurityGroupsTest {
         @Override
         protected Mono<Void> invoke(DeleteSecurityGroupRunningDefaultRequest request) {
             return this.securityGroups.deleteRunningDefault(request);
+        }
+
+    }
+
+    public static final class DeleteStaging extends AbstractApiTest<DeleteSecurityGroupStagingDefaultRequest, Void> {
+
+        private final SpringSecurityGroups securityGroups = new SpringSecurityGroups(this.restTemplate, this.root, PROCESSOR_GROUP);
+
+        @Override
+        protected DeleteSecurityGroupStagingDefaultRequest getInvalidRequest() {
+            return DeleteSecurityGroupStagingDefaultRequest.builder().build();
+        }
+
+        @Override
+        protected RequestContext getRequestContext() {
+            return new RequestContext()
+                .method(DELETE).path("/v2/config/staging_security_groups/test-id")
+                .status(NO_CONTENT);
+        }
+
+        @Override
+        protected Void getResponse() {
+            return null;
+        }
+
+        @Override
+        protected DeleteSecurityGroupStagingDefaultRequest getValidRequest() throws Exception {
+            return DeleteSecurityGroupStagingDefaultRequest.builder()
+                .securityGroupStagingDefaultId("test-id")
+                .build();
+        }
+
+        @Override
+        protected Mono<Void> invoke(DeleteSecurityGroupStagingDefaultRequest request) {
+            return this.securityGroups.deleteStagingDefault(request);
         }
 
     }

--- a/cloudfoundry-client/src/main/java/org/cloudfoundry/client/v2/securitygroups/SecurityGroups.java
+++ b/cloudfoundry-client/src/main/java/org/cloudfoundry/client/v2/securitygroups/SecurityGroups.java
@@ -30,6 +30,15 @@ public interface SecurityGroups {
     Mono<Void> deleteRunningDefault(DeleteSecurityGroupRunningDefaultRequest request);
 
     /**
+     * Makes the <a href="http://apidocs.cloudfoundry.org/latest-release/security_group_staging_defaults/removing_a_security_group_as_a_default_for_staging.html">Delete Staging Security Group</a>
+     * request.
+     *
+     * @param request the delete staging security group request
+     * @return the response from the delete runstagingning security group request
+     */
+    Mono<Void> deleteStagingDefault(DeleteSecurityGroupStagingDefaultRequest request);
+
+    /**
      * Makes the <a href="http://apidocs.cloudfoundry.org/latest-release/security_group_running_defaults/return_the_security_groups_used_for_running_apps.html">List Running Security Groups</a>
      * request.
      *

--- a/cloudfoundry-client/src/main/lombok/org/cloudfoundry/client/v2/securitygroups/DeleteSecurityGroupStagingDefaultRequest.java
+++ b/cloudfoundry-client/src/main/lombok/org/cloudfoundry/client/v2/securitygroups/DeleteSecurityGroupStagingDefaultRequest.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright 2013-2016 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.cloudfoundry.client.v2.securitygroups;
+
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import lombok.Builder;
+import lombok.Data;
+import lombok.Getter;
+import org.cloudfoundry.Validatable;
+import org.cloudfoundry.ValidationResult;
+
+/**
+ * The request payload for the Delete Security Group Staging Default operation
+ */
+@Data
+public final class DeleteSecurityGroupStagingDefaultRequest implements Validatable {
+
+    /**
+     * The security group staging default id
+     *
+     * @param securityGroupStagingDefaultId the security group staging default id
+     * @return the security group staging default id
+     */
+    @Getter(onMethod = @__(@JsonIgnore))
+    private final String securityGroupStagingDefaultId;
+
+    @Builder
+    DeleteSecurityGroupStagingDefaultRequest(String securityGroupStagingDefaultId) {
+        this.securityGroupStagingDefaultId = securityGroupStagingDefaultId;
+    }
+
+    @Override
+    public ValidationResult isValid() {
+        ValidationResult.ValidationResultBuilder builder = ValidationResult.builder();
+
+        if (this.securityGroupStagingDefaultId == null) {
+            builder.message("security group staging default id must be specified");
+        }
+
+        return builder.build();
+    }
+
+}

--- a/cloudfoundry-client/src/test/java/org/cloudfoundry/client/v2/securitygroups/DeleteSecurityGroupStagingDefaultRequestTest.java
+++ b/cloudfoundry-client/src/test/java/org/cloudfoundry/client/v2/securitygroups/DeleteSecurityGroupStagingDefaultRequestTest.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2013-2016 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.cloudfoundry.client.v2.securitygroups;
+
+import org.cloudfoundry.ValidationResult;
+import org.junit.Test;
+
+import static org.cloudfoundry.ValidationResult.Status.INVALID;
+import static org.cloudfoundry.ValidationResult.Status.VALID;
+import static org.junit.Assert.assertEquals;
+
+public final class DeleteSecurityGroupStagingDefaultRequestTest {
+
+    @Test
+    public void isNotValidNoId() {
+        ValidationResult result = DeleteSecurityGroupStagingDefaultRequest.builder()
+            .build()
+            .isValid();
+
+        assertEquals(INVALID, result.getStatus());
+        assertEquals("security group staging default id must be specified", result.getMessages().get(0));
+    }
+
+    @Test
+    public void isValid() {
+        ValidationResult result = DeleteSecurityGroupStagingDefaultRequest.builder()
+            .securityGroupStagingDefaultId("test-security-group-default-id")
+            .build()
+            .isValid();
+
+        assertEquals(VALID, result.getStatus());
+    }
+
+}


### PR DESCRIPTION
This change adds the api to delete a security group staging (`DELETE /v2/config/staging_security_groups/:guid`)
See [here](https://www.pivotaltracker.com/projects/816799/stories/101522644)