### PR TITLE
Authorized grant type

### DIFF
--- a/cloudfoundry-client-reactor/src/test/java/org/cloudfoundry/reactor/uaa/clients/ReactorClientsTest.java
+++ b/cloudfoundry-client-reactor/src/test/java/org/cloudfoundry/reactor/uaa/clients/ReactorClientsTest.java
@@ -21,6 +21,7 @@ import org.cloudfoundry.reactor.TestRequest;
 import org.cloudfoundry.reactor.TestResponse;
 import org.cloudfoundry.reactor.uaa.AbstractUaaApiTest;
 import org.cloudfoundry.uaa.SortOrder;
+import org.cloudfoundry.uaa.clients.AuthorizedGrantType;
 import org.cloudfoundry.uaa.clients.Client;
 import org.cloudfoundry.uaa.clients.CreateClientRequest;
 import org.cloudfoundry.uaa.clients.CreateClientResponse;
@@ -66,7 +67,7 @@ public final class ReactorClientsTest {
             return CreateClientResponse.builder()
                 .allowedProvider("uaa", "ldap", "my-saml-provider")
                 .authority("clients.read", "clients.write")
-                .authorizedGrantType("client_credentials")
+                .authorizedGrantType(AuthorizedGrantType.CLIENT_CREDENTIALS)
                 .autoApprove("true")
                 .clientId("aPq3I1")
                 .lastModified(1468364445109L)
@@ -83,7 +84,7 @@ public final class ReactorClientsTest {
             return CreateClientRequest.builder()
                 .allowedProvider("uaa", "ldap", "my-saml-provider")
                 .authority("clients.read", "clients.write")
-                .authorizedGrantType("client_credentials")
+                .authorizedGrantType(AuthorizedGrantType.CLIENT_CREDENTIALS)
                 .autoApprove("true")
                 .clientId("aPq3I1")
                 .clientSecret("secret")
@@ -122,7 +123,7 @@ public final class ReactorClientsTest {
             return DeleteClientResponse.builder()
                 .allowedProvider("uaa", "ldap", "my-saml-provider")
                 .authority("clients.read", "clients.write")
-                .authorizedGrantType("client_credentials")
+                .authorizedGrantType(AuthorizedGrantType.CLIENT_CREDENTIALS)
                 .autoApprove("true")
                 .clientId("Gieovr")
                 .lastModified(1468364443957L)
@@ -169,7 +170,7 @@ public final class ReactorClientsTest {
             return GetClientResponse.builder()
                 .allowedProvider("uaa", "ldap", "my-saml-provider")
                 .authority("clients.read", "clients.write")
-                .authorizedGrantType("client_credentials")
+                .authorizedGrantType(AuthorizedGrantType.CLIENT_CREDENTIALS)
                 .autoApprove("true")
                 .clientId("4Z3t1r")
                 .lastModified(1468364445592L)
@@ -217,7 +218,7 @@ public final class ReactorClientsTest {
                 .resource(Client.builder()
                     .allowedProvider("uaa", "ldap", "my-saml-provider")
                     .authority("clients.read", "clients.write")
-                    .authorizedGrantType("client_credentials")
+                    .authorizedGrantType(AuthorizedGrantType.CLIENT_CREDENTIALS)
                     .autoApprove("true")
                     .clientId("EGgNW3")
                     .lastModified(1468364445334L)
@@ -255,12 +256,12 @@ public final class ReactorClientsTest {
 
         private final ReactorClients clients = new ReactorClients(CONNECTION_CONTEXT, this.root, TOKEN_PROVIDER);
 
-        @Override
-        protected InteractionContext getInteractionContext() {
-            return InteractionContext.builder()
-                .request(TestRequest.builder()
-                    .method(PUT).path("/oauth/clients/55pTMX")
-                    .payload("fixtures/uaa/clients/PUT_{id}_request.json")
+            @Override
+            protected InteractionContext getInteractionContext() {
+                return InteractionContext.builder()
+                    .request(TestRequest.builder()
+                        .method(PUT).path("/oauth/clients/55pTMX")
+                        .payload("fixtures/uaa/clients/PUT_{id}_request.json")
                     .build())
                 .response(TestResponse.builder()
                     .status(OK)
@@ -274,7 +275,7 @@ public final class ReactorClientsTest {
             return UpdateClientResponse.builder()
                 .allowedProvider("uaa", "ldap", "my-saml-provider")
                 .authority("clients.read", "clients.write")
-                .authorizedGrantType("client_credentials")
+                .authorizedGrantType(AuthorizedGrantType.CLIENT_CREDENTIALS)
                 .autoApprove("clients.autoapprove")
                 .clientId("55pTMX")
                 .lastModified(1468364443857L)
@@ -289,7 +290,7 @@ public final class ReactorClientsTest {
         @Override
         protected UpdateClientRequest getValidRequest() throws Exception {
             return UpdateClientRequest.builder()
-                .authorizedGrantType("client_credentials")
+                .authorizedGrantType(AuthorizedGrantType.CLIENT_CREDENTIALS)
                 .autoApprove("clients.autoapprove")
                 .clientId("55pTMX")
                 .scope("clients.new", "clients.autoapprove")

--- a/cloudfoundry-client/src/main/java/org/cloudfoundry/uaa/clients/AbstractClient.java
+++ b/cloudfoundry-client/src/main/java/org/cloudfoundry/uaa/clients/AbstractClient.java
@@ -49,7 +49,7 @@ abstract class AbstractClient {
      * List of grant types that can be used to obtain a token with this client. Can include authorization_code, password, implicit, and/or client_credentials.
      */
     @JsonProperty("authorized_grant_types")
-    abstract List<String> getAuthorizedGrantTypes();
+    abstract List<AuthorizedGrantType> getAuthorizedGrantTypes();
 
     /**
      * Scopes that do not require user approval

--- a/cloudfoundry-client/src/main/java/org/cloudfoundry/uaa/clients/AuthorizedGrantType.java
+++ b/cloudfoundry-client/src/main/java/org/cloudfoundry/uaa/clients/AuthorizedGrantType.java
@@ -1,0 +1,78 @@
+/*
+ * Copyright 2013-2016 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.cloudfoundry.uaa.clients;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonValue;
+
+/**
+ * The grant types that can be used to obtain a token with this client.
+ */
+public enum AuthorizedGrantType {
+
+    /**
+     * The authorization code grant type
+     */
+    AUTHORIZATION_CODE("authorization_code"),
+
+    /**
+     * The client_credentials grant type
+     */
+    CLIENT_CREDENTIALS("client_credentials"),
+
+    /**
+     * The implicit grant type
+     */
+    IMPLICIT("implicit"),
+
+    /**
+     * The password grant type
+     */
+    PASSWORD("password");
+
+    private final String value;
+
+    AuthorizedGrantType(String value) {
+        this.value = value;
+    }
+
+    @JsonValue
+    public String getValue() {
+        return this.value;
+    }
+
+    @Override
+    public String toString() {
+        return getValue();
+    }
+
+    @JsonCreator
+    static AuthorizedGrantType from(String s) {
+        switch (s.toLowerCase()) {
+            case "authorization_code":
+                return AUTHORIZATION_CODE;
+            case "client_credentials":
+                return CLIENT_CREDENTIALS;
+            case "implicit":
+                return IMPLICIT;
+            case "password":
+                return PASSWORD;
+            default:
+                throw new IllegalArgumentException(String.format("Unknown authorized grant type: %s", s));
+        }
+    }
+}

--- a/cloudfoundry-client/src/main/java/org/cloudfoundry/uaa/clients/_CreateClientRequest.java
+++ b/cloudfoundry-client/src/main/java/org/cloudfoundry/uaa/clients/_CreateClientRequest.java
@@ -52,7 +52,7 @@ abstract class _CreateClientRequest implements IdentityZoned {
      * List of grant types that can be used to obtain a token with this client. Can include authorization_code, password, implicit, and/or client_credentials.
      */
     @JsonProperty("authorized_grant_types")
-    abstract List<String> getAuthorizedGrantTypes();
+    abstract List<AuthorizedGrantType> getAuthorizedGrantTypes();
 
     /**
      * Scopes that do not require user approval

--- a/cloudfoundry-client/src/main/java/org/cloudfoundry/uaa/clients/_UpdateClientRequest.java
+++ b/cloudfoundry-client/src/main/java/org/cloudfoundry/uaa/clients/_UpdateClientRequest.java
@@ -54,7 +54,7 @@ abstract class _UpdateClientRequest implements IdentityZoned {
      * List of grant types that can be used to obtain a token with this client. Can include authorization_code, password, implicit, and/or client_credentials.
      */
     @JsonProperty("authorized_grant_types")
-    abstract List<String> getAuthorizedGrantTypes();
+    abstract List<AuthorizedGrantType> getAuthorizedGrantTypes();
 
     /**
      * Scopes that do not require user approval


### PR DESCRIPTION
As the values for client attribute authorized grant types are restricted to specific OAuth 2 process grant type values, this field can be implemented with an enum value 