### PR TITLE
Create Client

### DIFF
--- a/cloudfoundry-client-reactor/src/main/java/org/cloudfoundry/reactor/uaa/clients/ReactorClients.java
+++ b/cloudfoundry-client-reactor/src/main/java/org/cloudfoundry/reactor/uaa/clients/ReactorClients.java
@@ -20,6 +20,8 @@ import org.cloudfoundry.reactor.ConnectionContext;
 import org.cloudfoundry.reactor.TokenProvider;
 import org.cloudfoundry.reactor.uaa.AbstractUaaOperations;
 import org.cloudfoundry.uaa.clients.Clients;
+import org.cloudfoundry.uaa.clients.CreateClientRequest;
+import org.cloudfoundry.uaa.clients.CreateClientResponse;
 import org.cloudfoundry.uaa.clients.GetClientRequest;
 import org.cloudfoundry.uaa.clients.GetClientResponse;
 import reactor.core.publisher.Mono;
@@ -38,6 +40,11 @@ public final class ReactorClients extends AbstractUaaOperations implements Clien
      */
     public ReactorClients(ConnectionContext connectionContext, Mono<String> root, TokenProvider tokenProvider) {
         super(connectionContext, root, tokenProvider);
+    }
+
+    @Override
+    public Mono<CreateClientResponse> create(CreateClientRequest request) {
+        return post(request, CreateClientResponse.class, builder -> builder.pathSegment("oauth", "clients"));
     }
 
     @Override

--- a/cloudfoundry-client-reactor/src/test/java/org/cloudfoundry/reactor/uaa/clients/ReactorClientsTest.java
+++ b/cloudfoundry-client-reactor/src/test/java/org/cloudfoundry/reactor/uaa/clients/ReactorClientsTest.java
@@ -20,14 +20,85 @@ import org.cloudfoundry.reactor.InteractionContext;
 import org.cloudfoundry.reactor.TestRequest;
 import org.cloudfoundry.reactor.TestResponse;
 import org.cloudfoundry.reactor.uaa.AbstractUaaApiTest;
+import org.cloudfoundry.uaa.clients.CreateClientRequest;
+import org.cloudfoundry.uaa.clients.CreateClientResponse;
 import org.cloudfoundry.uaa.clients.GetClientRequest;
 import org.cloudfoundry.uaa.clients.GetClientResponse;
 import reactor.core.publisher.Mono;
 
 import static io.netty.handler.codec.http.HttpMethod.GET;
+import static io.netty.handler.codec.http.HttpMethod.POST;
+import static io.netty.handler.codec.http.HttpResponseStatus.CREATED;
 import static io.netty.handler.codec.http.HttpResponseStatus.OK;
 
 public final class ReactorClientsTest {
+
+    public static final class Create extends AbstractUaaApiTest<CreateClientRequest, CreateClientResponse> {
+
+        private final ReactorClients clients = new ReactorClients(CONNECTION_CONTEXT, this.root, TOKEN_PROVIDER);
+
+        @Override
+        protected InteractionContext getInteractionContext() {
+            return InteractionContext.builder()
+                .request(TestRequest.builder()
+                    .method(POST).path("/oauth/clients")
+                    .payload("fixtures/uaa/clients/POST_request.json")
+                    .build())
+                .response(TestResponse.builder()
+                    .status(CREATED)
+                    .payload("fixtures/uaa/clients/POST_response.json")
+                    .build())
+                .build();
+        }
+
+        @Override
+        protected CreateClientResponse getResponse() {
+            return CreateClientResponse.builder()
+                .allowedProvider("uaa")
+                .allowedProvider("ldap")
+                .allowedProvider("my-saml-provider")
+                .authority("clients.read")
+                .authority("clients.write")
+                .authorizedGrantType("client_credentials")
+                .autoApprove("true")
+                .clientId("aPq3I1")
+                .lastModified(1468364445109L)
+                .name("My Client Name")
+                .redirectUriPattern("http*://ant.path.wildcard/**/passback/*")
+                .redirectUriPattern("http://test1.com")
+                .resourceId("none")
+                .scope("clients.read")
+                .scope("clients.write")
+                .tokenSalt("hRZ21X")
+                .build();
+        }
+
+        @Override
+        protected CreateClientRequest getValidRequest() throws Exception {
+            return CreateClientRequest.builder()
+                .allowedProvider("uaa")
+                .allowedProvider("ldap")
+                .allowedProvider("my-saml-provider")
+                .authority("clients.read")
+                .authority("clients.write")
+                .authorizedGrantType("client_credentials")
+                .autoApprove("true")
+                .clientId("aPq3I1")
+                .clientSecret("secret")
+                .name("My Client Name")
+                .redirectUriPattern("http://test1.com")
+                .redirectUriPattern("http*://ant.path.wildcard/**/passback/*")
+                .scope("clients.read")
+                .scope("clients.write")
+                .tokenSalt("hRZ21X")
+                .build();
+        }
+
+        @Override
+        protected Mono<CreateClientResponse> invoke(CreateClientRequest request) {
+            return this.clients.create(request);
+        }
+    }
 
     public static final class Get extends AbstractUaaApiTest<GetClientRequest, GetClientResponse> {
 

--- a/cloudfoundry-client-reactor/src/test/resources/fixtures/uaa/clients/POST_request.json
+++ b/cloudfoundry-client-reactor/src/test/resources/fixtures/uaa/clients/POST_request.json
@@ -1,0 +1,30 @@
+{
+  "allowedproviders": [
+    "uaa",
+    "ldap",
+    "my-saml-provider"
+  ],
+  "authorities": [
+    "clients.read",
+    "clients.write"
+  ],
+  "authorized_grant_types": [
+    "client_credentials"
+  ],
+  "autoapprove": [
+    "true"
+  ],
+  "client_id": "aPq3I1",
+  "client_secret": "secret",
+  "name": "My Client Name",
+  "redirect_uri": [
+    "http://test1.com",
+    "http*://ant.path.wildcard/**/passback/*"
+  ],
+  "resource_ids": [],
+  "scope": [
+    "clients.read",
+    "clients.write"
+  ],
+  "token_salt": "hRZ21X"
+}

--- a/cloudfoundry-client-reactor/src/test/resources/fixtures/uaa/clients/POST_response.json
+++ b/cloudfoundry-client-reactor/src/test/resources/fixtures/uaa/clients/POST_response.json
@@ -1,0 +1,32 @@
+{
+  "scope": [
+    "clients.read",
+    "clients.write"
+  ],
+  "client_id": "aPq3I1",
+  "resource_ids": [
+    "none"
+  ],
+  "authorized_grant_types": [
+    "client_credentials"
+  ],
+  "redirect_uri": [
+    "http*://ant.path.wildcard/**/passback/*",
+    "http://test1.com"
+  ],
+  "autoapprove": [
+    "true"
+  ],
+  "authorities": [
+    "clients.read",
+    "clients.write"
+  ],
+  "token_salt": "hRZ21X",
+  "allowedproviders": [
+    "uaa",
+    "ldap",
+    "my-saml-provider"
+  ],
+  "name": "My Client Name",
+  "lastModified": 1468364445109
+}

--- a/cloudfoundry-client/src/main/java/org/cloudfoundry/uaa/clients/_CreateClientRequest.java
+++ b/cloudfoundry-client/src/main/java/org/cloudfoundry/uaa/clients/_CreateClientRequest.java
@@ -1,0 +1,116 @@
+/*
+ * Copyright 2013-2016 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.cloudfoundry.uaa.clients;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import org.cloudfoundry.Nullable;
+import org.cloudfoundry.uaa.IdentityZoned;
+import org.immutables.value.Value;
+
+import java.util.List;
+
+/**
+ * The request payload for the create client
+ */
+@Value.Immutable
+abstract class _CreateClientRequest implements IdentityZoned {
+
+    /**
+     * A list of origin keys (alias) for identity providers the client is limited to. Null implies any identity provider is allowed.
+     */
+    @JsonProperty("allowedproviders")
+    abstract List<String> getAllowedProviders();
+
+    /**
+     * Were the approvals deleted for the client, and an audit event sent
+     */
+    @JsonProperty("approvals_deleted")
+    @Nullable
+    abstract Boolean getApprovalsDeleted();
+
+    /**
+     * Scopes that the client is able to grant when creating a client
+     */
+    @JsonProperty("authorities")
+    abstract List<String> getAuthorities();
+
+    /**
+     * List of grant types that can be used to obtain a token with this client. Can include authorization_code, password, implicit, and/or client_credentials.
+     */
+    @JsonProperty("authorized_grant_types")
+    abstract List<String> getAuthorizedGrantTypes();
+
+    /**
+     * Scopes that do not require user approval
+     */
+    @JsonProperty("autoapprove")
+    abstract List<String> getAutoApproves();
+
+    /**
+     * Client identifier, unique within identity zone
+     */
+    @JsonProperty("client_id")
+    abstract String getClientId();
+
+    /**
+     * A secret string used for authenticating as this client
+     */
+    @JsonProperty("client_secret")
+    @Nullable
+    abstract String getClientSecret();
+
+    /**
+     * What scope the bearer token had when client was created
+     */
+    @JsonProperty("createdwith")
+    @Nullable
+    abstract String getCreatedWith();
+
+    /**
+     * A human readable name for the client
+     */
+    @JsonProperty("name")
+    @Nullable
+    abstract String getName();
+
+    /**
+     * Allowed URI pattern for redirect during authorization
+     */
+    @JsonProperty("redirect_uri")
+    abstract List<String> getRedirectUriPatterns();
+
+    /**
+     * Resources the client is allowed access to
+     */
+    @JsonProperty("resource_ids")
+    abstract List<String> getResourceIds();
+
+    /**
+     * Scopes allowed for the client
+     */
+    @JsonProperty("scope")
+    abstract List<String> getScopes();
+
+    /**
+     * A random string used to generate the client’s revokation key. Change this value to revoke all active tokens for the client
+     */
+    @JsonProperty("token_salt")
+    @Nullable
+    abstract String getTokenSalt();
+
+
+}

--- a/cloudfoundry-client/src/main/java/org/cloudfoundry/uaa/clients/_CreateClientResponse.java
+++ b/cloudfoundry-client/src/main/java/org/cloudfoundry/uaa/clients/_CreateClientResponse.java
@@ -16,27 +16,14 @@
 
 package org.cloudfoundry.uaa.clients;
 
-import reactor.core.publisher.Mono;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import org.immutables.value.Value;
 
 /**
- * Main entry point to the UAA Clients API
+ * The response from the create client request
  */
-public interface Clients {
-
-    /**
-     * Makes the <a href="">Create Client</a> request
-     *
-     * @param request Create Client request
-     * @return the Response to the Create Client Request
-     */
-    Mono<CreateClientResponse> create(CreateClientRequest request);
-
-    /**
-     * Makes the <a href="http://docs.cloudfoundry.com/uaa/#retrieve77">Retrieve Client</a> request
-     *
-     * @param request Retrieve Client request
-     * @return the Response to the Retrieve Client Request
-     */
-    Mono<GetClientResponse> get(GetClientRequest request);
+@JsonDeserialize
+@Value.Immutable
+abstract class _CreateClientResponse extends AbstractClient {
 
 }

--- a/cloudfoundry-client/src/main/java/org/cloudfoundry/uaa/clients/_GetClientResponse.java
+++ b/cloudfoundry-client/src/main/java/org/cloudfoundry/uaa/clients/_GetClientResponse.java
@@ -20,7 +20,7 @@ import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import org.immutables.value.Value;
 
 /**
- * The response from the get group request
+ * The response from the get client request
  */
 @JsonDeserialize
 @Value.Immutable

--- a/cloudfoundry-client/src/test/java/org/cloudfoundry/uaa/clients/CreateClientRequestTest.java
+++ b/cloudfoundry-client/src/test/java/org/cloudfoundry/uaa/clients/CreateClientRequestTest.java
@@ -16,27 +16,21 @@
 
 package org.cloudfoundry.uaa.clients;
 
-import reactor.core.publisher.Mono;
+import org.junit.Test;
 
-/**
- * Main entry point to the UAA Clients API
- */
-public interface Clients {
+public final class CreateClientRequestTest {
 
-    /**
-     * Makes the <a href="">Create Client</a> request
-     *
-     * @param request Create Client request
-     * @return the Response to the Create Client Request
-     */
-    Mono<CreateClientResponse> create(CreateClientRequest request);
+    @Test(expected = IllegalStateException.class)
+    public void noId() {
+        CreateClientRequest.builder()
+            .build();
+    }
 
-    /**
-     * Makes the <a href="http://docs.cloudfoundry.com/uaa/#retrieve77">Retrieve Client</a> request
-     *
-     * @param request Retrieve Client request
-     * @return the Response to the Retrieve Client Request
-     */
-    Mono<GetClientResponse> get(GetClientRequest request);
+    @Test
+    public void valid() {
+        CreateClientRequest.builder()
+            .clientId("test-client-id")
+            .build();
+    }
 
 }


### PR DESCRIPTION
This change brings the api to create a client (POST `/oauth/clients`)
@twoseat @nebhale I spotted a little issue in the [documentation](http://docs.cloudfoundry.com/uaa/#create76): in the example, the `autoapprove`, supposed to be an `Array` of `String` (I checked their code), is set with a `boolean` value... 
