### PR TITLE
Polishing: replace duplicate code by util static function

### DIFF
--- a/cloudfoundry-client-reactor/src/test/java/org/cloudfoundry/reactor/client/AbstractClientApiTest.java
+++ b/cloudfoundry-client-reactor/src/test/java/org/cloudfoundry/reactor/client/AbstractClientApiTest.java
@@ -20,9 +20,6 @@ import okhttp3.Headers;
 import org.cloudfoundry.client.v2.CloudFoundryException;
 import org.cloudfoundry.reactor.AbstractApiTest;
 import org.junit.Test;
-import reactor.core.Exceptions;
-import reactor.core.publisher.Flux;
-import reactor.core.publisher.Mono;
 
 import java.io.ByteArrayOutputStream;
 import java.io.File;
@@ -48,19 +45,6 @@ public abstract class AbstractClientApiTest<REQ, RSP> extends AbstractApiTest<RE
 
         this.testSubscriber.verify(Duration.ofSeconds(5));
         verify();
-    }
-
-    protected static Mono<byte[]> collectByteArray(Flux<byte[]> bytes) {
-        return bytes
-            .reduceWith(ByteArrayOutputStream::new, (prev, next) -> {
-                try {
-                    prev.write(next);
-                } catch (IOException e) {
-                    throw Exceptions.propagate(e);
-                }
-                return prev;
-            })
-            .map(ByteArrayOutputStream::toByteArray);
     }
 
     protected static String extractBoundary(Headers headers) {

--- a/cloudfoundry-client-reactor/src/test/java/org/cloudfoundry/reactor/client/v2/applications/ReactorApplicationsV2Test.java
+++ b/cloudfoundry-client-reactor/src/test/java/org/cloudfoundry/reactor/client/v2/applications/ReactorApplicationsV2Test.java
@@ -72,6 +72,7 @@ import org.cloudfoundry.reactor.TestRequest;
 import org.cloudfoundry.reactor.TestResponse;
 import org.cloudfoundry.reactor.client.AbstractClientApiTest;
 import org.cloudfoundry.util.FluentMap;
+import org.cloudfoundry.util.OperationUtils;
 import org.cloudfoundry.util.test.TestSubscriber;
 import org.reactivestreams.Publisher;
 import org.springframework.core.io.ClassPathResource;
@@ -361,7 +362,7 @@ public final class ReactorApplicationsV2Test {
         @Override
         protected Mono<byte[]> invoke(DownloadApplicationRequest request) {
             return this.applications.download(request)
-                .as(AbstractClientApiTest::collectByteArray);
+                .as(OperationUtils::collectByteArray);
         }
 
     }
@@ -404,7 +405,7 @@ public final class ReactorApplicationsV2Test {
         @Override
         protected Mono<byte[]> invoke(DownloadApplicationDropletRequest request) {
             return this.applications.downloadDroplet(request)
-                .as(AbstractClientApiTest::collectByteArray);
+                .as(OperationUtils::collectByteArray);
         }
 
     }

--- a/cloudfoundry-client-reactor/src/test/java/org/cloudfoundry/reactor/client/v3/packages/ReactorPackagesTest.java
+++ b/cloudfoundry-client-reactor/src/test/java/org/cloudfoundry/reactor/client/v3/packages/ReactorPackagesTest.java
@@ -46,6 +46,7 @@ import org.cloudfoundry.reactor.TestRequest;
 import org.cloudfoundry.reactor.TestResponse;
 import org.cloudfoundry.reactor.client.AbstractClientApiTest;
 import org.cloudfoundry.util.FluentMap;
+import org.cloudfoundry.util.OperationUtils;
 import org.cloudfoundry.util.test.TestSubscriber;
 import org.reactivestreams.Publisher;
 import org.springframework.core.io.ClassPathResource;
@@ -253,7 +254,7 @@ public final class ReactorPackagesTest {
         @Override
         protected Mono<byte[]> invoke(DownloadPackageRequest request) {
             return this.packages.download(request)
-                .as(AbstractClientApiTest::collectByteArray);
+                .as(OperationUtils::collectByteArray);
         }
 
     }

--- a/cloudfoundry-util/src/main/java/org/cloudfoundry/util/OperationUtils.java
+++ b/cloudfoundry-util/src/main/java/org/cloudfoundry/util/OperationUtils.java
@@ -16,8 +16,12 @@
 
 package org.cloudfoundry.util;
 
+import reactor.core.Exceptions;
+import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
 import java.util.function.Function;
 
 /**
@@ -40,13 +44,32 @@ public final class OperationUtils {
     }
 
     /**
-     * Produces a Mono transformer that preserves the type of the source {@code Mono<IN>}.
+     * Operation to collect a {@code Flux<byte[]>} into a contiguous single byte array, delivered as a single element of a {@code Mono<byte[]>}.
      *
+     * @param bytes a Flux of 0 or more byte arrays
+     * @return a Mono of a byte array
+     */
+    public static Mono<byte[]> collectByteArray(Flux<byte[]> bytes) {
+        return bytes
+            .reduceWith(ByteArrayOutputStream::new, (prev, next) -> {
+                try {
+                    prev.write(next);
+                } catch (IOException e) {
+                    throw Exceptions.propagate(e);
+                }
+                return prev;
+            })
+            .map(ByteArrayOutputStream::toByteArray);
+    }
+
+    /**
+     * Produces a Mono transformer that preserves the type of the source {@code Mono<IN>}.
+     * <p>
      * <p> The Mono produced expects a single element from the source, passes this to the function (as in {@code .then}) and requests an element from the resulting {@code Mono<OUT>}. When successful,
      * the result (if any) is discarded and the input value is signalled. </p>
-     *
+     * <p>
      * <p> <b>Summary:</b> does a {@code .then} on the new Mono but keeps the input to pass on unchanged. </p>
-     *
+     * <p>
      * <p> <b>Usage:</b> Can be used inline thus: {@code .as(thenKeep(in -> funcOf(in)))} </p>
      *
      * @param thenFunction from source input element to some {@code Mono<OUT>}

--- a/integration-test/src/test/java/org/cloudfoundry/AbstractIntegrationTest.java
+++ b/integration-test/src/test/java/org/cloudfoundry/AbstractIntegrationTest.java
@@ -27,8 +27,6 @@ import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.SpringApplicationConfiguration;
 import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
-import reactor.core.Exceptions;
-import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 import reactor.util.function.Tuple2;
 
@@ -65,19 +63,6 @@ public abstract class AbstractIntegrationTest {
     public final void verify() throws InterruptedException {
         this.testSubscriber.verify(Duration.ofMinutes(5));
         this.logger.debug("<< {} >>", getTestName());
-    }
-
-    protected static Mono<byte[]> collectByteArray(Flux<byte[]> bytes) {
-        return bytes
-            .reduceWith(ByteArrayOutputStream::new, (prev, next) -> {
-                try {
-                    prev.write(next);
-                } catch (IOException e) {
-                    throw Exceptions.propagate(e);
-                }
-                return prev;
-            })
-            .map(ByteArrayOutputStream::toByteArray);
     }
 
     protected static Mono<byte[]> getBytes(String path) {

--- a/integration-test/src/test/java/org/cloudfoundry/client/v2/ApplicationsTest.java
+++ b/integration-test/src/test/java/org/cloudfoundry/client/v2/ApplicationsTest.java
@@ -60,6 +60,7 @@ import org.cloudfoundry.client.v2.servicebindings.ServiceBindingResource;
 import org.cloudfoundry.client.v2.userprovidedserviceinstances.CreateUserProvidedServiceInstanceRequest;
 import org.cloudfoundry.client.v2.userprovidedserviceinstances.CreateUserProvidedServiceInstanceResponse;
 import org.cloudfoundry.util.JobUtils;
+import org.cloudfoundry.util.OperationUtils;
 import org.cloudfoundry.util.PaginationUtils;
 import org.cloudfoundry.util.ResourceUtils;
 import org.cloudfoundry.util.tuple.Consumer2;
@@ -197,7 +198,7 @@ public final class ApplicationsTest extends AbstractIntegrationTest {
                 .downloadDroplet(DownloadApplicationDropletRequest.builder()
                     .applicationId(applicationId)
                     .build())
-                .as(AbstractIntegrationTest::collectByteArray))
+                .as(OperationUtils::collectByteArray))
             .subscribe(this.<byte[]>testSubscriber()
                 .expectThat(ApplicationsTest::assertIsTestApplicationDroplet));
     }
@@ -1017,7 +1018,7 @@ public final class ApplicationsTest extends AbstractIntegrationTest {
             .download(DownloadApplicationRequest.builder()
                 .applicationId(applicationId)
                 .build())
-            .as(AbstractIntegrationTest::collectByteArray);
+            .as(OperationUtils::collectByteArray);
     }
 
 }


### PR DESCRIPTION
Mono<byte[]> collectByteArray(Flux<byte[]> bytes) is pulled out to a static
method in ResourceUtils so that it is available to the four places it is used
(twice in integration tests and twice in Reactor unit tests). This actually
increases the runtime jar (util is available in production) but not the
runtime footprint. It is a reasonably useful method, however, and reduces the
interdependencies in the test code.