### PR TITLE
Returning Envelope as part of the Firehose response

### DIFF
--- a/cloudfoundry-client/src/main/java/org/cloudfoundry/doppler/DopplerClient.java
+++ b/cloudfoundry-client/src/main/java/org/cloudfoundry/doppler/DopplerClient.java
@@ -40,6 +40,14 @@ public interface DopplerClient {
     Flux<Event> firehose(FirehoseRequest request);
 
     /**
+     * Makes the <a href="https://github.com/cloudfoundry/loggregator/tree/develop/src/trafficcontroller#endpoints">Firehose</a> request
+     *
+     * @param request the Firehose request
+     * @return the events wrapped with an Envelope holding metadata from the firehose
+     */
+    Flux<Envelope<? extends Event>> envelopedFirehose(FirehoseRequest request);
+
+    /**
      * Makes the <a href="https://github.com/cloudfoundry/loggregator/tree/develop/src/trafficcontroller#endpoints">Recent Logs</a> request
      *
      * @param request the Recent Logs request

--- a/cloudfoundry-client/src/main/java/org/cloudfoundry/doppler/EventBuilder.java
+++ b/cloudfoundry-client/src/main/java/org/cloudfoundry/doppler/EventBuilder.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2013-2016 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.cloudfoundry.doppler;
+
+import org.cloudfoundry.dropsonde.events.*;
+
+public class EventBuilder {
+    @SuppressWarnings("unchecked")
+    public static <T extends Event> T toEvent(org.cloudfoundry.dropsonde.events.Envelope envelope) {
+        switch (envelope.eventType) {
+            case HttpStart:
+                return (T) HttpStart.from(envelope.httpStart);
+            case HttpStop:
+                return (T) HttpStop.from(envelope.httpStop);
+            case HttpStartStop:
+                return (T) HttpStartStop.from(envelope.httpStartStop);
+            case LogMessage:
+                return (T) LogMessage.from(envelope.logMessage);
+            case ValueMetric:
+                return (T) ValueMetric.from(envelope.valueMetric);
+            case CounterEvent:
+                return (T) CounterEvent.from(envelope.counterEvent);
+            case Error:
+                return (T) Error.from(envelope.error);
+            case ContainerMetric:
+                return (T) ContainerMetric.from(envelope.containerMetric);
+            default:
+                throw new IllegalStateException(String.format("Envelope event type %s is unsupported", envelope.eventType));
+        }
+    }
+
+}

--- a/cloudfoundry-client/src/main/java/org/cloudfoundry/doppler/EventType.java
+++ b/cloudfoundry-client/src/main/java/org/cloudfoundry/doppler/EventType.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2013-2016 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.cloudfoundry.doppler;
+
+public enum EventType {
+    HttpStart,
+    HttpStop,
+    HttpStartStop,
+    LogMessage,
+    ValueMetric,
+    CounterEvent,
+    Error,
+    ContainerMetric
+}

--- a/cloudfoundry-client/src/main/java/org/cloudfoundry/doppler/_Envelope.java
+++ b/cloudfoundry-client/src/main/java/org/cloudfoundry/doppler/_Envelope.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright 2013-2016 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.cloudfoundry.doppler;
+
+import org.immutables.value.Value;
+
+@Value.Immutable
+public abstract class _Envelope<T extends Event> {
+
+    public static Envelope<? extends Event> from(org.cloudfoundry.dropsonde.events.Envelope dropsondeEnvelope) {
+        return Envelope.builder()
+            .deployment(dropsondeEnvelope.deployment)
+            .eventType(EventType.valueOf(dropsondeEnvelope.eventType.name()))
+            .event(EventBuilder.toEvent(dropsondeEnvelope))
+            .index(dropsondeEnvelope.index)
+            .deployment(dropsondeEnvelope.deployment)
+            .job(dropsondeEnvelope.job)
+            .ip(dropsondeEnvelope.ip)
+            .timestamp(dropsondeEnvelope.timestamp)
+            .origin(dropsondeEnvelope.origin)
+            .build();
+    }
+
+    @SuppressWarnings("unchecked")
+    /**
+     * Convenience method to be able to retrieve the event subtype without the user
+     * having to cast to the relevant event subtype.
+     *
+     */
+    public <S extends Event> S getEvent(Class<S> clazz) {
+        return (S)getEvent();
+    }
+
+    abstract String getOrigin();
+
+    abstract EventType getEventType();
+
+    abstract Long getTimestamp();
+
+    abstract String getDeployment();
+
+    abstract String getJob();
+
+    abstract String getIndex();
+
+    abstract String getIp();
+
+    abstract T getEvent();
+
+}

--- a/cloudfoundry-client/src/test/java/org/cloudfoundry/doppler/EnvelopeTest.java
+++ b/cloudfoundry-client/src/test/java/org/cloudfoundry/doppler/EnvelopeTest.java
@@ -1,0 +1,119 @@
+/*
+ * Copyright 2013-2016 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.cloudfoundry.doppler;
+
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+public class EnvelopeTest {
+
+    @Test
+    public void validEnvelope() {
+        Envelope<? extends Event> envelope = sampleEnvelope();
+
+        assertEquals("index", envelope.getIndex());
+        assertEquals(EventType.CounterEvent, envelope.getEventType());
+        assertEquals("deployment", envelope.getDeployment());
+        assertEquals("origin", envelope.getOrigin());
+        assertEquals("job", envelope.getJob());
+        assertEquals("ip", envelope.getIp());
+        assertTrue(envelope.getTimestamp() == 123L);
+        Event event = envelope.getEvent();
+        CounterEvent counterEvent = (CounterEvent)event;
+        assertTrue(counterEvent.getDelta() == 1L);
+        assertEquals("counter", counterEvent.getName());
+
+    }
+
+    @Test
+    public void retrieveCorrectEventTypeFromEnvelope() {
+        Envelope<? extends Event> envelope = sampleEnvelope();
+        CounterEvent resEvent = envelope.getEvent(CounterEvent.class);
+
+        assertTrue(resEvent.getDelta() == 1L);
+        assertEquals("counter", resEvent.getName());
+    }
+
+    @Test(expected = ClassCastException.class)
+    public void retrieveWrongEventTypeFromEnvelopeShouldThrowCastingException() {
+        Envelope<? extends Event> envelope = sampleEnvelope();
+        HttpStart httpStartEvent = envelope.getEvent(HttpStart.class);
+        assertFalse(true);//should not reach this point
+    }
+
+    @Test(expected = IllegalStateException.class)
+    public void missingOriginShouldTriggerException() {
+        org.cloudfoundry.dropsonde.events.CounterEvent cfCounterEvent =
+            new org.cloudfoundry.dropsonde.events.CounterEvent.Builder()
+                .name("counter")
+                .delta(1L)
+                .build();
+
+        org.cloudfoundry.dropsonde.events.Envelope cfEnvelope = new org.cloudfoundry.dropsonde.events.Envelope.Builder()
+            .index("index")
+            .eventType(org.cloudfoundry.dropsonde.events.Envelope.EventType.CounterEvent)
+            .deployment("deployment")
+            .job("job")
+            .ip("ip")
+            .timestamp(123L)
+            .counterEvent(cfCounterEvent)
+            .build();
+    }
+
+    @Test(expected = IllegalStateException.class)
+    public void missingEventTypeShouldTriggerException() {
+        org.cloudfoundry.dropsonde.events.CounterEvent cfCounterEvent =
+            new org.cloudfoundry.dropsonde.events.CounterEvent.Builder()
+                .name("counter")
+                .delta(1L)
+                .build();
+
+        org.cloudfoundry.dropsonde.events.Envelope cfEnvelope = new org.cloudfoundry.dropsonde.events.Envelope.Builder()
+            .index("index")
+            .deployment("deployment")
+            .origin("origin")
+            .job("job")
+            .ip("ip")
+            .timestamp(123L)
+            .counterEvent(cfCounterEvent)
+            .build();
+    }
+
+    private Envelope<? extends Event> sampleEnvelope() {
+        org.cloudfoundry.dropsonde.events.CounterEvent cfCounterEvent =
+            new org.cloudfoundry.dropsonde.events.CounterEvent.Builder()
+                .name("counter")
+                .delta(1L)
+                .build();
+
+        org.cloudfoundry.dropsonde.events.Envelope cfEnvelope = new org.cloudfoundry.dropsonde.events.Envelope.Builder()
+            .index("index")
+            .eventType(org.cloudfoundry.dropsonde.events.Envelope.EventType.CounterEvent)
+            .deployment("deployment")
+            .origin("origin")
+            .job("job")
+            .ip("ip")
+            .timestamp(123L)
+            .counterEvent(cfCounterEvent)
+            .build();
+
+        return Envelope.from(cfEnvelope);
+    }
+}


### PR DESCRIPTION
This is a purely Proof of concept PR to facilitate a discussion - I feel that it would be useful for the firehose responses to have the information from the envelope available also, this is discarded today and only the containing event passed to the consumer. This PR attempts to provide an additional API to retrieve the enveloped version of the events also. Can you please review this approach and if it looks reasonable I can add sufficient tests and send a cleaner PR.