### PR TITLE
External groups

### DIFF
--- a/cloudfoundry-client-spring/src/main/java/org/cloudfoundry/reactor/uaa/groups/ReactorGroups.java
+++ b/cloudfoundry-client-spring/src/main/java/org/cloudfoundry/reactor/uaa/groups/ReactorGroups.java
@@ -30,6 +30,8 @@ import org.cloudfoundry.uaa.groups.ListGroupsRequest;
 import org.cloudfoundry.uaa.groups.ListGroupsResponse;
 import org.cloudfoundry.uaa.groups.MapExternalGroupRequest;
 import org.cloudfoundry.uaa.groups.MapExternalGroupResponse;
+import org.cloudfoundry.uaa.groups.UnmapExternalGroupByGroupDisplayNameRequest;
+import org.cloudfoundry.uaa.groups.UnmapExternalGroupByGroupDisplayNameResponse;
 import org.cloudfoundry.uaa.groups.UnmapExternalGroupByGroupIdRequest;
 import org.cloudfoundry.uaa.groups.UnmapExternalGroupByGroupIdResponse;
 import org.cloudfoundry.uaa.groups.UpdateGroupRequest;
@@ -77,6 +79,14 @@ public class ReactorGroups extends AbstractUaaOperations implements Groups {
     @Override
     public Mono<MapExternalGroupResponse> mapExternalGroup(MapExternalGroupRequest request) {
         return post(request, MapExternalGroupResponse.class, builder -> builder.pathSegment("Groups", "External"));
+    }
+
+    @Override
+    public Mono<UnmapExternalGroupByGroupDisplayNameResponse> unmapExternalGroupByGroupDisplayName(UnmapExternalGroupByGroupDisplayNameRequest request) {
+        return delete(
+            request,
+            UnmapExternalGroupByGroupDisplayNameResponse.class,
+            builder -> builder.pathSegment("Groups", "External", "displayName", request.getGroupDisplayName(), "externalGroup", request.getExternalGroup(), "origin", request.getOriginKey()));
     }
 
     @Override

--- a/cloudfoundry-client-spring/src/main/java/org/cloudfoundry/reactor/uaa/groups/ReactorGroups.java
+++ b/cloudfoundry-client-spring/src/main/java/org/cloudfoundry/reactor/uaa/groups/ReactorGroups.java
@@ -30,6 +30,8 @@ import org.cloudfoundry.uaa.groups.ListGroupsRequest;
 import org.cloudfoundry.uaa.groups.ListGroupsResponse;
 import org.cloudfoundry.uaa.groups.MapExternalGroupRequest;
 import org.cloudfoundry.uaa.groups.MapExternalGroupResponse;
+import org.cloudfoundry.uaa.groups.UnmapExternalGroupByGroupIdRequest;
+import org.cloudfoundry.uaa.groups.UnmapExternalGroupByGroupIdResponse;
 import org.cloudfoundry.uaa.groups.UpdateGroupRequest;
 import org.cloudfoundry.uaa.groups.UpdateGroupResponse;
 import reactor.core.publisher.Mono;
@@ -75,6 +77,14 @@ public class ReactorGroups extends AbstractUaaOperations implements Groups {
     @Override
     public Mono<MapExternalGroupResponse> mapExternalGroup(MapExternalGroupRequest request) {
         return post(request, MapExternalGroupResponse.class, builder -> builder.pathSegment("Groups", "External"));
+    }
+
+    @Override
+    public Mono<UnmapExternalGroupByGroupIdResponse> unmapExternalGroupByGroupId(UnmapExternalGroupByGroupIdRequest request) {
+        return delete(
+            request,
+            UnmapExternalGroupByGroupIdResponse.class,
+            builder -> builder.pathSegment("Groups", "External", "groupId", request.getGroupId(), "externalGroup", request.getExternalGroup(), "origin", request.getOriginKey()));
     }
 
     @Override

--- a/cloudfoundry-client-spring/src/main/java/org/cloudfoundry/reactor/uaa/groups/ReactorGroups.java
+++ b/cloudfoundry-client-spring/src/main/java/org/cloudfoundry/reactor/uaa/groups/ReactorGroups.java
@@ -28,6 +28,8 @@ import org.cloudfoundry.uaa.groups.GetGroupResponse;
 import org.cloudfoundry.uaa.groups.Groups;
 import org.cloudfoundry.uaa.groups.ListGroupsRequest;
 import org.cloudfoundry.uaa.groups.ListGroupsResponse;
+import org.cloudfoundry.uaa.groups.MapExternalGroupRequest;
+import org.cloudfoundry.uaa.groups.MapExternalGroupResponse;
 import org.cloudfoundry.uaa.groups.UpdateGroupRequest;
 import org.cloudfoundry.uaa.groups.UpdateGroupResponse;
 import reactor.core.publisher.Mono;
@@ -68,6 +70,11 @@ public class ReactorGroups extends AbstractUaaOperations implements Groups {
     @Override
     public Mono<ListGroupsResponse> list(ListGroupsRequest request) {
         return get(request, ListGroupsResponse.class, builder -> builder.pathSegment("Groups"));
+    }
+
+    @Override
+    public Mono<MapExternalGroupResponse> mapExternalGroup(MapExternalGroupRequest request) {
+        return post(request, MapExternalGroupResponse.class, builder -> builder.pathSegment("Groups", "External"));
     }
 
     @Override

--- a/cloudfoundry-client-spring/src/main/java/org/cloudfoundry/reactor/uaa/groups/ReactorGroups.java
+++ b/cloudfoundry-client-spring/src/main/java/org/cloudfoundry/reactor/uaa/groups/ReactorGroups.java
@@ -26,6 +26,8 @@ import org.cloudfoundry.uaa.groups.DeleteGroupResponse;
 import org.cloudfoundry.uaa.groups.GetGroupRequest;
 import org.cloudfoundry.uaa.groups.GetGroupResponse;
 import org.cloudfoundry.uaa.groups.Groups;
+import org.cloudfoundry.uaa.groups.ListExternalGroupMappingsRequest;
+import org.cloudfoundry.uaa.groups.ListExternalGroupMappingsResponse;
 import org.cloudfoundry.uaa.groups.ListGroupsRequest;
 import org.cloudfoundry.uaa.groups.ListGroupsResponse;
 import org.cloudfoundry.uaa.groups.MapExternalGroupRequest;
@@ -74,6 +76,11 @@ public class ReactorGroups extends AbstractUaaOperations implements Groups {
     @Override
     public Mono<ListGroupsResponse> list(ListGroupsRequest request) {
         return get(request, ListGroupsResponse.class, builder -> builder.pathSegment("Groups"));
+    }
+
+    @Override
+    public Mono<ListExternalGroupMappingsResponse> listExternalGroupMappings(ListExternalGroupMappingsRequest request) {
+        return get(request, ListExternalGroupMappingsResponse.class, builder -> builder.pathSegment("Groups", "External"));
     }
 
     @Override

--- a/cloudfoundry-client-spring/src/test/java/org/cloudfoundry/reactor/uaa/groups/ReactorGroupsTest.java
+++ b/cloudfoundry-client-spring/src/test/java/org/cloudfoundry/reactor/uaa/groups/ReactorGroupsTest.java
@@ -34,6 +34,8 @@ import org.cloudfoundry.uaa.groups.MapExternalGroupRequest;
 import org.cloudfoundry.uaa.groups.MapExternalGroupResponse;
 import org.cloudfoundry.uaa.groups.Member;
 import org.cloudfoundry.uaa.groups.MemberType;
+import org.cloudfoundry.uaa.groups.UnmapExternalGroupByGroupIdRequest;
+import org.cloudfoundry.uaa.groups.UnmapExternalGroupByGroupIdResponse;
 import org.cloudfoundry.uaa.groups.UpdateGroupRequest;
 import org.cloudfoundry.uaa.groups.UpdateGroupResponse;
 import reactor.core.publisher.Mono;
@@ -324,6 +326,55 @@ public final class ReactorGroupsTest {
             return this.groups.mapExternalGroup(request);
         }
     }
+
+    public static final class UnmapExternalGroupByGroupId extends AbstractUaaApiTest<UnmapExternalGroupByGroupIdRequest, UnmapExternalGroupByGroupIdResponse> {
+
+        private final ReactorGroups groups = new ReactorGroups(AUTHORIZATION_PROVIDER, HTTP_CLIENT, OBJECT_MAPPER, this.root);
+
+        @Override
+        protected InteractionContext getInteractionContext() {
+            return InteractionContext.builder()
+                .request(TestRequest.builder()
+                    .method(DELETE).path("/Groups/External/groupId/d68167b4-81b3-490d-9838-94092d5c89f6/externalGroup/external group/origin/ldap")
+                    .build())
+                .response(TestResponse.builder()
+                    .status(OK)
+                    .payload("fixtures/uaa/groups/DELETE_external_groupid_{groupId}_externalgroup_{externalGroup}_origin_{origin}_response.json")
+                    .build())
+                .build();
+        }
+
+        @Override
+        protected UnmapExternalGroupByGroupIdResponse getResponse() {
+            return UnmapExternalGroupByGroupIdResponse.builder()
+                .groupId("d68167b4-81b3-490d-9838-94092d5c89f6")
+                .groupDisplayName("Group For Testing Deleting External Group Mapping")
+                .originKey("ldap")
+                .externalGroup("external group")
+                .metadata(Metadata.builder()
+                    .created("2016-06-16T00:01:41.223Z")
+                    .lastModified("2016-06-16T00:01:41.223Z")
+                    .version(0)
+                    .build())
+                .schema("urn:scim:schemas:core:1.0")
+                .build();
+        }
+
+        @Override
+        protected UnmapExternalGroupByGroupIdRequest getValidRequest() throws Exception {
+            return UnmapExternalGroupByGroupIdRequest.builder()
+                .groupId("d68167b4-81b3-490d-9838-94092d5c89f6")
+                .externalGroup("external group")
+                .originKey("ldap")
+                .build();
+        }
+
+        @Override
+        protected Mono<UnmapExternalGroupByGroupIdResponse> invoke(UnmapExternalGroupByGroupIdRequest request) {
+            return this.groups.unmapExternalGroupByGroupId(request);
+        }
+    }
+
 
     public static final class Update extends AbstractUaaApiTest<UpdateGroupRequest, UpdateGroupResponse> {
 

--- a/cloudfoundry-client-spring/src/test/java/org/cloudfoundry/reactor/uaa/groups/ReactorGroupsTest.java
+++ b/cloudfoundry-client-spring/src/test/java/org/cloudfoundry/reactor/uaa/groups/ReactorGroupsTest.java
@@ -30,6 +30,8 @@ import org.cloudfoundry.uaa.groups.GetGroupResponse;
 import org.cloudfoundry.uaa.groups.Group;
 import org.cloudfoundry.uaa.groups.ListGroupsRequest;
 import org.cloudfoundry.uaa.groups.ListGroupsResponse;
+import org.cloudfoundry.uaa.groups.MapExternalGroupRequest;
+import org.cloudfoundry.uaa.groups.MapExternalGroupResponse;
 import org.cloudfoundry.uaa.groups.Member;
 import org.cloudfoundry.uaa.groups.MemberType;
 import org.cloudfoundry.uaa.groups.UpdateGroupRequest;
@@ -272,6 +274,54 @@ public final class ReactorGroupsTest {
         @Override
         protected Mono<ListGroupsResponse> invoke(ListGroupsRequest request) {
             return this.groups.list(request);
+        }
+    }
+
+    public static final class MapExternalGroup extends AbstractUaaApiTest<MapExternalGroupRequest, MapExternalGroupResponse> {
+
+        private final ReactorGroups groups = new ReactorGroups(AUTHORIZATION_PROVIDER, HTTP_CLIENT, OBJECT_MAPPER, this.root);
+
+        @Override
+        protected InteractionContext getInteractionContext() {
+            return InteractionContext.builder()
+                .request(TestRequest.builder()
+                    .method(POST).path("/Groups/External")
+                    .payload("fixtures/uaa/groups/POST_external_request.json")
+                    .build())
+                .response(TestResponse.builder()
+                    .status(CREATED)
+                    .payload("fixtures/uaa/groups/POST_external_response.json")
+                    .build())
+                .build();
+        }
+
+        @Override
+        protected MapExternalGroupResponse getResponse() {
+            return MapExternalGroupResponse.builder()
+                .groupId("76937b62-346c-4848-953c-d790b87ec80a")
+                .groupDisplayName("Group For Testing Creating External Group Mapping")
+                .originKey("ldap")
+                .externalGroup("External group")
+                .metadata(Metadata.builder()
+                    .created("2016-06-16T00:01:41.393Z")
+                    .lastModified("2016-06-16T00:01:41.393Z")
+                    .version(0)
+                    .build())
+                .schema("urn:scim:schemas:core:1.0")
+                .build();
+        }
+
+        @Override
+        protected MapExternalGroupRequest getValidRequest() throws Exception {
+            return MapExternalGroupRequest.builder()
+                .groupId("76937b62-346c-4848-953c-d790b87ec80a")
+                .externalGroup("External group")
+                .build();
+        }
+
+        @Override
+        protected Mono<MapExternalGroupResponse> invoke(MapExternalGroupRequest request) {
+            return this.groups.mapExternalGroup(request);
         }
     }
 

--- a/cloudfoundry-client-spring/src/test/java/org/cloudfoundry/reactor/uaa/groups/ReactorGroupsTest.java
+++ b/cloudfoundry-client-spring/src/test/java/org/cloudfoundry/reactor/uaa/groups/ReactorGroupsTest.java
@@ -34,6 +34,8 @@ import org.cloudfoundry.uaa.groups.MapExternalGroupRequest;
 import org.cloudfoundry.uaa.groups.MapExternalGroupResponse;
 import org.cloudfoundry.uaa.groups.Member;
 import org.cloudfoundry.uaa.groups.MemberType;
+import org.cloudfoundry.uaa.groups.UnmapExternalGroupByGroupDisplayNameRequest;
+import org.cloudfoundry.uaa.groups.UnmapExternalGroupByGroupDisplayNameResponse;
 import org.cloudfoundry.uaa.groups.UnmapExternalGroupByGroupIdRequest;
 import org.cloudfoundry.uaa.groups.UnmapExternalGroupByGroupIdResponse;
 import org.cloudfoundry.uaa.groups.UpdateGroupRequest;
@@ -324,6 +326,54 @@ public final class ReactorGroupsTest {
         @Override
         protected Mono<MapExternalGroupResponse> invoke(MapExternalGroupRequest request) {
             return this.groups.mapExternalGroup(request);
+        }
+    }
+
+    public static final class UnmapExternalGroupByGroupDisplayName extends AbstractUaaApiTest<UnmapExternalGroupByGroupDisplayNameRequest, UnmapExternalGroupByGroupDisplayNameResponse> {
+
+        private final ReactorGroups groups = new ReactorGroups(AUTHORIZATION_PROVIDER, HTTP_CLIENT, OBJECT_MAPPER, this.root);
+
+        @Override
+        protected InteractionContext getInteractionContext() {
+            return InteractionContext.builder()
+                .request(TestRequest.builder()
+                    .method(DELETE).path("/Groups/External/displayName/Group For Testing Deleting External Group Mapping By Name/externalGroup/external group/origin/ldap")
+                    .build())
+                .response(TestResponse.builder()
+                    .status(OK)
+                    .payload("fixtures/uaa/groups/DELETE_external_displayname_{displayName}_externalgroup_{externalGroup}_origin_{origin}_response.json")
+                    .build())
+                .build();
+        }
+
+        @Override
+        protected UnmapExternalGroupByGroupDisplayNameResponse getResponse() {
+            return UnmapExternalGroupByGroupDisplayNameResponse.builder()
+                .groupId("f8f0048f-de32-4d20-b41d-5820b690063d")
+                .groupDisplayName("Group For Testing Deleting External Group Mapping By Name")
+                .originKey("ldap")
+                .externalGroup("external group")
+                .metadata(Metadata.builder()
+                    .created("2016-06-16T00:01:41.465Z")
+                    .lastModified("2016-06-16T00:01:41.465Z")
+                    .version(0)
+                    .build())
+                .schema("urn:scim:schemas:core:1.0")
+                .build();
+        }
+
+        @Override
+        protected UnmapExternalGroupByGroupDisplayNameRequest getValidRequest() throws Exception {
+            return UnmapExternalGroupByGroupDisplayNameRequest.builder()
+                .groupDisplayName("Group For Testing Deleting External Group Mapping By Name")
+                .externalGroup("external group")
+                .originKey("ldap")
+                .build();
+        }
+
+        @Override
+        protected Mono<UnmapExternalGroupByGroupDisplayNameResponse> invoke(UnmapExternalGroupByGroupDisplayNameRequest request) {
+            return this.groups.unmapExternalGroupByGroupDisplayName(request);
         }
     }
 

--- a/cloudfoundry-client-spring/src/test/java/org/cloudfoundry/reactor/uaa/groups/ReactorGroupsTest.java
+++ b/cloudfoundry-client-spring/src/test/java/org/cloudfoundry/reactor/uaa/groups/ReactorGroupsTest.java
@@ -25,9 +25,12 @@ import org.cloudfoundry.uaa.groups.CreateGroupRequest;
 import org.cloudfoundry.uaa.groups.CreateGroupResponse;
 import org.cloudfoundry.uaa.groups.DeleteGroupRequest;
 import org.cloudfoundry.uaa.groups.DeleteGroupResponse;
+import org.cloudfoundry.uaa.groups.ExternalGroupMapping;
 import org.cloudfoundry.uaa.groups.GetGroupRequest;
 import org.cloudfoundry.uaa.groups.GetGroupResponse;
 import org.cloudfoundry.uaa.groups.Group;
+import org.cloudfoundry.uaa.groups.ListExternalGroupMappingsRequest;
+import org.cloudfoundry.uaa.groups.ListExternalGroupMappingsResponse;
 import org.cloudfoundry.uaa.groups.ListGroupsRequest;
 import org.cloudfoundry.uaa.groups.ListGroupsResponse;
 import org.cloudfoundry.uaa.groups.MapExternalGroupRequest;
@@ -278,6 +281,61 @@ public final class ReactorGroupsTest {
         @Override
         protected Mono<ListGroupsResponse> invoke(ListGroupsRequest request) {
             return this.groups.list(request);
+        }
+    }
+
+    public static final class ListExternalGroupMappings extends AbstractUaaApiTest<ListExternalGroupMappingsRequest, ListExternalGroupMappingsResponse> {
+
+        private final ReactorGroups groups = new ReactorGroups(AUTHORIZATION_PROVIDER, HTTP_CLIENT, OBJECT_MAPPER, this.root);
+
+        @Override
+        protected InteractionContext getInteractionContext() {
+            return InteractionContext.builder()
+                .request(TestRequest.builder()
+                    .method(GET)
+                    .path("/Groups/External?count=50&filter=group_id%2Beq%2B%220480db7f-d1bc-4d2b-b723-febc684c0ee9%22&startIndex=1")
+                    .build())
+                .response(TestResponse.builder()
+                    .status(OK)
+                    .payload("fixtures/uaa/groups/GET_external_response.json")
+                    .build())
+                .build();
+        }
+
+        @Override
+        protected ListExternalGroupMappingsResponse getResponse() {
+            return ListExternalGroupMappingsResponse.builder()
+                .resource(ExternalGroupMapping.builder()
+                    .groupId("0480db7f-d1bc-4d2b-b723-febc684c0ee9")
+                    .groupDisplayName("Group For Testing Retrieving External Group Mappings")
+                    .originKey("ldap")
+                    .externalGroup("external group")
+                    .metadata(Metadata.builder()
+                        .created("2016-06-16T00:01:41.223Z")
+                        .lastModified("2016-06-16T00:01:41.223Z")
+                        .version(0)
+                        .build())
+                    .build()
+                )
+                .startIndex(1)
+                .itemsPerPage(1)
+                .totalResults(1)
+                .schema("urn:scim:schemas:core:1.0")
+                .build();
+        }
+
+        @Override
+        protected ListExternalGroupMappingsRequest getValidRequest() throws Exception {
+            return ListExternalGroupMappingsRequest.builder()
+                .filter("group_id+eq+\"0480db7f-d1bc-4d2b-b723-febc684c0ee9\"")
+                .count(50)
+                .startIndex(1)
+                .build();
+        }
+
+        @Override
+        protected Mono<ListExternalGroupMappingsResponse> invoke(ListExternalGroupMappingsRequest request) {
+            return this.groups.listExternalGroupMappings(request);
         }
     }
 

--- a/cloudfoundry-client-spring/src/test/resources/fixtures/uaa/groups/DELETE_external_displayname_{displayName}_externalgroup_{externalGroup}_origin_{origin}_response.json
+++ b/cloudfoundry-client-spring/src/test/resources/fixtures/uaa/groups/DELETE_external_displayname_{displayName}_externalgroup_{externalGroup}_origin_{origin}_response.json
@@ -1,0 +1,14 @@
+{
+  "meta": {
+    "version": 0,
+    "created": "2016-06-16T00:01:41.465Z",
+    "lastModified": "2016-06-16T00:01:41.465Z"
+  },
+  "groupId": "f8f0048f-de32-4d20-b41d-5820b690063d",
+  "externalGroup": "external group",
+  "displayName": "Group For Testing Deleting External Group Mapping By Name",
+  "origin": "ldap",
+  "schemas": [
+    "urn:scim:schemas:core:1.0"
+  ]
+}

--- a/cloudfoundry-client-spring/src/test/resources/fixtures/uaa/groups/DELETE_external_groupid_{groupId}_externalgroup_{externalGroup}_origin_{origin}_response.json
+++ b/cloudfoundry-client-spring/src/test/resources/fixtures/uaa/groups/DELETE_external_groupid_{groupId}_externalgroup_{externalGroup}_origin_{origin}_response.json
@@ -1,0 +1,12 @@
+{
+  "meta" : {
+    "version" : 0,
+    "created" : "2016-06-16T00:01:41.223Z",
+    "lastModified" : "2016-06-16T00:01:41.223Z"
+  },
+  "groupId" : "d68167b4-81b3-490d-9838-94092d5c89f6",
+  "externalGroup" : "external group",
+  "displayName" : "Group For Testing Deleting External Group Mapping",
+  "origin" : "ldap",
+  "schemas" : [ "urn:scim:schemas:core:1.0" ]
+}

--- a/cloudfoundry-client-spring/src/test/resources/fixtures/uaa/groups/GET_external_response.json
+++ b/cloudfoundry-client-spring/src/test/resources/fixtures/uaa/groups/GET_external_response.json
@@ -1,0 +1,21 @@
+{
+  "resources": [
+    {
+      "groupId": "0480db7f-d1bc-4d2b-b723-febc684c0ee9",
+      "displayName": "Group For Testing Retrieving External Group Mappings",
+      "externalGroup": "external group",
+      "origin": "ldap",
+      "meta": {
+        "version": 0,
+        "created": "2016-06-16T00:01:41.223Z",
+        "lastModified": "2016-06-16T00:01:41.223Z"
+      }
+    }
+  ],
+  "startIndex": 1,
+  "itemsPerPage": 1,
+  "totalResults": 1,
+  "schemas": [
+    "urn:scim:schemas:core:1.0"
+  ]
+}

--- a/cloudfoundry-client-spring/src/test/resources/fixtures/uaa/groups/POST_external_request.json
+++ b/cloudfoundry-client-spring/src/test/resources/fixtures/uaa/groups/POST_external_request.json
@@ -1,0 +1,4 @@
+{
+  "externalGroup": "External group",
+  "groupId": "76937b62-346c-4848-953c-d790b87ec80a"
+}

--- a/cloudfoundry-client-spring/src/test/resources/fixtures/uaa/groups/POST_external_response.json
+++ b/cloudfoundry-client-spring/src/test/resources/fixtures/uaa/groups/POST_external_response.json
@@ -1,0 +1,14 @@
+{
+  "meta": {
+    "version": 0,
+    "created": "2016-06-16T00:01:41.393Z",
+    "lastModified": "2016-06-16T00:01:41.393Z"
+  },
+  "groupId": "76937b62-346c-4848-953c-d790b87ec80a",
+  "externalGroup": "External group",
+  "displayName": "Group For Testing Creating External Group Mapping",
+  "origin": "ldap",
+  "schemas": [
+    "urn:scim:schemas:core:1.0"
+  ]
+}

--- a/cloudfoundry-client/src/main/java/org/cloudfoundry/uaa/groups/AbstractExternalGroupMapping.java
+++ b/cloudfoundry-client/src/main/java/org/cloudfoundry/uaa/groups/AbstractExternalGroupMapping.java
@@ -17,40 +17,32 @@
 package org.cloudfoundry.uaa.groups;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
-import org.cloudfoundry.Nullable;
 import org.cloudfoundry.uaa.Metadata;
 
 import java.util.List;
 
 /**
- * The entity response payload for Group
+ * The entity response payload for External Group
  */
-abstract class AbstractGroup {
+abstract class AbstractExternalGroupMapping {
 
     /**
-     * Human readable description of the group, displayed e.g. when approving scopes
+     * The identifier for the group in external identity provider that needs to be mapped to internal UAA groups
      */
-    @JsonProperty("description")
-    @Nullable
-    abstract String getDescription();
+    @JsonProperty("externalGroup")
+    abstract String getExternalGroup();
 
     /**
-     * The identifier specified upon creation of the group, unique within the identity zone
+     * The group's displayed name
      */
     @JsonProperty("displayName")
-    abstract String getDisplayName();
+    abstract String getGroupDisplayName();
 
     /**
-     * The globally unique group ID
+     * The group unique ID
      */
-    @JsonProperty("id")
-    abstract String getId();
-
-    /**
-     * Array of group members
-     */
-    @JsonProperty("members")
-    abstract List<Member> getMembers();
+    @JsonProperty("groupId")
+    abstract String getGroupId();
 
     /**
      * The group's metadata
@@ -59,15 +51,15 @@ abstract class AbstractGroup {
     abstract Metadata getMetadata();
 
     /**
+     * Unique alias of the identity provider
+     */
+    @JsonProperty("origin")
+    abstract String getOriginKey();
+
+    /**
      * The group's schemas:  "urn:scim:schemas:core:1.0" ]
      */
     @JsonProperty("schemas")
     abstract List<String> getSchemas();
-
-    /**
-     * Identifier for the identity zone to which the group belongs
-     */
-    @JsonProperty("zoneId")
-    abstract String getZoneId();
 
 }

--- a/cloudfoundry-client/src/main/java/org/cloudfoundry/uaa/groups/Groups.java
+++ b/cloudfoundry-client/src/main/java/org/cloudfoundry/uaa/groups/Groups.java
@@ -56,6 +56,14 @@ public interface Groups {
     Mono<ListGroupsResponse> list(ListGroupsRequest request);
 
     /**
+     * Makes the <a href="http://docs.cloudfoundry.com/uaa/#update59">Map External Group</a> request
+     *
+     * @param request the Map External Group request
+     * @return the response from the Map External Group request
+     */
+    Mono<MapExternalGroupResponse> mapExternalGroup(MapExternalGroupRequest request);
+
+    /**
      * Makes the <a href="http://docs.cloudfoundry.com/uaa/#update59">Update Group</a> request
      *
      * @param request the Update Group request

--- a/cloudfoundry-client/src/main/java/org/cloudfoundry/uaa/groups/Groups.java
+++ b/cloudfoundry-client/src/main/java/org/cloudfoundry/uaa/groups/Groups.java
@@ -64,6 +64,14 @@ public interface Groups {
     Mono<MapExternalGroupResponse> mapExternalGroup(MapExternalGroupRequest request);
 
     /**
+     * Makes the <a href="http://docs.cloudfoundry.com/uaa/#by-group-display-name">Unmap External Group By Group Display Name</a> request
+     *
+     * @param request the Unmap External Group By Group Display Name request
+     * @return the response from the Unmap External Group By Group Display Name request
+     */
+    Mono<UnmapExternalGroupByGroupDisplayNameResponse> unmapExternalGroupByGroupDisplayName(UnmapExternalGroupByGroupDisplayNameRequest request);
+
+    /**
      * Makes the <a href="http://docs.cloudfoundry.com/uaa/#by-group-id">Unmap External Group By Group Id</a> request
      *
      * @param request the Unmap External Group By Group Id request

--- a/cloudfoundry-client/src/main/java/org/cloudfoundry/uaa/groups/Groups.java
+++ b/cloudfoundry-client/src/main/java/org/cloudfoundry/uaa/groups/Groups.java
@@ -64,6 +64,14 @@ public interface Groups {
     Mono<MapExternalGroupResponse> mapExternalGroup(MapExternalGroupRequest request);
 
     /**
+     * Makes the <a href="http://docs.cloudfoundry.com/uaa/#by-group-id">Unmap External Group By Group Id</a> request
+     *
+     * @param request the Unmap External Group By Group Id request
+     * @return the response from the Unmap External Group By Group Id request
+     */
+    Mono<UnmapExternalGroupByGroupIdResponse> unmapExternalGroupByGroupId(UnmapExternalGroupByGroupIdRequest request);
+
+    /**
      * Makes the <a href="http://docs.cloudfoundry.com/uaa/#update59">Update Group</a> request
      *
      * @param request the Update Group request

--- a/cloudfoundry-client/src/main/java/org/cloudfoundry/uaa/groups/Groups.java
+++ b/cloudfoundry-client/src/main/java/org/cloudfoundry/uaa/groups/Groups.java
@@ -56,6 +56,14 @@ public interface Groups {
     Mono<ListGroupsResponse> list(ListGroupsRequest request);
 
     /**
+     * Makes the <a href="http://docs.cloudfoundry.com/uaa/#list72">List External Group Mappings</a> request
+     *
+     * @param request the List External Group Mappings request
+     * @return the response from the List External Group Mappings request
+     */
+    Mono<ListExternalGroupMappingsResponse> listExternalGroupMappings(ListExternalGroupMappingsRequest request);
+
+    /**
      * Makes the <a href="http://docs.cloudfoundry.com/uaa/#update59">Map External Group</a> request
      *
      * @param request the Map External Group request

--- a/cloudfoundry-client/src/main/java/org/cloudfoundry/uaa/groups/_ExternalGroupMapping.java
+++ b/cloudfoundry-client/src/main/java/org/cloudfoundry/uaa/groups/_ExternalGroupMapping.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright 2013-2016 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.cloudfoundry.uaa.groups;
+
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import org.immutables.value.Value;
+
+/**
+ * The resource in the list external group mappings response
+ */
+@JsonDeserialize
+@Value.Immutable
+abstract class _ExternalGroupMapping extends AbstractExternalGroupMapping {
+
+}

--- a/cloudfoundry-client/src/main/java/org/cloudfoundry/uaa/groups/_ListExternalGroupMappingsRequest.java
+++ b/cloudfoundry-client/src/main/java/org/cloudfoundry/uaa/groups/_ListExternalGroupMappingsRequest.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2013-2016 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.cloudfoundry.uaa.groups;
+
+import org.cloudfoundry.uaa.PaginatedAndSortedByRequest;
+import org.immutables.value.Value;
+
+/**
+ * The request payload for the list external group mappings operation
+ */
+@Value.Immutable
+abstract class _ListExternalGroupMappingsRequest extends PaginatedAndSortedByRequest {
+
+}

--- a/cloudfoundry-client/src/main/java/org/cloudfoundry/uaa/groups/_ListExternalGroupMappingsResponse.java
+++ b/cloudfoundry-client/src/main/java/org/cloudfoundry/uaa/groups/_ListExternalGroupMappingsResponse.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2013-2016 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.cloudfoundry.uaa.groups;
+
+
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import org.cloudfoundry.uaa.PaginatedResponse;
+import org.immutables.value.Value;
+
+/**
+ * The response from the list External Group Mappings request
+ */
+@JsonDeserialize
+@Value.Immutable
+abstract class _ListExternalGroupMappingsResponse extends PaginatedResponse<ExternalGroupMapping> {
+
+}

--- a/cloudfoundry-client/src/main/java/org/cloudfoundry/uaa/groups/_MapExternalGroupRequest.java
+++ b/cloudfoundry-client/src/main/java/org/cloudfoundry/uaa/groups/_MapExternalGroupRequest.java
@@ -14,39 +14,35 @@
  * limitations under the License.
  */
 
-package org.cloudfoundry.uaa;
+package org.cloudfoundry.uaa.groups;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import org.cloudfoundry.Nullable;
 import org.immutables.value.Value;
 
 /**
- * The metadata payload entities
+ * The request payload for the map external group request
  */
-@JsonDeserialize
 @Value.Immutable
-abstract class _Metadata {
+abstract class _MapExternalGroupRequest {
 
     /**
-     * When the resource record was created
+     * The identifier for the group in external identity provider that needs to be mapped to internal UAA groups
      */
-    @JsonProperty("created")
-    @Nullable
-    abstract String getCreated();
+    @JsonProperty("externalGroup")
+    abstract String getExternalGroup();
 
     /**
-     * When the resource record was last modified
+     * The group unique ID
      */
-    @JsonProperty("lastModified")
-    @Nullable
-    abstract String getLastModified();
+    @JsonProperty("groupId")
+    abstract String getGroupId();
 
     /**
-     * The metadata version
+     * Unique alias of the identity provider
      */
-    @JsonProperty("version")
+    @JsonProperty("origin")
     @Nullable
-    abstract Integer getVersion();
+    abstract String getOriginKey();
 
 }

--- a/cloudfoundry-client/src/main/java/org/cloudfoundry/uaa/groups/_MapExternalGroupResponse.java
+++ b/cloudfoundry-client/src/main/java/org/cloudfoundry/uaa/groups/_MapExternalGroupResponse.java
@@ -14,39 +14,16 @@
  * limitations under the License.
  */
 
-package org.cloudfoundry.uaa;
+package org.cloudfoundry.uaa.groups;
 
-import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
-import org.cloudfoundry.Nullable;
 import org.immutables.value.Value;
 
 /**
- * The metadata payload entities
+ * The response payload for the map external group request
  */
 @JsonDeserialize
 @Value.Immutable
-abstract class _Metadata {
-
-    /**
-     * When the resource record was created
-     */
-    @JsonProperty("created")
-    @Nullable
-    abstract String getCreated();
-
-    /**
-     * When the resource record was last modified
-     */
-    @JsonProperty("lastModified")
-    @Nullable
-    abstract String getLastModified();
-
-    /**
-     * The metadata version
-     */
-    @JsonProperty("version")
-    @Nullable
-    abstract Integer getVersion();
+abstract class _MapExternalGroupResponse extends AbstractExternalGroupMapping {
 
 }

--- a/cloudfoundry-client/src/main/java/org/cloudfoundry/uaa/groups/_UnmapExternalGroupByGroupDisplayNameRequest.java
+++ b/cloudfoundry-client/src/main/java/org/cloudfoundry/uaa/groups/_UnmapExternalGroupByGroupDisplayNameRequest.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2013-2016 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.cloudfoundry.uaa.groups;
+
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import org.immutables.value.Value;
+
+/**
+ * The request payload for the unmap external group by group display name request
+ */
+@Value.Immutable
+abstract class _UnmapExternalGroupByGroupDisplayNameRequest {
+
+    /**
+     * The identifier for the group in external identity provider that needs to be unmapped to internal UAA groups
+     */
+    @JsonIgnore
+    abstract String getExternalGroup();
+
+    /**
+     * The group's displayed name
+     */
+    @JsonIgnore
+    abstract String getGroupDisplayName();
+
+    /**
+     * Unique alias of the identity provider
+     */
+    @JsonIgnore
+    abstract String getOriginKey();
+
+}

--- a/cloudfoundry-client/src/main/java/org/cloudfoundry/uaa/groups/_UnmapExternalGroupByGroupDisplayNameResponse.java
+++ b/cloudfoundry-client/src/main/java/org/cloudfoundry/uaa/groups/_UnmapExternalGroupByGroupDisplayNameResponse.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright 2013-2016 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.cloudfoundry.uaa.groups;
+
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import org.immutables.value.Value;
+
+/**
+ * The response payload for the unmap external group by group display name request
+ */
+@JsonDeserialize
+@Value.Immutable
+abstract class _UnmapExternalGroupByGroupDisplayNameResponse extends AbstractExternalGroupMapping {
+
+}

--- a/cloudfoundry-client/src/main/java/org/cloudfoundry/uaa/groups/_UnmapExternalGroupByGroupIdRequest.java
+++ b/cloudfoundry-client/src/main/java/org/cloudfoundry/uaa/groups/_UnmapExternalGroupByGroupIdRequest.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2013-2016 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.cloudfoundry.uaa.groups;
+
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import org.immutables.value.Value;
+
+/**
+ * The request payload for the unmap external group by group id request
+ */
+@Value.Immutable
+abstract class _UnmapExternalGroupByGroupIdRequest {
+
+    /**
+     * The identifier for the group in external identity provider that needs to be unmapped to internal UAA groups
+     */
+    @JsonIgnore
+    abstract String getExternalGroup();
+
+    /**
+     * The group unique ID
+     */
+    @JsonIgnore
+    abstract String getGroupId();
+
+    /**
+     * Unique alias of the identity provider
+     */
+    @JsonIgnore
+    abstract String getOriginKey();
+
+}

--- a/cloudfoundry-client/src/main/java/org/cloudfoundry/uaa/groups/_UnmapExternalGroupByGroupIdResponse.java
+++ b/cloudfoundry-client/src/main/java/org/cloudfoundry/uaa/groups/_UnmapExternalGroupByGroupIdResponse.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright 2013-2016 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.cloudfoundry.uaa.groups;
+
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import org.immutables.value.Value;
+
+/**
+ * The response payload for the unmap external group by group id request
+ */
+@JsonDeserialize
+@Value.Immutable
+abstract class _UnmapExternalGroupByGroupIdResponse extends AbstractExternalGroupMapping {
+
+}

--- a/cloudfoundry-client/src/test/java/org/cloudfoundry/uaa/groups/ListExternalGroupMappingsRequestTest.java
+++ b/cloudfoundry-client/src/test/java/org/cloudfoundry/uaa/groups/ListExternalGroupMappingsRequestTest.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright 2013-2016 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.cloudfoundry.uaa.groups;
+
+import org.junit.Test;
+
+public final class ListExternalGroupMappingsRequestTest {
+
+    @Test
+    public void valid() {
+        ListExternalGroupMappingsRequest.builder()
+            .build();
+    }
+
+}

--- a/cloudfoundry-client/src/test/java/org/cloudfoundry/uaa/groups/MapExternalGroupRequestTest.java
+++ b/cloudfoundry-client/src/test/java/org/cloudfoundry/uaa/groups/MapExternalGroupRequestTest.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2013-2016 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.cloudfoundry.uaa.groups;
+
+import org.junit.Test;
+
+public final class MapExternalGroupRequestTest {
+
+    @Test(expected = IllegalStateException.class)
+    public void noExternalGroup() {
+        MapExternalGroupRequest.builder()
+            .groupId("test-group-id")
+            .build();
+    }
+
+    @Test(expected = IllegalStateException.class)
+    public void noGroupId() {
+        MapExternalGroupRequest.builder()
+            .externalGroup("test-external-group")
+            .build();
+    }
+
+    @Test
+    public void valid() {
+        MapExternalGroupRequest.builder()
+            .groupId("test-group-id")
+            .externalGroup("test-external-group")
+            .build();
+    }
+
+}

--- a/cloudfoundry-client/src/test/java/org/cloudfoundry/uaa/groups/UnmapExternalGroupByGroupDisplayNameRequestTest.java
+++ b/cloudfoundry-client/src/test/java/org/cloudfoundry/uaa/groups/UnmapExternalGroupByGroupDisplayNameRequestTest.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright 2013-2016 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.cloudfoundry.uaa.groups;
+
+import org.junit.Test;
+
+public final class UnmapExternalGroupByGroupDisplayNameRequestTest {
+
+    @Test(expected = IllegalStateException.class)
+    public void noExternalGroup() {
+        UnmapExternalGroupByGroupDisplayNameRequest.builder()
+            .groupDisplayName("test-group-display-name")
+            .originKey("test-origin")
+            .build();
+    }
+
+    @Test(expected = IllegalStateException.class)
+    public void noGroupDisplayName() {
+        UnmapExternalGroupByGroupDisplayNameRequest.builder()
+            .externalGroup("test-external-group")
+            .originKey("test-origin")
+            .build();
+    }
+
+    @Test(expected = IllegalStateException.class)
+    public void noOriginKey() {
+        UnmapExternalGroupByGroupDisplayNameRequest.builder()
+            .groupDisplayName("test-group-display-name")
+            .externalGroup("test-external-group")
+            .build();
+    }
+
+    @Test
+    public void valid() {
+        UnmapExternalGroupByGroupDisplayNameRequest.builder()
+            .groupDisplayName("test-group-display-name")
+            .externalGroup("test-external-group")
+            .originKey("test-origin")
+            .build();
+    }
+
+}

--- a/cloudfoundry-client/src/test/java/org/cloudfoundry/uaa/groups/UnmapExternalGroupByGroupIdRequestTest.java
+++ b/cloudfoundry-client/src/test/java/org/cloudfoundry/uaa/groups/UnmapExternalGroupByGroupIdRequestTest.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright 2013-2016 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.cloudfoundry.uaa.groups;
+
+import org.junit.Test;
+
+public final class UnmapExternalGroupByGroupIdRequestTest {
+
+    @Test(expected = IllegalStateException.class)
+    public void noExternalGroup() {
+        UnmapExternalGroupByGroupIdRequest.builder()
+            .groupId("test-group-id")
+            .originKey("test-origin")
+            .build();
+    }
+
+    @Test(expected = IllegalStateException.class)
+    public void noGroupId() {
+        UnmapExternalGroupByGroupIdRequest.builder()
+            .externalGroup("test-external-group")
+            .originKey("test-origin")
+            .build();
+    }
+
+    @Test(expected = IllegalStateException.class)
+    public void noOriginKey() {
+        UnmapExternalGroupByGroupIdRequest.builder()
+            .groupId("test-group-id")
+            .externalGroup("test-external-group")
+            .build();
+    }
+
+    @Test
+    public void valid() {
+        UnmapExternalGroupByGroupIdRequest.builder()
+            .groupId("test-group-id")
+            .externalGroup("test-external-group")
+            .originKey("test-origin")
+            .build();
+    }
+
+}


### PR DESCRIPTION
This change brings the api to handle external group mapping
- [Map External Group](http://docs.cloudfoundry.com/uaa/#map)
- [Unmap by group id](http://docs.cloudfoundry.com/uaa/#by-group-id)
- [Unmap by group display name](http://docs.cloudfoundry.com/uaa/#by-group-display-name)
- [List external group mappings](http://docs.cloudfoundry.com/uaa/#by-group-display-name)

@nebhale Few notes:
Looking at [the source](https://github.com/cloudfoundry/uaa/blob/master/server/src/main/java/org/cloudfoundry/identity/uaa/scim/endpoints/ScimGroupEndpoints.java) showed me few mistakes in the documentation:
- at mapping phase, no `metadata` is asked. It is just the way they implement their requests as they expose thei inner model
- the list example is wrong, the result contains objetcs that have `metadata`.