### PR TITLE
Fix Create/Update client requests

### DIFF
--- a/cloudfoundry-client-reactor/src/test/resources/fixtures/uaa/clients/POST_request.json
+++ b/cloudfoundry-client-reactor/src/test/resources/fixtures/uaa/clients/POST_request.json
@@ -21,7 +21,6 @@
     "http://test1.com",
     "http*://ant.path.wildcard/**/passback/*"
   ],
-  "resource_ids": [],
   "scope": [
     "clients.read",
     "clients.write"

--- a/cloudfoundry-client/src/main/java/org/cloudfoundry/uaa/clients/_CreateClientRequest.java
+++ b/cloudfoundry-client/src/main/java/org/cloudfoundry/uaa/clients/_CreateClientRequest.java
@@ -30,10 +30,18 @@ import java.util.List;
 @Value.Immutable
 abstract class _CreateClientRequest implements IdentityZoned {
 
+    @Value.Check
+    void checkAuthorizedGrantType() {
+        if (this.getAuthorizedGrantTypes() == null) {
+            throw new IllegalStateException("authorizedGrantTypes must be set");
+        }
+    }
+
     /**
      * A list of origin keys (alias) for identity providers the client is limited to. Null implies any identity provider is allowed.
      */
     @JsonProperty("allowedproviders")
+    @Nullable
     abstract List<String> getAllowedProviders();
 
     /**
@@ -47,18 +55,21 @@ abstract class _CreateClientRequest implements IdentityZoned {
      * Scopes that the client is able to grant when creating a client
      */
     @JsonProperty("authorities")
+    @Nullable
     abstract List<String> getAuthorities();
 
     /**
      * List of grant types that can be used to obtain a token with this client. Can include authorization_code, password, implicit, and/or client_credentials.
      */
     @JsonProperty("authorized_grant_types")
+    @Nullable
     abstract List<GrantType> getAuthorizedGrantTypes();
 
     /**
      * Scopes that do not require user approval
      */
     @JsonProperty("autoapprove")
+    @Nullable
     abstract List<String> getAutoApproves();
 
     /**
@@ -92,18 +103,21 @@ abstract class _CreateClientRequest implements IdentityZoned {
      * Allowed URI pattern for redirect during authorization
      */
     @JsonProperty("redirect_uri")
+    @Nullable
     abstract List<String> getRedirectUriPatterns();
 
     /**
      * Resources the client is allowed access to
      */
     @JsonProperty("resource_ids")
+    @Nullable
     abstract List<String> getResourceIds();
 
     /**
      * Scopes allowed for the client
      */
     @JsonProperty("scope")
+    @Nullable
     abstract List<String> getScopes();
 
     /**

--- a/cloudfoundry-client/src/main/java/org/cloudfoundry/uaa/clients/_UpdateClientRequest.java
+++ b/cloudfoundry-client/src/main/java/org/cloudfoundry/uaa/clients/_UpdateClientRequest.java
@@ -30,38 +30,46 @@ import java.util.List;
 @Value.Immutable
 abstract class _UpdateClientRequest implements IdentityZoned {
 
+    @Value.Check
+    void checkAuthorizedGrantType() {
+        if (this.getAuthorizedGrantTypes() == null) {
+            throw new IllegalStateException("authorizedGrantTypes must be set");
+        }
+    }
+
     /**
      * A list of origin keys (alias) for identity providers the client is limited to. Null implies any identity provider is allowed.
      */
-    @Nullable
     @JsonProperty("allowedproviders")
+    @Nullable
     abstract List<String> getAllowedProviders();
 
     /**
      * Were the approvals deleted for the client, and an audit event sent
      */
-    @Nullable
     @JsonProperty("approvals_deleted")
+    @Nullable
     abstract Boolean getApprovalsDeleted();
 
     /**
      * Scopes that the client is able to grant when creating a client
      */
-    @Nullable
     @JsonProperty("authorities")
+    @Nullable
     abstract List<String> getAuthorities();
 
     /**
      * List of grant types that can be used to obtain a token with this client. Can include authorization_code, password, implicit, and/or client_credentials.
      */
     @JsonProperty("authorized_grant_types")
+    @Nullable
     abstract List<GrantType> getAuthorizedGrantTypes();
 
     /**
      * Scopes that do not require user approval
      */
-    @Nullable
     @JsonProperty("autoapprove")
+    @Nullable
     abstract List<String> getAutoApproves();
 
     /**
@@ -73,43 +81,43 @@ abstract class _UpdateClientRequest implements IdentityZoned {
     /**
      * What scope the bearer token had when client was created
      */
-    @Nullable
     @JsonProperty("createdwith")
+    @Nullable
     abstract String getCreatedWith();
 
     /**
      * A human readable name for the client
      */
-    @Nullable
     @JsonProperty("name")
+    @Nullable
     abstract String getName();
 
     /**
      * Allowed URI pattern for redirect during authorization
      */
-    @Nullable
     @JsonProperty("redirect_uri")
+    @Nullable
     abstract List<String> getRedirectUriPatterns();
 
     /**
      * Resources the client is allowed access to
      */
-    @Nullable
     @JsonProperty("resource_ids")
+    @Nullable
     abstract List<String> getResourceIds();
 
     /**
      * Scopes allowed for the client
      */
-    @Nullable
     @JsonProperty("scope")
+    @Nullable
     abstract List<String> getScopes();
 
     /**
      * A random string used to generate the client’s revokation key. Change this value to revoke all active tokens for the client
      */
-    @Nullable
     @JsonProperty("token_salt")
+    @Nullable
     abstract String getTokenSalt();
 
 }

--- a/cloudfoundry-client/src/test/java/org/cloudfoundry/uaa/clients/CreateClientRequestTest.java
+++ b/cloudfoundry-client/src/test/java/org/cloudfoundry/uaa/clients/CreateClientRequestTest.java
@@ -16,13 +16,22 @@
 
 package org.cloudfoundry.uaa.clients;
 
+import org.cloudfoundry.uaa.tokens.GrantType;
 import org.junit.Test;
 
 public final class CreateClientRequestTest {
 
     @Test(expected = IllegalStateException.class)
-    public void noId() {
+    public void noAuthorizedGrantType() {
         CreateClientRequest.builder()
+            .clientId("test-client-id")
+            .build();
+    }
+
+    @Test(expected = IllegalStateException.class)
+    public void noClientId() {
+        CreateClientRequest.builder()
+            .authorizedGrantType(GrantType.CLIENT_CREDENTIALS)
             .build();
     }
 
@@ -30,6 +39,7 @@ public final class CreateClientRequestTest {
     public void valid() {
         CreateClientRequest.builder()
             .clientId("test-client-id")
+            .authorizedGrantType(GrantType.CLIENT_CREDENTIALS)
             .build();
     }
 

--- a/cloudfoundry-client/src/test/java/org/cloudfoundry/uaa/clients/UpdateClientRequestTest.java
+++ b/cloudfoundry-client/src/test/java/org/cloudfoundry/uaa/clients/UpdateClientRequestTest.java
@@ -16,19 +16,29 @@
 
 package org.cloudfoundry.uaa.clients;
 
+import org.cloudfoundry.uaa.tokens.GrantType;
 import org.junit.Test;
 
 public final class UpdateClientRequestTest {
 
     @Test(expected = IllegalStateException.class)
-    public void noId() {
+    public void noAuthorizedGrantType() {
         UpdateClientRequest.builder()
+            .clientId("test-client-id")
+            .build();
+    }
+
+    @Test(expected = IllegalStateException.class)
+    public void noClientId() {
+        UpdateClientRequest.builder()
+            .authorizedGrantType(GrantType.CLIENT_CREDENTIALS)
             .build();
     }
 
     @Test
     public void valid() {
         UpdateClientRequest.builder()
+            .authorizedGrantType(GrantType.CLIENT_CREDENTIALS)
             .clientId("test-client-id")
             .build();
     }


### PR DESCRIPTION
Set all list attributes as `@Nullable` in order not to send an empty collection as default value.
Add a check on required attribute.