### PR TITLE
Batch Delete Clients

### DIFF
--- a/cloudfoundry-client-reactor/src/main/java/org/cloudfoundry/reactor/uaa/clients/ReactorClients.java
+++ b/cloudfoundry-client-reactor/src/main/java/org/cloudfoundry/reactor/uaa/clients/ReactorClients.java
@@ -19,6 +19,8 @@ package org.cloudfoundry.reactor.uaa.clients;
 import org.cloudfoundry.reactor.ConnectionContext;
 import org.cloudfoundry.reactor.TokenProvider;
 import org.cloudfoundry.reactor.uaa.AbstractUaaOperations;
+import org.cloudfoundry.uaa.clients.BatchDeleteClientsRequest;
+import org.cloudfoundry.uaa.clients.BatchDeleteClientsResponse;
 import org.cloudfoundry.uaa.clients.Clients;
 import org.cloudfoundry.uaa.clients.CreateClientRequest;
 import org.cloudfoundry.uaa.clients.CreateClientResponse;
@@ -52,6 +54,11 @@ public final class ReactorClients extends AbstractUaaOperations implements Clien
      */
     public ReactorClients(ConnectionContext connectionContext, Mono<String> root, TokenProvider tokenProvider) {
         super(connectionContext, root, tokenProvider);
+    }
+
+    @Override
+    public Mono<BatchDeleteClientsResponse> batchDelete(BatchDeleteClientsRequest request) {
+        return post(request, BatchDeleteClientsResponse.class, builder -> builder.pathSegment("oauth", "clients", "tx", "delete"));
     }
 
     @Override

--- a/cloudfoundry-client-reactor/src/test/java/org/cloudfoundry/reactor/uaa/clients/ReactorClientsTest.java
+++ b/cloudfoundry-client-reactor/src/test/java/org/cloudfoundry/reactor/uaa/clients/ReactorClientsTest.java
@@ -21,6 +21,8 @@ import org.cloudfoundry.reactor.TestRequest;
 import org.cloudfoundry.reactor.TestResponse;
 import org.cloudfoundry.reactor.uaa.AbstractUaaApiTest;
 import org.cloudfoundry.uaa.SortOrder;
+import org.cloudfoundry.uaa.clients.BatchDeleteClientsRequest;
+import org.cloudfoundry.uaa.clients.BatchDeleteClientsResponse;
 import org.cloudfoundry.uaa.clients.Client;
 import org.cloudfoundry.uaa.clients.CreateClientRequest;
 import org.cloudfoundry.uaa.clients.CreateClientResponse;
@@ -52,6 +54,71 @@ import static org.cloudfoundry.uaa.tokens.GrantType.CLIENT_CREDENTIALS;
 import static org.cloudfoundry.uaa.tokens.GrantType.REFRESH_TOKEN;
 
 public final class ReactorClientsTest {
+
+    public static final class BatchDelete extends AbstractUaaApiTest<BatchDeleteClientsRequest, BatchDeleteClientsResponse> {
+
+        private final ReactorClients clients = new ReactorClients(CONNECTION_CONTEXT, this.root, TOKEN_PROVIDER);
+
+        @Override
+        protected InteractionContext getInteractionContext() {
+            return InteractionContext.builder()
+                .request(TestRequest.builder()
+                    .method(POST).path("/oauth/clients/tx/delete")
+                    .payload("fixtures/uaa/clients/POST_tx_delete_request.json")
+                    .build())
+                .response(TestResponse.builder()
+                    .status(OK)
+                    .payload("fixtures/uaa/clients/POST_tx_delete_response.json")
+                    .build())
+                .build();
+        }
+
+        @Override
+        protected BatchDeleteClientsResponse getResponse() {
+            return BatchDeleteClientsResponse.builder()
+                .client(Client.builder()
+                    .approvalsDeleted(true)
+                    .allowedProvider("uaa", "ldap", "my-saml-provider")
+                    .authority("clients.read", "clients.write")
+                    .authorizedGrantType(CLIENT_CREDENTIALS)
+                    .autoApprove("true")
+                    .clientId("14pnUs")
+                    .lastModified(1468364444461L)
+                    .name("My Client Name")
+                    .redirectUriPattern("http*://ant.path.wildcard/**/passback/*", "http://test1.com")
+                    .resourceId("none")
+                    .scope("clients.read", "clients.write")
+                    .tokenSalt("erRsWH")
+                    .build())
+                .client(Client.builder()
+                    .approvalsDeleted(true)
+                    .allowedProvider("uaa", "ldap", "my-saml-provider")
+                    .authority("clients.read", "clients.write")
+                    .authorizedGrantType(CLIENT_CREDENTIALS)
+                    .autoApprove("true")
+                    .clientId("qECLyr")
+                    .lastModified(1468364444868L)
+                    .name("My Client Name")
+                    .redirectUriPattern("http*://ant.path.wildcard/**/passback/*", "http://test1.com")
+                    .resourceId("none")
+                    .scope("clients.read", "clients.write")
+                    .tokenSalt("48TIsq")
+                    .build())
+                .build();
+        }
+
+        @Override
+        protected BatchDeleteClientsRequest getValidRequest() throws Exception {
+            return BatchDeleteClientsRequest.builder()
+                .clientId("14pnUs", "qECLyr")
+                .build();
+        }
+
+        @Override
+        protected Mono<BatchDeleteClientsResponse> invoke(BatchDeleteClientsRequest request) {
+            return this.clients.batchDelete(request);
+        }
+    }
 
     public static final class Create extends AbstractUaaApiTest<CreateClientRequest, CreateClientResponse> {
 

--- a/cloudfoundry-client-reactor/src/test/resources/fixtures/uaa/clients/POST_tx_delete_request.json
+++ b/cloudfoundry-client-reactor/src/test/resources/fixtures/uaa/clients/POST_tx_delete_request.json
@@ -1,0 +1,8 @@
+[
+  {
+    "client_id": "14pnUs"
+  },
+  {
+    "client_id": "qECLyr"
+  }
+]

--- a/cloudfoundry-client-reactor/src/test/resources/fixtures/uaa/clients/POST_tx_delete_response.json
+++ b/cloudfoundry-client-reactor/src/test/resources/fixtures/uaa/clients/POST_tx_delete_response.json
@@ -1,0 +1,68 @@
+[
+  {
+    "scope": [
+      "clients.read",
+      "clients.write"
+    ],
+    "client_id": "14pnUs",
+    "resource_ids": [
+      "none"
+    ],
+    "authorized_grant_types": [
+      "client_credentials"
+    ],
+    "redirect_uri": [
+      "http*://ant.path.wildcard/**/passback/*",
+      "http://test1.com"
+    ],
+    "autoapprove": [
+      "true"
+    ],
+    "authorities": [
+      "clients.read",
+      "clients.write"
+    ],
+    "token_salt": "erRsWH",
+    "allowedproviders": [
+      "uaa",
+      "ldap",
+      "my-saml-provider"
+    ],
+    "name": "My Client Name",
+    "lastModified": 1468364444461,
+    "approvals_deleted": true
+  },
+  {
+    "scope": [
+      "clients.read",
+      "clients.write"
+    ],
+    "client_id": "qECLyr",
+    "resource_ids": [
+      "none"
+    ],
+    "authorized_grant_types": [
+      "client_credentials"
+    ],
+    "redirect_uri": [
+      "http*://ant.path.wildcard/**/passback/*",
+      "http://test1.com"
+    ],
+    "autoapprove": [
+      "true"
+    ],
+    "authorities": [
+      "clients.read",
+      "clients.write"
+    ],
+    "token_salt": "48TIsq",
+    "allowedproviders": [
+      "uaa",
+      "ldap",
+      "my-saml-provider"
+    ],
+    "name": "My Client Name",
+    "lastModified": 1468364444868,
+    "approvals_deleted": true
+  }
+]

--- a/cloudfoundry-client/src/main/java/org/cloudfoundry/uaa/clients/Clients.java
+++ b/cloudfoundry-client/src/main/java/org/cloudfoundry/uaa/clients/Clients.java
@@ -24,6 +24,14 @@ import reactor.core.publisher.Mono;
 public interface Clients {
 
     /**
+     * Makes the <a href="http://docs.cloudfoundry.com/uaa/#batch-delete">Batch Delete Clients</a> request
+     *
+     * @param request Batch Delete Clients request
+     * @return the Response to the Batch Delete Clients Request
+     */
+    Mono<BatchDeleteClientsResponse> batchDelete(BatchDeleteClientsRequest request);
+
+    /**
      * Makes the <a href="http://docs.cloudfoundry.com/uaa/#create76">Create Client</a> request
      *
      * @param request Create Client request

--- a/cloudfoundry-client/src/main/java/org/cloudfoundry/uaa/clients/_BatchDeleteClientsRequest.java
+++ b/cloudfoundry-client/src/main/java/org/cloudfoundry/uaa/clients/_BatchDeleteClientsRequest.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright 2013-2016 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.cloudfoundry.uaa.clients;
+
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.databind.SerializerProvider;
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+import com.fasterxml.jackson.databind.ser.std.StdSerializer;
+import org.cloudfoundry.Nullable;
+import org.cloudfoundry.uaa.IdentityZoned;
+import org.immutables.value.Value;
+
+import java.io.IOException;
+import java.util.Collections;
+import java.util.List;
+import java.util.stream.Collectors;
+
+/**
+ * The request payload for Batch Delete Clients
+ */
+@Value.Immutable
+@JsonSerialize(using = _BatchDeleteClientsRequest.BatchDeleteClientsSerializer.class)
+abstract class _BatchDeleteClientsRequest implements IdentityZoned {
+
+    @Value.Check
+    void checkClientIdentifications() {
+        if (this.getClientIds() == null) {
+            throw new IllegalStateException("Cannot build BatchDeleteClientsRequest, required attribute clientIds is not set");
+        }
+    }
+
+    /**
+     * Clients identifiers to delete
+     */
+    @Nullable
+    @JsonIgnore
+    abstract List<String> getClientIds();
+
+    static class BatchDeleteClientsSerializer extends StdSerializer<BatchDeleteClientsRequest> {
+
+        private static final long serialVersionUID = 621601835573250942L;
+
+        BatchDeleteClientsSerializer() {
+            super(BatchDeleteClientsRequest.class);
+        }
+
+        @Override
+        public void serialize(BatchDeleteClientsRequest request, JsonGenerator g, SerializerProvider ctxt) throws IOException {
+            g.writeObject(request.getClientIds().stream()
+                .map(clientId -> Collections.singletonMap("client_id", clientId))
+                .collect(Collectors.toList()));
+        }
+    }
+
+}

--- a/cloudfoundry-client/src/main/java/org/cloudfoundry/uaa/clients/_BatchDeleteClientsResponse.java
+++ b/cloudfoundry-client/src/main/java/org/cloudfoundry/uaa/clients/_BatchDeleteClientsResponse.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright 2013-2016 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.cloudfoundry.uaa.clients;
+
+/**
+ * The response from the list Members request
+ */
+
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.DeserializationContext;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.fasterxml.jackson.databind.deser.std.StdDeserializer;
+import org.immutables.value.Value;
+
+import java.io.IOException;
+import java.util.List;
+
+/**
+ * The response from the Batch Delete Clients request
+ */
+@JsonDeserialize(using = _BatchDeleteClientsResponse.BatchDeleteClientsResponseDeserializer.class)
+@Value.Immutable
+abstract class _BatchDeleteClientsResponse {
+
+
+    /**
+     * The deleted clients
+     */
+    abstract List<Client> getClients();
+
+    static class BatchDeleteClientsResponseDeserializer extends StdDeserializer<BatchDeleteClientsResponse> {
+
+        private static final long serialVersionUID = 999593607348906876L;
+
+        BatchDeleteClientsResponseDeserializer() {
+            super(BatchDeleteClientsResponse.class);
+        }
+
+        @Override
+        public BatchDeleteClientsResponse deserialize(JsonParser p, DeserializationContext ctxt) throws IOException {
+            return BatchDeleteClientsResponse.builder()
+                .clients(p.readValueAs(new TypeReference<List<Client>>() {
+
+                }))
+                .build();
+        }
+    }
+
+}

--- a/cloudfoundry-client/src/test/java/org/cloudfoundry/uaa/clients/BatchDeleteClientsRequestTest.java
+++ b/cloudfoundry-client/src/test/java/org/cloudfoundry/uaa/clients/BatchDeleteClientsRequestTest.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2013-2016 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.cloudfoundry.uaa.clients;
+
+import org.junit.Test;
+
+public final class BatchDeleteClientsRequestTest {
+
+    @Test(expected = IllegalStateException.class)
+    public void noClientIdentification() {
+        BatchDeleteClientsRequest.builder()
+            .build();
+    }
+
+    @Test
+    public void valid() {
+        BatchDeleteClientsRequest.builder()
+            .clientId("test-client-id")
+            .build();
+    }
+
+}


### PR DESCRIPTION
This change brings the api to delete clients in batch (`POST /oauth/clients/tx/delete`)