### PR TITLE
 Delete Security Group

### DIFF
--- a/cloudfoundry-client-spring/src/main/java/org/cloudfoundry/reactor/client/v2/securitygroups/ReactorSecurityGroups.java
+++ b/cloudfoundry-client-spring/src/main/java/org/cloudfoundry/reactor/client/v2/securitygroups/ReactorSecurityGroups.java
@@ -19,6 +19,8 @@ package org.cloudfoundry.reactor.client.v2.securitygroups;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.cloudfoundry.client.v2.securitygroups.CreateSecurityGroupRequest;
 import org.cloudfoundry.client.v2.securitygroups.CreateSecurityGroupResponse;
+import org.cloudfoundry.client.v2.securitygroups.DeleteSecurityGroupRequest;
+import org.cloudfoundry.client.v2.securitygroups.DeleteSecurityGroupResponse;
 import org.cloudfoundry.client.v2.securitygroups.DeleteSecurityGroupRunningDefaultRequest;
 import org.cloudfoundry.client.v2.securitygroups.DeleteSecurityGroupStagingDefaultRequest;
 import org.cloudfoundry.client.v2.securitygroups.ListSecurityGroupRunningDefaultsRequest;
@@ -85,6 +87,11 @@ public class ReactorSecurityGroups extends AbstractClientV2Operations implements
     @Override
     public Mono<CreateSecurityGroupResponse> create(CreateSecurityGroupRequest request) {
         return post(request, CreateSecurityGroupResponse.class, builder -> builder.pathSegment("v2", "security_groups"));
+    }
+
+    @Override
+    public Mono<DeleteSecurityGroupResponse> delete(DeleteSecurityGroupRequest request) {
+        return delete(request, DeleteSecurityGroupResponse.class, builder -> builder.pathSegment("v2", "security_groups", request.getSecurityGroupId()));
     }
 
 }

--- a/cloudfoundry-client-spring/src/test/java/org/cloudfoundry/reactor/client/v2/securitygroups/ReactorSecurityGroupsTest.java
+++ b/cloudfoundry-client-spring/src/test/java/org/cloudfoundry/reactor/client/v2/securitygroups/ReactorSecurityGroupsTest.java
@@ -17,8 +17,11 @@
 package org.cloudfoundry.reactor.client.v2.securitygroups;
 
 import org.cloudfoundry.client.v2.Metadata;
+import org.cloudfoundry.client.v2.jobs.JobEntity;
 import org.cloudfoundry.client.v2.securitygroups.CreateSecurityGroupRequest;
 import org.cloudfoundry.client.v2.securitygroups.CreateSecurityGroupResponse;
+import org.cloudfoundry.client.v2.securitygroups.DeleteSecurityGroupRequest;
+import org.cloudfoundry.client.v2.securitygroups.DeleteSecurityGroupResponse;
 import org.cloudfoundry.client.v2.securitygroups.DeleteSecurityGroupRunningDefaultRequest;
 import org.cloudfoundry.client.v2.securitygroups.DeleteSecurityGroupStagingDefaultRequest;
 import org.cloudfoundry.client.v2.securitygroups.ListSecurityGroupRunningDefaultsRequest;
@@ -42,6 +45,7 @@ import static io.netty.handler.codec.http.HttpMethod.DELETE;
 import static io.netty.handler.codec.http.HttpMethod.GET;
 import static io.netty.handler.codec.http.HttpMethod.POST;
 import static io.netty.handler.codec.http.HttpMethod.PUT;
+import static io.netty.handler.codec.http.HttpResponseStatus.ACCEPTED;
 import static io.netty.handler.codec.http.HttpResponseStatus.NO_CONTENT;
 import static io.netty.handler.codec.http.HttpResponseStatus.OK;
 
@@ -420,6 +424,87 @@ public final class ReactorSecurityGroupsTest {
             return this.securityGroups.create(request);
         }
 
+    }
+
+    public static final class Delete extends AbstractClientApiTest<DeleteSecurityGroupRequest, DeleteSecurityGroupResponse> {
+
+        private final ReactorSecurityGroups securityGroups = new ReactorSecurityGroups(AUTHORIZATION_PROVIDER, HTTP_CLIENT, OBJECT_MAPPER, this.root);
+
+        @Override
+        protected InteractionContext getInteractionContext() {
+            return InteractionContext.builder()
+                .request(TestRequest.builder()
+                    .method(DELETE).path("/v2/security_groups/test-id")
+                    .build())
+                .response(TestResponse.builder()
+                    .status(NO_CONTENT)
+                    .build())
+                .build();
+        }
+
+        @Override
+        protected DeleteSecurityGroupResponse getResponse() {
+            return null;
+        }
+
+        @Override
+        protected DeleteSecurityGroupRequest getValidRequest() throws Exception {
+            return DeleteSecurityGroupRequest.builder()
+                .securityGroupId("test-id")
+                .build();
+        }
+
+        @Override
+        protected Mono<DeleteSecurityGroupResponse> invoke(DeleteSecurityGroupRequest request) {
+            return this.securityGroups.delete(request);
+        }
+
+    }
+
+    public static final class DeleteAsync extends AbstractClientApiTest<DeleteSecurityGroupRequest, DeleteSecurityGroupResponse> {
+
+        private final ReactorSecurityGroups domains = new ReactorSecurityGroups(AUTHORIZATION_PROVIDER, HTTP_CLIENT, OBJECT_MAPPER, this.root);
+
+        @Override
+        protected InteractionContext getInteractionContext() {
+            return InteractionContext.builder()
+                .request(TestRequest.builder()
+                    .method(DELETE).path("/v2/security_groups/test-id?async=true")
+                    .build())
+                .response(TestResponse.builder()
+                    .status(ACCEPTED)
+                    .payload("fixtures/client/v2/security_groups/DELETE_{id}_async_response.json")
+                    .build())
+                .build();
+        }
+
+        @Override
+        protected DeleteSecurityGroupResponse getResponse() {
+            return DeleteSecurityGroupResponse.builder()
+                .metadata(Metadata.builder()
+                    .id("260ba675-47b6-4094-be7a-349d58e3d36a")
+                    .createdAt("2016-02-02T17:16:31Z")
+                    .url("/v2/jobs/260ba675-47b6-4094-be7a-349d58e3d36a")
+                    .build())
+                .entity(JobEntity.builder()
+                    .id("260ba675-47b6-4094-be7a-349d58e3d36a")
+                    .status("queued")
+                    .build())
+                .build();
+        }
+
+        @Override
+        protected DeleteSecurityGroupRequest getValidRequest() throws Exception {
+            return DeleteSecurityGroupRequest.builder()
+                .async(true)
+                .securityGroupId("test-id")
+                .build();
+        }
+
+        @Override
+        protected Mono<DeleteSecurityGroupResponse> invoke(DeleteSecurityGroupRequest request) {
+            return this.domains.delete(request);
+        }
     }
 
 }

--- a/cloudfoundry-client-spring/src/test/resources/fixtures/client/v2/security_groups/DELETE_{id}_async_response.json
+++ b/cloudfoundry-client-spring/src/test/resources/fixtures/client/v2/security_groups/DELETE_{id}_async_response.json
@@ -1,0 +1,11 @@
+{
+  "metadata": {
+    "guid": "260ba675-47b6-4094-be7a-349d58e3d36a",
+    "created_at": "2016-02-02T17:16:31Z",
+    "url": "/v2/jobs/260ba675-47b6-4094-be7a-349d58e3d36a"
+  },
+  "entity": {
+    "guid": "260ba675-47b6-4094-be7a-349d58e3d36a",
+    "status": "queued"
+  }
+}

--- a/cloudfoundry-client/src/main/java/org/cloudfoundry/client/v2/securitygroups/SecurityGroups.java
+++ b/cloudfoundry-client/src/main/java/org/cloudfoundry/client/v2/securitygroups/SecurityGroups.java
@@ -80,4 +80,12 @@ public interface SecurityGroups {
      * @return the response from the create security group request
      */
     Mono<CreateSecurityGroupResponse> create(CreateSecurityGroupRequest request);
+
+    /**
+     * Makes the <a href="http://apidocs.cloudfoundry.org/latest-release/security_groups/delete_a_particular_security_group.html">Delete a Particular Security Group</a> request.
+     *
+     * @param request the delete security group request
+     * @return the response from the delete security group request
+     */
+    Mono<DeleteSecurityGroupResponse> delete(DeleteSecurityGroupRequest request);
 }

--- a/cloudfoundry-client/src/main/java/org/cloudfoundry/client/v2/securitygroups/_DeleteSecurityGroupRequest.java
+++ b/cloudfoundry-client/src/main/java/org/cloudfoundry/client/v2/securitygroups/_DeleteSecurityGroupRequest.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2013-2016 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.cloudfoundry.client.v2.securitygroups;
+
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import org.cloudfoundry.Nullable;
+import org.cloudfoundry.QueryParameter;
+import org.immutables.value.Value;
+
+/**
+ * The request payload for the Delete Security Group operation
+ */
+@Value.Immutable
+abstract class _DeleteSecurityGroupRequest {
+
+    /**
+     * The security group id
+     */
+    @JsonIgnore
+    abstract String getSecurityGroupId();
+
+    /**
+     * The async flag
+     */
+    @QueryParameter("async")
+    @Nullable
+    abstract Boolean getAsync();
+
+}

--- a/cloudfoundry-client/src/main/java/org/cloudfoundry/client/v2/securitygroups/_DeleteSecurityGroupResponse.java
+++ b/cloudfoundry-client/src/main/java/org/cloudfoundry/client/v2/securitygroups/_DeleteSecurityGroupResponse.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2013-2016 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.cloudfoundry.client.v2.securitygroups;
+
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import org.cloudfoundry.client.v2.jobs.AbstractJobResource;
+import org.immutables.value.Value;
+
+/**
+ * The response payload for the Delete Security Group operation
+ */
+@JsonDeserialize
+@Value.Immutable
+abstract class _DeleteSecurityGroupResponse extends AbstractJobResource {
+
+}

--- a/cloudfoundry-client/src/test/java/org/cloudfoundry/client/v2/securitygroups/DeleteSecurityGroupRequestTest.java
+++ b/cloudfoundry-client/src/test/java/org/cloudfoundry/client/v2/securitygroups/DeleteSecurityGroupRequestTest.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2013-2016 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.cloudfoundry.client.v2.securitygroups;
+
+import org.junit.Test;
+
+public final class DeleteSecurityGroupRequestTest {
+
+    @Test(expected = IllegalStateException.class)
+    public void noSecurityGroupId() {
+        DeleteSecurityGroupRequest.builder()
+            .build();
+    }
+
+    @Test
+    public void valid() {
+        DeleteSecurityGroupRequest.builder()
+            .securityGroupId("test-security-group-default-id")
+            .build();
+    }
+
+}


### PR DESCRIPTION
This change adds the API to delete a particular security group (DELETE /v2/security_groups/:guid?)

[#101522658][#509]