### PR TITLE
List service keys for a service instance api

### DIFF
--- a/cloudfoundry-client-spring/src/main/lombok/org/cloudfoundry/spring/client/v2/serviceinstances/SpringServiceInstances.java
+++ b/cloudfoundry-client-spring/src/main/lombok/org/cloudfoundry/spring/client/v2/serviceinstances/SpringServiceInstances.java
@@ -29,6 +29,8 @@ import org.cloudfoundry.client.v2.serviceinstances.GetServiceInstanceRequest;
 import org.cloudfoundry.client.v2.serviceinstances.GetServiceInstanceResponse;
 import org.cloudfoundry.client.v2.serviceinstances.ListServiceInstanceServiceBindingsRequest;
 import org.cloudfoundry.client.v2.serviceinstances.ListServiceInstanceServiceBindingsResponse;
+import org.cloudfoundry.client.v2.serviceinstances.ListServiceInstanceServiceKeysRequest;
+import org.cloudfoundry.client.v2.serviceinstances.ListServiceInstanceServiceKeysResponse;
 import org.cloudfoundry.client.v2.serviceinstances.ListServiceInstancesRequest;
 import org.cloudfoundry.client.v2.serviceinstances.ListServiceInstancesResponse;
 import org.cloudfoundry.client.v2.serviceinstances.ServiceInstances;
@@ -104,6 +106,15 @@ public final class SpringServiceInstances extends AbstractSpringOperations imple
     public Mono<ListServiceInstanceServiceBindingsResponse> listServiceBindings(ListServiceInstanceServiceBindingsRequest request) {
         return get(request, ListServiceInstanceServiceBindingsResponse.class, builder -> {
             builder.pathSegment("v2", "service_instances", request.getServiceInstanceId(), "service_bindings");
+            FilterBuilder.augment(builder, request);
+            QueryBuilder.augment(builder, request);
+        });
+    }
+
+    @Override
+    public Mono<ListServiceInstanceServiceKeysResponse> listServiceKeys(ListServiceInstanceServiceKeysRequest request) {
+        return get(request, ListServiceInstanceServiceKeysResponse.class, builder -> {
+            builder.pathSegment("v2", "service_instances", request.getServiceInstanceId(), "service_keys");
             FilterBuilder.augment(builder, request);
             QueryBuilder.augment(builder, request);
         });

--- a/cloudfoundry-client-spring/src/test/java/org/cloudfoundry/spring/client/v2/serviceinstances/SpringServiceInstancesTest.java
+++ b/cloudfoundry-client-spring/src/test/java/org/cloudfoundry/spring/client/v2/serviceinstances/SpringServiceInstancesTest.java
@@ -33,12 +33,16 @@ import org.cloudfoundry.client.v2.serviceinstances.GetServiceInstanceResponse;
 import org.cloudfoundry.client.v2.serviceinstances.LastOperation;
 import org.cloudfoundry.client.v2.serviceinstances.ListServiceInstanceServiceBindingsRequest;
 import org.cloudfoundry.client.v2.serviceinstances.ListServiceInstanceServiceBindingsResponse;
+import org.cloudfoundry.client.v2.serviceinstances.ListServiceInstanceServiceKeysRequest;
+import org.cloudfoundry.client.v2.serviceinstances.ListServiceInstanceServiceKeysResponse;
 import org.cloudfoundry.client.v2.serviceinstances.ListServiceInstancesRequest;
 import org.cloudfoundry.client.v2.serviceinstances.ListServiceInstancesResponse;
 import org.cloudfoundry.client.v2.serviceinstances.ServiceInstanceEntity;
 import org.cloudfoundry.client.v2.serviceinstances.ServiceInstanceResource;
 import org.cloudfoundry.client.v2.serviceinstances.UpdateServiceInstanceRequest;
 import org.cloudfoundry.client.v2.serviceinstances.UpdateServiceInstanceResponse;
+import org.cloudfoundry.client.v2.servicekeys.ServiceKeyEntity;
+import org.cloudfoundry.client.v2.servicekeys.ServiceKeyResource;
 import org.cloudfoundry.spring.AbstractApiTest;
 import reactor.core.publisher.Mono;
 
@@ -497,6 +501,62 @@ public final class SpringServiceInstancesTest {
         @Override
         protected Mono<ListServiceInstanceServiceBindingsResponse> invoke(ListServiceInstanceServiceBindingsRequest request) {
             return this.serviceInstances.listServiceBindings(request);
+        }
+
+    }
+
+    public static final class ListServiceKeys extends AbstractApiTest<ListServiceInstanceServiceKeysRequest, ListServiceInstanceServiceKeysResponse> {
+
+        private final SpringServiceInstances serviceInstances = new SpringServiceInstances(this.restTemplate, this.root, PROCESSOR_GROUP);
+
+        @Override
+        protected ListServiceInstanceServiceKeysRequest getInvalidRequest() {
+            return ListServiceInstanceServiceKeysRequest.builder()
+                .build();
+        }
+
+        @Override
+        protected RequestContext getRequestContext() {
+            return new RequestContext()
+                .method(GET)
+                .path("v2/service_instances/test-service-instance-id/service_keys?q=name%20IN%20test-service-key&page=-1")
+                .status(OK)
+                .responsePayload("fixtures/client/v2/service_instances/GET_{id}_service_keys_response.json");
+        }
+
+        @Override
+        protected ListServiceInstanceServiceKeysResponse getResponse() {
+            return ListServiceInstanceServiceKeysResponse.builder()
+                .totalResults(1)
+                .totalPages(1)
+                .resource(ServiceKeyResource.builder()
+                    .metadata(Resource.Metadata.builder()
+                        .createdAt("2016-05-04T22:43:09Z")
+                        .id("9803ec3c-8d97-4bd8-bf86-e44cc835a154")
+                        .url("/v2/service_keys/05f3ec3c-8d97-4bd8-bf86-e44cc835a154")
+                        .build())
+                    .entity(ServiceKeyEntity.builder()
+                        .serviceInstanceId("c6a0890e-edbf-4da9-ae90-dce24af308a1")
+                        .credential("credential-key", "credential-value")
+                        .name("test-service-key")
+                        .serviceInstanceUrl("/v2/service_instances/c6a0890e-edbf-4da9-ae90-dce24af308a1")
+                        .build())
+                    .build())
+                .build();
+        }
+
+        @Override
+        protected ListServiceInstanceServiceKeysRequest getValidRequest() throws Exception {
+            return ListServiceInstanceServiceKeysRequest.builder()
+                .serviceInstanceId("test-service-instance-id")
+                .name("test-service-key")
+                .page(-1)
+                .build();
+        }
+
+        @Override
+        protected Mono<ListServiceInstanceServiceKeysResponse> invoke(ListServiceInstanceServiceKeysRequest request) {
+            return this.serviceInstances.listServiceKeys(request);
         }
 
     }

--- a/cloudfoundry-client-spring/src/test/resources/fixtures/client/v2/service_instances/GET_{id}_service_keys_response.json
+++ b/cloudfoundry-client-spring/src/test/resources/fixtures/client/v2/service_instances/GET_{id}_service_keys_response.json
@@ -1,0 +1,24 @@
+{
+  "total_results": 1,
+  "total_pages": 1,
+  "prev_url": null,
+  "next_url": null,
+  "resources": [
+    {
+      "metadata": {
+        "guid": "9803ec3c-8d97-4bd8-bf86-e44cc835a154",
+        "url": "/v2/service_keys/05f3ec3c-8d97-4bd8-bf86-e44cc835a154",
+        "created_at": "2016-05-04T22:43:09Z",
+        "updated_at": null
+      },
+      "entity": {
+        "service_instance_guid": "c6a0890e-edbf-4da9-ae90-dce24af308a1",
+        "credentials": {
+          "credential-key": "credential-value"
+        },
+        "name": "test-service-key",
+        "service_instance_url": "/v2/service_instances/c6a0890e-edbf-4da9-ae90-dce24af308a1"
+      }
+    }
+  ]
+}

--- a/cloudfoundry-client/src/main/java/org/cloudfoundry/client/v2/serviceinstances/ServiceInstances.java
+++ b/cloudfoundry-client/src/main/java/org/cloudfoundry/client/v2/serviceinstances/ServiceInstances.java
@@ -81,6 +81,15 @@ public interface ServiceInstances {
     Mono<ListServiceInstanceServiceBindingsResponse> listServiceBindings(ListServiceInstanceServiceBindingsRequest request);
 
     /**
+     * Makes the <a href="http://apidocs.cloudfoundry.org/latest-release/service_instances/list_all_service_keys_for_the_service_instance.html">List all Service keys for the Service
+     * Instance</a> request
+     *
+     * @param request the List Service Keys request
+     * @return the response from the List Service Keys request
+     */
+    Mono<ListServiceInstanceServiceKeysResponse> listServiceKeys(ListServiceInstanceServiceKeysRequest request);
+
+    /**
      * Makes the <a href="http://apidocs.cloudfoundry.org/latest-release/service_instances/update_a_service_instance.html">Update Service Instance</a> request
      *
      * @param request the Update Service Instance request

--- a/cloudfoundry-client/src/main/lombok/org/cloudfoundry/client/v2/serviceinstances/ListServiceInstanceServiceKeysRequest.java
+++ b/cloudfoundry-client/src/main/lombok/org/cloudfoundry/client/v2/serviceinstances/ListServiceInstanceServiceKeysRequest.java
@@ -1,0 +1,78 @@
+/*
+ * Copyright 2013-2016 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.cloudfoundry.client.v2.serviceinstances;
+
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import lombok.Builder;
+import lombok.Data;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.Singular;
+import lombok.ToString;
+import org.cloudfoundry.Validatable;
+import org.cloudfoundry.ValidationResult;
+import org.cloudfoundry.client.v2.InFilterParameter;
+import org.cloudfoundry.client.v2.PaginatedRequest;
+
+import java.util.List;
+
+/**
+ * The request payload for the List all Service Keys for the Service Instance operation
+ */
+@Data
+@EqualsAndHashCode(callSuper = true)
+@ToString(callSuper = true)
+public final class ListServiceInstanceServiceKeysRequest extends PaginatedRequest implements Validatable {
+
+    /**
+     * The names of the service keys to filter
+     *
+     * @param names the names of the service keys to filter
+     * @return the names of the service keys to filter
+     */
+    @Getter(onMethod = @__(@InFilterParameter("name")))
+    private final List<String> names;
+
+    /**
+     * The service instance id
+     *
+     * @param serviceInstanceId the service instance id
+     * @return the service instance id
+     */
+    @Getter(onMethod = @__(@JsonIgnore))
+    private final String serviceInstanceId;
+
+    @Builder
+    ListServiceInstanceServiceKeysRequest(OrderDirection orderDirection, Integer page, Integer resultsPerPage,
+                                          @Singular List<String> names,
+                                          String serviceInstanceId) {
+        super(orderDirection, page, resultsPerPage);
+        this.names = names;
+        this.serviceInstanceId = serviceInstanceId;
+    }
+
+    @Override
+    public ValidationResult isValid() {
+        ValidationResult.ValidationResultBuilder builder = ValidationResult.builder();
+
+        if (this.serviceInstanceId == null) {
+            builder.message("service instance id must be specified");
+        }
+
+        return builder.build();
+    }
+}

--- a/cloudfoundry-client/src/main/lombok/org/cloudfoundry/client/v2/serviceinstances/ListServiceInstanceServiceKeysResponse.java
+++ b/cloudfoundry-client/src/main/lombok/org/cloudfoundry/client/v2/serviceinstances/ListServiceInstanceServiceKeysResponse.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2013-2016 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.cloudfoundry.client.v2.serviceinstances;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.Builder;
+import lombok.Data;
+import lombok.EqualsAndHashCode;
+import lombok.Singular;
+import lombok.ToString;
+import org.cloudfoundry.client.v2.PaginatedResponse;
+import org.cloudfoundry.client.v2.servicekeys.ServiceKeyResource;
+
+import java.util.List;
+
+/**
+ * The response payload for the List all Service Keys for the Service Instance operation
+ */
+@Data
+@EqualsAndHashCode(callSuper = true)
+@ToString(callSuper = true)
+public final class ListServiceInstanceServiceKeysResponse extends PaginatedResponse<ServiceKeyResource> {
+
+    @Builder
+    ListServiceInstanceServiceKeysResponse(@JsonProperty("next_url") String nextUrl,
+                                           @JsonProperty("prev_url") String previousUrl,
+                                           @JsonProperty("resources") @Singular List<ServiceKeyResource> resources,
+                                           @JsonProperty("total_pages") Integer totalPages,
+                                           @JsonProperty("total_results") Integer totalResults) {
+        super(nextUrl, previousUrl, resources, totalPages, totalResults);
+    }
+
+}

--- a/cloudfoundry-client/src/test/java/org/cloudfoundry/client/v2/serviceinstances/ListServiceInstancecServiceKeysRequestTest.java
+++ b/cloudfoundry-client/src/test/java/org/cloudfoundry/client/v2/serviceinstances/ListServiceInstancecServiceKeysRequestTest.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright 2013-2016 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.cloudfoundry.client.v2.serviceinstances;
+
+import org.cloudfoundry.ValidationResult;
+import org.junit.Test;
+
+import static org.cloudfoundry.ValidationResult.Status.INVALID;
+import static org.cloudfoundry.ValidationResult.Status.VALID;
+import static org.junit.Assert.assertEquals;
+
+public final class ListServiceInstancecServiceKeysRequestTest {
+
+    @Test
+    public void isInValidNoId() {
+        ValidationResult result = ListServiceInstanceServiceBindingsRequest.builder()
+            .build()
+            .isValid();
+
+        assertEquals(INVALID, result.getStatus());
+        assertEquals("service instance id must be specified", result.getMessages().get(0));
+    }
+
+    @Test
+    public void isValid() {
+        ValidationResult result = ListServiceInstanceServiceKeysRequest.builder()
+            .serviceInstanceId("test-service-instance-id")
+            .build()
+            .isValid();
+
+        assertEquals(VALID, result.getStatus());
+    }
+
+    @Test
+    public void isValidWithName() {
+        ValidationResult result = ListServiceInstanceServiceKeysRequest.builder()
+            .serviceInstanceId("test-service-instance-id")
+            .name("test-service-key")
+            .build()
+            .isValid();
+
+        assertEquals(VALID, result.getStatus());
+    }
+
+}


### PR DESCRIPTION
This change adds the api to fetch the service keys for a service instance.

@nebhale The api is not updated yet, I got the parameter details from this PR https://github.com/cloudfoundry/cloud_controller_ng/pull/349/files