### PR TITLE
Delete Identity Provider

### DIFF
--- a/cloudfoundry-client-spring/src/main/java/org/cloudfoundry/reactor/uaa/identityproviders/ReactorIdentityProviders.java
+++ b/cloudfoundry-client-spring/src/main/java/org/cloudfoundry/reactor/uaa/identityproviders/ReactorIdentityProviders.java
@@ -21,6 +21,8 @@ import org.cloudfoundry.reactor.uaa.AbstractUaaOperations;
 import org.cloudfoundry.reactor.util.AuthorizationProvider;
 import org.cloudfoundry.uaa.identityproviders.CreateIdentityProviderRequest;
 import org.cloudfoundry.uaa.identityproviders.CreateIdentityProviderResponse;
+import org.cloudfoundry.uaa.identityproviders.DeleteIdentityProviderRequest;
+import org.cloudfoundry.uaa.identityproviders.DeleteIdentityProviderResponse;
 import org.cloudfoundry.uaa.identityproviders.GetIdentityProviderRequest;
 import org.cloudfoundry.uaa.identityproviders.GetIdentityProviderResponse;
 import org.cloudfoundry.uaa.identityproviders.IdentityProviders;
@@ -51,6 +53,11 @@ public final class ReactorIdentityProviders extends AbstractUaaOperations implem
     @Override
     public Mono<CreateIdentityProviderResponse> create(CreateIdentityProviderRequest request) {
         return post(request, CreateIdentityProviderResponse.class, builder -> builder.pathSegment("identity-providers"));
+    }
+
+    @Override
+    public Mono<DeleteIdentityProviderResponse> delete(DeleteIdentityProviderRequest request) {
+        return delete(request, DeleteIdentityProviderResponse.class, builder -> builder.pathSegment("identity-providers", request.getIdentityProviderId()));
     }
 
     @Override

--- a/cloudfoundry-client-spring/src/test/resources/fixtures/uaa/identity-providers/DELETE_{id}_response.json
+++ b/cloudfoundry-client-spring/src/test/resources/fixtures/uaa/identity-providers/DELETE_{id}_response.json
@@ -1,0 +1,30 @@
+{
+  "type" : "saml",
+  "config" : {
+    "emailDomain" : null,
+    "additionalConfiguration" : null,
+    "providerDescription" : null,
+    "externalGroupsWhitelist" : [ ],
+    "attributeMappings" : { },
+    "metaDataLocation" : "<?xml version=\"1.0\" encoding=\"UTF-8\"?><md:EntityDescriptor xmlns:md=\"urn:oasis:names:tc:SAML:2.0:metadata\" entityID=\"http://www.okta.com/saml-for-delete\"><md:IDPSSODescriptor WantAuthnRequestsSigned=\"true\" protocolSupportEnumeration=\"urn:oasis:names:tc:SAML:2.0:protocol\"><md:KeyDescriptor use=\"signing\"><ds:KeyInfo xmlns:ds=\"http://www.w3.org/2000/09/xmldsig#\"><ds:X509Data><ds:X509Certificate>MIICmTCCAgKgAwIBAgIGAUPATqmEMA0GCSqGSIb3DQEBBQUAMIGPMQswCQYDVQQGEwJVUzETMBEG\nA1UECAwKQ2FsaWZvcm5pYTEWMBQGA1UEBwwNU2FuIEZyYW5jaXNjbzENMAsGA1UECgwET2t0YTEU\nMBIGA1UECwwLU1NPUHJvdmlkZXIxEDAOBgNVBAMMB1Bpdm90YWwxHDAaBgkqhkiG9w0BCQEWDWlu\nZm9Ab2t0YS5jb20wHhcNMTQwMTIzMTgxMjM3WhcNNDQwMTIzMTgxMzM3WjCBjzELMAkGA1UEBhMC\nVVMxEzARBgNVBAgMCkNhbGlmb3JuaWExFjAUBgNVBAcMDVNhbiBGcmFuY2lzY28xDTALBgNVBAoM\nBE9rdGExFDASBgNVBAsMC1NTT1Byb3ZpZGVyMRAwDgYDVQQDDAdQaXZvdGFsMRwwGgYJKoZIhvcN\nAQkBFg1pbmZvQG9rdGEuY29tMIGfMA0GCSqGSIb3DQEBAQUAA4GNADCBiQKBgQCeil67/TLOiTZU\nWWgW2XEGgFZ94bVO90v5J1XmcHMwL8v5Z/8qjdZLpGdwI7Ph0CyXMMNklpaR/Ljb8fsls3amdT5O\nBw92Zo8ulcpjw2wuezTwL0eC0wY/GQDAZiXL59npE6U+fH1lbJIq92hx0HJSru/0O1q3+A/+jjZL\n3tL/SwIDAQABMA0GCSqGSIb3DQEBBQUAA4GBAI5BoWZoH6Mz9vhypZPOJCEKa/K+biZQsA4Zqsuk\nvvphhSERhqk/Nv76Vkl8uvJwwHbQrR9KJx4L3PRkGCG24rix71jEuXVGZUsDNM3CUKnARx4MEab6\nGFHNkZ6DmoT/PFagngecHu+EwmuDtaG0rEkFrARwe+d8Ru0BN558abFb</ds:X509Certificate></ds:X509Data></ds:KeyInfo></md:KeyDescriptor><md:NameIDFormat>urn:oasis:names:tc:SAML:1.1:nameid-format:emailAddress</md:NameIDFormat><md:NameIDFormat>urn:oasis:names:tc:SAML:1.1:nameid-format:unspecified</md:NameIDFormat><md:SingleSignOnService Binding=\"urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST\" Location=\"https://pivotal.oktapreview.com/app/pivotal_pivotalcfstaging_1/k2lw4l5bPODCMIIDBRYZ/sso/saml\"/><md:SingleSignOnService Binding=\"urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Redirect\" Location=\"https://pivotal.oktapreview.com/app/pivotal_pivotalcfstaging_1/k2lw4l5bPODCMIIDBRYZ/sso/saml\"/></md:IDPSSODescriptor></md:EntityDescriptor>\n",
+    "idpEntityAlias" : "saml-for-delete",
+    "zoneId" : "uaa",
+    "nameID" : "urn:oasis:names:tc:SAML:1.1:nameid-format:emailAddress",
+    "assertionConsumerIndex" : 0,
+    "metadataTrustCheck" : false,
+    "showSamlLink" : false,
+    "socketFactoryClassName" : "org.apache.commons.httpclient.protocol.DefaultProtocolSocketFactory",
+    "linkText" : "IDPEndpointsMockTests Saml Provider:saml-for-delete",
+    "iconUrl" : null,
+    "addShadowUserOnLogin" : true,
+    "groupMappingMode" : "EXPLICITLY_MAPPED"
+  },
+  "id" : "3ba5978b-8db1-4f27-bfbd-f24f6773b52f",
+  "originKey" : "saml-for-delete",
+  "name" : "saml-for-delete name",
+  "version" : 0,
+  "created" : 1466035298319,
+  "last_modified" : 1466035298319,
+  "active" : true,
+  "identityZoneId" : "uaa"
+}

--- a/cloudfoundry-client-spring/src/test/resources/fixtures/uaa/identity-providers/POST_request_ldap.json
+++ b/cloudfoundry-client-spring/src/test/resources/fixtures/uaa/identity-providers/POST_request_ldap.json
@@ -7,7 +7,7 @@
     "skipSSLVerification" : false,
     "mailAttributeName" : "mail",
     "mailSubstituteOverridesLdap" : false,
-    "ldapGroupFile" : "ldap/ldap-groups-null.xml"
+    "ldapGroupFile" : "ldap/ldap-no-groups.xml"
   },
   "originKey" : "ldap",
   "name" : "ldap name",

--- a/cloudfoundry-client-spring/src/test/resources/fixtures/uaa/identity-providers/POST_response_ldap.json
+++ b/cloudfoundry-client-spring/src/test/resources/fixtures/uaa/identity-providers/POST_response_ldap.json
@@ -22,7 +22,7 @@
     "mailAttributeName": "mail",
     "mailSubstitute": null,
     "mailSubstituteOverridesLdap": false,
-    "ldapGroupFile": "ldap/ldap-groups-null.xml",
+    "ldapGroupFile": "ldap/ldap-no-groups.xml",
     "groupSearchBase": null,
     "groupSearchFilter": null,
     "groupsIgnorePartialResults": null,

--- a/cloudfoundry-client/src/main/java/org/cloudfoundry/uaa/identityproviders/IdentityProviders.java
+++ b/cloudfoundry-client/src/main/java/org/cloudfoundry/uaa/identityproviders/IdentityProviders.java
@@ -32,6 +32,14 @@ public interface IdentityProviders {
     Mono<CreateIdentityProviderResponse> create(CreateIdentityProviderRequest request);
 
     /**
+     * Makes the <a href="http://docs.cloudfoundry.com/uaa/#delete">Delete Identity Provider</a> request
+     *
+     * @param request the Delete Identity Provider request
+     * @return the response from the Delete Identity Provider request
+     */
+    Mono<DeleteIdentityProviderResponse> delete(DeleteIdentityProviderRequest request);
+
+    /**
      * Makes the <a href="http://docs.cloudfoundry.com/uaa/#retrieve">Get Identity Provider</a> request
      *
      * @param request the Get Identity Provider request

--- a/cloudfoundry-client/src/main/java/org/cloudfoundry/uaa/identityproviders/LdapGroupFile.java
+++ b/cloudfoundry-client/src/main/java/org/cloudfoundry/uaa/identityproviders/LdapGroupFile.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright 2013-2016 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.cloudfoundry.uaa.identityproviders;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonValue;
+
+/**
+ * The file to be used for group integration.
+ */
+public enum LdapGroupFile {
+    NoGroup("ldap/ldap-no-groups.xml"),
+
+    GroupsAsScopes("ldap/ldap-groups-as-scopes.xml"),
+
+    GroupsMapToScopes("ldap/ldap-groups-map-to-scopes.xml");
+
+    private final String value;
+
+    LdapGroupFile(String value) {
+        this.value = value;
+    }
+
+    @JsonValue
+    public String getValue() {
+        return this.value;
+    }
+
+    @Override
+    public String toString() {
+        return getValue();
+    }
+
+    @JsonCreator
+    static LdapGroupFile from(String s) {
+        switch (s.toLowerCase()) {
+            case "ldap/ldap-no-groups.xml":
+                return NoGroup;
+            case "ldap/ldap-groups-as-scopes.xml":
+                return GroupsAsScopes;
+            case "ldap/ldap-groups-map-to-scopes.xml":
+                return GroupsMapToScopes;
+            default:
+                throw new IllegalArgumentException(String.format("Unknown ldap group file: %s", s));
+        }
+    }
+
+}

--- a/cloudfoundry-client/src/main/java/org/cloudfoundry/uaa/identityproviders/LdapProfileFile.java
+++ b/cloudfoundry-client/src/main/java/org/cloudfoundry/uaa/identityproviders/LdapProfileFile.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright 2013-2016 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.cloudfoundry.uaa.identityproviders;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonValue;
+
+/**
+ * The file to be used for configuring the LDAP authentication.
+ */
+public enum LdapProfileFile {
+    SimpleBind("ldap/ldap-simple-bind.xml"),
+
+    SearchAndBind("ldap/ldap-search-and-bind.xml"),
+
+    SearchAndCompare("ldap/ldap-search-and-compare.xml");
+
+    private final String value;
+
+    LdapProfileFile(String value) {
+        this.value = value;
+    }
+
+    @JsonValue
+    public String getValue() {
+        return this.value;
+    }
+
+    @Override
+    public String toString() {
+        return getValue();
+    }
+
+    @JsonCreator
+    static LdapProfileFile from(String s) {
+        switch (s.toLowerCase()) {
+            case "ldap/ldap-simple-bind.xml":
+                return SimpleBind;
+            case "ldap/ldap-search-and-bind.xml":
+                return SearchAndBind;
+            case "ldap/ldap-search-and-compare.xml":
+                return SearchAndCompare;
+            default:
+                throw new IllegalArgumentException(String.format("Unknown ldap profile file: %s", s));
+        }
+    }
+
+}

--- a/cloudfoundry-client/src/main/java/org/cloudfoundry/uaa/identityproviders/_DeleteIdentityProviderRequest.java
+++ b/cloudfoundry-client/src/main/java/org/cloudfoundry/uaa/identityproviders/_DeleteIdentityProviderRequest.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2013-2016 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.cloudfoundry.uaa.identityproviders;
+
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import org.cloudfoundry.uaa.IdentityZoned;
+import org.immutables.value.Value;
+
+/**
+ * The request payload for the delete identity provider
+ */
+@Value.Immutable
+abstract class _DeleteIdentityProviderRequest implements IdentityZoned {
+
+    /**
+     * The identity provider id
+     */
+    @JsonIgnore
+    abstract String getIdentityProviderId();
+
+}

--- a/cloudfoundry-client/src/main/java/org/cloudfoundry/uaa/identityproviders/_DeleteIdentityProviderResponse.java
+++ b/cloudfoundry-client/src/main/java/org/cloudfoundry/uaa/identityproviders/_DeleteIdentityProviderResponse.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright 2013-2016 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.cloudfoundry.uaa.identityproviders;
+
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import org.immutables.value.Value;
+
+/**
+ * The response from the delete identity provider request
+ */
+@JsonDeserialize
+@Value.Immutable
+abstract class _DeleteIdentityProviderResponse extends AbstractIdentityProvider {
+
+}

--- a/cloudfoundry-client/src/main/java/org/cloudfoundry/uaa/identityproviders/_LdapConfiguration.java
+++ b/cloudfoundry-client/src/main/java/org/cloudfoundry/uaa/identityproviders/_LdapConfiguration.java
@@ -98,16 +98,16 @@ abstract class _LdapConfiguration extends AbstractExternalIdentityProviderConfig
     abstract Boolean getGroupsIgnorePartialResults();
 
     /**
-     * The file to be used for group integration. Options are: ldap/ldap-no-groups.xml, ldap/ldap-groups-as-scopes.xml, ldap/ldap-groups-map-to-scopes.xml
+     * The file to be used for group integration.
      */
     @JsonProperty("ldapGroupFile")
-    abstract String getLdapGroupFile();
+    abstract LdapGroupFile getLdapGroupFile();
 
     /**
-     * The file to be used for configuring the LDAP authentication. Options are: ldap/ldap-simple-bind.xml, ldap/ldap-search-and-bind.xml, ldap/ldap-search-and-compare.xml
+     * The file to be used for configuring the LDAP authentication.
      */
     @JsonProperty("ldapProfileFile")
-    abstract String getLdapProfileFile();
+    abstract LdapProfileFile getLdapProfileFile();
 
     /**
      *

--- a/cloudfoundry-client/src/test/java/org/cloudfoundry/uaa/identityproviders/DeleteIdentityProviderRequestTest.java
+++ b/cloudfoundry-client/src/test/java/org/cloudfoundry/uaa/identityproviders/DeleteIdentityProviderRequestTest.java
@@ -18,38 +18,27 @@ package org.cloudfoundry.uaa.identityproviders;
 
 import org.junit.Test;
 
-public final class LdapConfigurationTest {
+public final class DeleteIdentityProviderRequestTest {
 
     @Test(expected = IllegalStateException.class)
-    public void noBaseUrl() {
-        LdapConfiguration.builder()
-            .ldapProfileFile(LdapProfileFile.SimpleBind)
-            .ldapGroupFile(LdapGroupFile.NoGroup)
+    public void noIdentityProviderId() {
+        DeleteIdentityProviderRequest.builder()
+            .identityZoneId("test-identity-zone-id")
             .build();
     }
 
     @Test(expected = IllegalStateException.class)
-    public void noLdapGroupFile() {
-        LdapConfiguration.builder()
-            .ldapProfileFile(LdapProfileFile.SimpleBind)
-            .baseUrl("test-base-url")
-            .build();
-    }
-
-    @Test(expected = IllegalStateException.class)
-    public void noLdapProfileFile() {
-        LdapConfiguration.builder()
-            .ldapGroupFile(LdapGroupFile.NoGroup)
-            .baseUrl("test-base-url")
+    public void noIdentityZoneId() {
+        DeleteIdentityProviderRequest.builder()
+            .identityProviderId("test-identity-provider-id")
             .build();
     }
 
     @Test
     public void valid() {
-        LdapConfiguration.builder()
-            .ldapProfileFile(LdapProfileFile.SimpleBind)
-            .ldapGroupFile(LdapGroupFile.NoGroup)
-            .baseUrl("test-base-url")
+        DeleteIdentityProviderRequest.builder()
+            .identityProviderId("test-identity-provider-id")
+            .identityZoneId("test-identity-zone-id")
             .build();
     }
 


### PR DESCRIPTION
This change brings the api to delete an identity provider (`DELETE /identity-providers/:id)

see [doc](http://docs.cloudfoundry.com/uaa/#delete)
and [story](https://www.pivotaltracker.com/projects/816799/stories/114245629)
@zteve: Guess you were right about not taking all the stories in a single motion but start them one by one: I started this one with the other, forgot to implement it and the story was accezpted.
By starting one story once I really start implementing it will prevent from getting this scenario again. Sorry.
I also implemented two `enum`for the `Ldap`configuration