### PR TITLE
Configure Netty client with a resolved proxy host address

### DIFF
--- a/cloudfoundry-client-reactor/src/main/java/org/cloudfoundry/reactor/_DefaultConnectionContext.java
+++ b/cloudfoundry-client-reactor/src/main/java/org/cloudfoundry/reactor/_DefaultConnectionContext.java
@@ -23,6 +23,7 @@ import com.fasterxml.jackson.datatype.jdk8.Jdk8Module;
 import org.cloudfoundry.reactor.util.DefaultSslCertificateTruster;
 import org.cloudfoundry.reactor.util.JsonCodec;
 import org.cloudfoundry.reactor.util.NetworkLogging;
+import org.cloudfoundry.reactor.util.ProxyConfigurator;
 import org.cloudfoundry.reactor.util.SslCertificateTruster;
 import org.cloudfoundry.reactor.util.StaticTrustManagerFactory;
 import org.immutables.value.Value;
@@ -78,7 +79,7 @@ abstract class _DefaultConnectionContext implements ConnectionContext {
                 .poolResources(PoolResources.fixed("cloudfoundry-client", getConnectionPoolSize()));
 
             getKeepAlive().ifPresent(keepAlive -> options.option(SO_KEEPALIVE, keepAlive));
-            getProxyConfiguration().ifPresent(c -> options.proxy(ClientOptions.Proxy.HTTP, c.getHost(), c.getPort().orElse(null), c.getUsername().orElse(null), u -> c.getPassword().orElse(null)));
+            getProxyConfiguration().ifPresent(c -> ProxyConfigurator.configure(options, c));
             getSocketTimeout().ifPresent(socketTimeout -> options.option(SO_TIMEOUT, (int) socketTimeout.toMillis()));
 
             options.sslSupport(ssl -> getSslCertificateTruster().ifPresent(trustManager -> ssl.trustManager(new StaticTrustManagerFactory(trustManager))));

--- a/cloudfoundry-client-reactor/src/main/java/org/cloudfoundry/reactor/util/DefaultSslCertificateTruster.java
+++ b/cloudfoundry-client-reactor/src/main/java/org/cloudfoundry/reactor/util/DefaultSslCertificateTruster.java
@@ -116,7 +116,7 @@ public final class DefaultSslCertificateTruster implements SslCertificateTruster
             options.connect(host, port)
                 .sslSupport(ssl -> ssl.trustManager(new StaticTrustManagerFactory(collector)));
 
-            proxyConfiguration.ifPresent(c -> options.proxy(ClientOptions.Proxy.HTTP, c.getHost(), c.getPort().orElse(null), c.getUsername().orElse(null), u -> c.getPassword().orElse(null)));
+            proxyConfiguration.ifPresent(c -> ProxyConfigurator.configure(options, c));
         });
     }
 

--- a/cloudfoundry-client-reactor/src/main/java/org/cloudfoundry/reactor/util/ProxyConfigurator.java
+++ b/cloudfoundry-client-reactor/src/main/java/org/cloudfoundry/reactor/util/ProxyConfigurator.java
@@ -1,0 +1,35 @@
+package org.cloudfoundry.reactor.util;
+
+import java.io.UncheckedIOException;
+import java.net.InetAddress;
+import java.net.InetSocketAddress;
+import java.net.UnknownHostException;
+import java.util.function.Supplier;
+
+import org.cloudfoundry.reactor.ProxyConfiguration;
+
+import reactor.ipc.netty.options.ClientOptions;
+import reactor.ipc.netty.options.ClientOptions.Proxy;
+
+/**
+ * Configures proxy in {@link ClientOptions}.
+ */
+public class ProxyConfigurator {
+
+    /**
+     * Configure the given options to use the proxy as defined in the provided proxy configuration.
+     */
+    public static void configure(ClientOptions opts, ProxyConfiguration proxyConf) {
+        Supplier<InetSocketAddress> hostAddr = () -> {
+            try {
+                InetAddress addr = InetAddress.getByName(proxyConf.getHost());
+                return new InetSocketAddress(addr, proxyConf.getPort().orElse(0));
+            } catch (UnknownHostException e) {
+                throw new UncheckedIOException("failed to resolve host " + proxyConf.getHost(), e);
+            }
+        };
+        opts.proxy(Proxy.HTTP, hostAddr, proxyConf.getUsername().orElse(null),
+                u -> proxyConf.getPassword().orElse(null));
+    }
+
+}


### PR DESCRIPTION
Netty uses unresolved address in proxy mode due to proxy delegation. The address of the proxy host itself should be resolved before being set in the client options to avoid UnknownHostException failures, during connections context SSL initialization as well.

Fixes issue https://github.com/cloudfoundry/cf-java-client/issues/479

Signed-off-by: Tareq Sharafy <tareq.sha@gmail.com>