### PR TITLE
Fix add member implementation

### DIFF
--- a/cloudfoundry-client/src/main/java/org/cloudfoundry/uaa/groups/_AddMemberRequest.java
+++ b/cloudfoundry-client/src/main/java/org/cloudfoundry/uaa/groups/_AddMemberRequest.java
@@ -17,6 +17,7 @@
 package org.cloudfoundry.uaa.groups;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import org.cloudfoundry.uaa.IdentityZoned;
 import org.immutables.value.Value;
@@ -26,12 +27,30 @@ import org.immutables.value.Value;
  */
 @JsonDeserialize
 @Value.Immutable
-abstract class _AddMemberRequest extends AbstractMember implements IdentityZoned {
+abstract class _AddMemberRequest implements IdentityZoned {
 
     /**
      * The group id
      */
     @JsonIgnore
     abstract String getGroupId();
+
+    /**
+     * Globally unique identifier of the member, either a user ID or another group ID
+     */
+    @JsonProperty("value")
+    abstract String getMemberId();
+
+    /**
+     * The alias of the identity provider that authenticated this user. "uaa" is an internal UAA user.
+     */
+    @JsonProperty("origin")
+    abstract String getOrigin();
+
+    /**
+     * The member type
+     */
+    @JsonProperty("type")
+    abstract MemberType getType();
 
 }

--- a/cloudfoundry-client/src/test/java/org/cloudfoundry/uaa/groups/AddMemberRequestTest.java
+++ b/cloudfoundry-client/src/test/java/org/cloudfoundry/uaa/groups/AddMemberRequestTest.java
@@ -23,7 +23,9 @@ public final class AddMemberRequestTest {
     @Test(expected = IllegalStateException.class)
     public void noGroupId() {
         AddMemberRequest.builder()
+            .origin("test-origin")
             .memberId("test-member-id")
+            .type(MemberType.USER)
             .build();
     }
 
@@ -31,6 +33,26 @@ public final class AddMemberRequestTest {
     public void noMemberId() {
         AddMemberRequest.builder()
             .groupId("test-group-id")
+            .origin("test-origin")
+            .type(MemberType.USER)
+            .build();
+    }
+
+    @Test(expected = IllegalStateException.class)
+    public void noOrigin() {
+        AddMemberRequest.builder()
+            .groupId("test-group-id")
+            .memberId("test-member-id")
+            .type(MemberType.USER)
+            .build();
+    }
+
+    @Test(expected = IllegalStateException.class)
+    public void noType() {
+        AddMemberRequest.builder()
+            .groupId("test-group-id")
+            .memberId("test-member-id")
+            .origin("test-origin")
             .build();
     }
 
@@ -39,6 +61,8 @@ public final class AddMemberRequestTest {
         AddMemberRequest.builder()
             .groupId("test-group-id")
             .memberId("test-member-id")
+            .origin("test-origin")
+            .type(MemberType.USER)
             .build();
     }
 


### PR DESCRIPTION
The current implementation of the `AddMemberRequest` did not illustrate the fact that all parameters are required
See [the documentation](http://docs.cloudfoundry.com/uaa/#add-member)