### PR TITLE
Get Client Metadata

### DIFF
--- a/cloudfoundry-client-reactor/src/main/java/org/cloudfoundry/reactor/uaa/clients/ReactorClients.java
+++ b/cloudfoundry-client-reactor/src/main/java/org/cloudfoundry/reactor/uaa/clients/ReactorClients.java
@@ -26,6 +26,8 @@ import org.cloudfoundry.uaa.clients.DeleteClientRequest;
 import org.cloudfoundry.uaa.clients.DeleteClientResponse;
 import org.cloudfoundry.uaa.clients.GetClientRequest;
 import org.cloudfoundry.uaa.clients.GetClientResponse;
+import org.cloudfoundry.uaa.clients.GetMetadataRequest;
+import org.cloudfoundry.uaa.clients.GetMetadataResponse;
 import org.cloudfoundry.uaa.clients.ListClientsRequest;
 import org.cloudfoundry.uaa.clients.ListClientsResponse;
 import org.cloudfoundry.uaa.clients.ListMetadatasRequest;
@@ -65,6 +67,11 @@ public final class ReactorClients extends AbstractUaaOperations implements Clien
     @Override
     public Mono<GetClientResponse> get(GetClientRequest request) {
         return get(request, GetClientResponse.class, builder -> builder.pathSegment("oauth", "clients", request.getClientId()));
+    }
+
+    @Override
+    public Mono<GetMetadataResponse> getMetadata(GetMetadataRequest request) {
+        return get(request, GetMetadataResponse.class, builder -> builder.pathSegment("oauth", "clients", request.getClientId(), "meta"));
     }
 
     @Override

--- a/cloudfoundry-client-reactor/src/test/java/org/cloudfoundry/reactor/uaa/clients/ReactorClientsTest.java
+++ b/cloudfoundry-client-reactor/src/test/java/org/cloudfoundry/reactor/uaa/clients/ReactorClientsTest.java
@@ -28,6 +28,8 @@ import org.cloudfoundry.uaa.clients.DeleteClientRequest;
 import org.cloudfoundry.uaa.clients.DeleteClientResponse;
 import org.cloudfoundry.uaa.clients.GetClientRequest;
 import org.cloudfoundry.uaa.clients.GetClientResponse;
+import org.cloudfoundry.uaa.clients.GetMetadataRequest;
+import org.cloudfoundry.uaa.clients.GetMetadataResponse;
 import org.cloudfoundry.uaa.clients.ListClientsRequest;
 import org.cloudfoundry.uaa.clients.ListClientsResponse;
 import org.cloudfoundry.uaa.clients.ListMetadatasRequest;
@@ -259,6 +261,46 @@ public final class ReactorClientsTest {
         @Override
         protected Mono<GetClientResponse> invoke(GetClientRequest request) {
             return this.clients.get(request);
+        }
+    }
+
+    public static final class GetMetadata extends AbstractUaaApiTest<GetMetadataRequest, GetMetadataResponse> {
+
+        private final ReactorClients clients = new ReactorClients(CONNECTION_CONTEXT, this.root, TOKEN_PROVIDER);
+
+        @Override
+        protected InteractionContext getInteractionContext() {
+            return InteractionContext.builder()
+                .request(TestRequest.builder()
+                    .method(GET).path("/oauth/clients/P4vuAaSe/meta")
+                    .build())
+                .response(TestResponse.builder()
+                    .status(OK)
+                    .payload("fixtures/uaa/clients/GET_{id}_meta_response.json")
+                    .build())
+                .build();
+        }
+
+        @Override
+        protected GetMetadataResponse getResponse() {
+            return GetMetadataResponse.builder()
+                .appIcon("aWNvbiBmb3IgY2xpZW50IDQ=")
+                .appLaunchUrl("http://myloginpage.com")
+                .clientId("P4vuAaSe")
+                .showOnHomePage(true)
+                .build();
+        }
+
+        @Override
+        protected GetMetadataRequest getValidRequest() throws Exception {
+            return GetMetadataRequest.builder()
+                .clientId("P4vuAaSe")
+                .build();
+        }
+
+        @Override
+        protected Mono<GetMetadataResponse> invoke(GetMetadataRequest request) {
+            return this.clients.getMetadata(request);
         }
     }
 

--- a/cloudfoundry-client-reactor/src/test/resources/fixtures/uaa/clients/GET_{id}_meta_response.json
+++ b/cloudfoundry-client-reactor/src/test/resources/fixtures/uaa/clients/GET_{id}_meta_response.json
@@ -1,0 +1,6 @@
+{
+  "clientId": "P4vuAaSe",
+  "showOnHomePage": true,
+  "appLaunchUrl": "http://myloginpage.com",
+  "appIcon": "aWNvbiBmb3IgY2xpZW50IDQ="
+}

--- a/cloudfoundry-client/src/main/java/org/cloudfoundry/uaa/clients/Clients.java
+++ b/cloudfoundry-client/src/main/java/org/cloudfoundry/uaa/clients/Clients.java
@@ -48,6 +48,14 @@ public interface Clients {
     Mono<GetClientResponse> get(GetClientRequest request);
 
     /**
+     * Makes the <a href="http://docs.cloudfoundry.com/uaa/#retrieve88">Retrieve Metadata</a> request
+     *
+     * @param request Retrieve Metadata request
+     * @return the Response to the Retrieve Metadata Request
+     */
+    Mono<GetMetadataResponse> getMetadata(GetMetadataRequest request);
+
+    /**
      * Makes the <a href="http://docs.cloudfoundry.com/uaa/#list81">List Clients</a> request
      *
      * @param request List Clients request

--- a/cloudfoundry-client/src/main/java/org/cloudfoundry/uaa/clients/_GetMetadataRequest.java
+++ b/cloudfoundry-client/src/main/java/org/cloudfoundry/uaa/clients/_GetMetadataRequest.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2013-2016 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.cloudfoundry.uaa.clients;
+
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import org.cloudfoundry.uaa.IdentityZoned;
+import org.immutables.value.Value;
+
+/**
+ * The request payload for Get Metadata
+ */
+@Value.Immutable
+abstract class _GetMetadataRequest implements IdentityZoned {
+
+    /**
+     * The client id
+     */
+    @JsonIgnore
+    abstract String getClientId();
+
+}

--- a/cloudfoundry-client/src/main/java/org/cloudfoundry/uaa/clients/_GetMetadataResponse.java
+++ b/cloudfoundry-client/src/main/java/org/cloudfoundry/uaa/clients/_GetMetadataResponse.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright 2013-2016 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.cloudfoundry.uaa.clients;
+
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import org.immutables.value.Value;
+
+/**
+ * The response from the Get Metadata request
+ */
+@JsonDeserialize
+@Value.Immutable
+abstract class _GetMetadataResponse extends AbstractMetadata {
+
+}

--- a/cloudfoundry-client/src/test/java/org/cloudfoundry/uaa/clients/GetMetadataRequestTest.java
+++ b/cloudfoundry-client/src/test/java/org/cloudfoundry/uaa/clients/GetMetadataRequestTest.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2013-2016 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.cloudfoundry.uaa.clients;
+
+import org.junit.Test;
+
+public final class GetMetadataRequestTest {
+
+    @Test(expected = IllegalStateException.class)
+    public void noClientId() {
+        GetMetadataRequest.builder()
+            .build();
+    }
+
+    @Test
+    public void valid() {
+        GetMetadataRequest.builder()
+            .clientId("test-client-id")
+            .build();
+    }
+
+}


### PR DESCRIPTION
This change brings the api to retrieve metadata (`GET /oauth/clients/:id/meta`)
