### PR TITLE
Fixes #684 - uses authorization_endpoint for grant_type of password

### DIFF
--- a/cloudfoundry-client-reactor/src/main/java/org/cloudfoundry/reactor/tokenprovider/AbstractUaaTokenProvider.java
+++ b/cloudfoundry-client-reactor/src/main/java/org/cloudfoundry/reactor/tokenprovider/AbstractUaaTokenProvider.java
@@ -63,7 +63,9 @@ public abstract class AbstractUaaTokenProvider implements TokenProvider {
 
     private static final String REFRESH_TOKEN = "refresh_token";
 
-    private static final String TOKEN_ENDPOINT = "token_endpoint";
+    protected static final String TOKEN_ENDPOINT = "token_endpoint";
+
+    protected static final String AUTHORIZATION_ENDPOINT = "authorization_endpoint";
 
     private static final String TOKEN_TYPE = "token_type";
 
@@ -205,9 +207,17 @@ public abstract class AbstractUaaTokenProvider implements TokenProvider {
                 .then());
     }
 
-    private Mono<HttpClientResponse> requestToken(ConnectionContext connectionContext, Function<Mono<HttpClientRequest>, Mono<Void>> tokenRequestTransformer) {
+    /**
+     * Gets the endpoint for retrieving a token.
+     * @return the url for the endpoint
+     */
+    Mono<String> getAuthorizationEndpoint(ConnectionContext connectionContext) {
         return connectionContext
-            .getRoot(TOKEN_ENDPOINT)
+            .getRoot(TOKEN_ENDPOINT);
+    }
+
+    private Mono<HttpClientResponse> requestToken(ConnectionContext connectionContext, Function<Mono<HttpClientRequest>, Mono<Void>> tokenRequestTransformer) {
+        return getAuthorizationEndpoint(connectionContext)
             .map(AbstractUaaTokenProvider::getTokenUri)
             .then(uri -> connectionContext.getHttpClient()
                 .post(uri, request -> Mono.just(request)

--- a/cloudfoundry-client-reactor/src/main/java/org/cloudfoundry/reactor/tokenprovider/_PasswordGrantTokenProvider.java
+++ b/cloudfoundry-client-reactor/src/main/java/org/cloudfoundry/reactor/tokenprovider/_PasswordGrantTokenProvider.java
@@ -16,6 +16,7 @@
 
 package org.cloudfoundry.reactor.tokenprovider;
 
+import org.cloudfoundry.reactor.ConnectionContext;
 import org.cloudfoundry.reactor.TokenProvider;
 import org.immutables.value.Value;
 import reactor.core.publisher.Mono;
@@ -36,6 +37,16 @@ abstract class _PasswordGrantTokenProvider extends AbstractUaaTokenProvider {
      * The username
      */
     abstract String getUsername();
+
+    /**
+     * For a password based authentication with a user,
+     * the authorization endpoint is the authorization_endpoint from /v2/info endpoint
+     */
+    @Override
+    Mono<String> getAuthorizationEndpoint(ConnectionContext connectionContext) {
+        return connectionContext
+            .getRoot(AUTHORIZATION_ENDPOINT);
+    }
 
     @Override
     Mono<Void> tokenRequestTransformer(Mono<HttpClientRequest> outbound) {

--- a/cloudfoundry-client-reactor/src/main/java/org/cloudfoundry/reactor/tokenprovider/_RefreshTokenGrantTokenProvider.java
+++ b/cloudfoundry-client-reactor/src/main/java/org/cloudfoundry/reactor/tokenprovider/_RefreshTokenGrantTokenProvider.java
@@ -16,6 +16,7 @@
 
 package org.cloudfoundry.reactor.tokenprovider;
 
+import org.cloudfoundry.reactor.ConnectionContext;
 import org.cloudfoundry.reactor.TokenProvider;
 import org.immutables.value.Value;
 import reactor.core.publisher.Mono;
@@ -31,6 +32,16 @@ abstract class _RefreshTokenGrantTokenProvider extends AbstractUaaTokenProvider 
      * The refresh token
      */
     abstract String getToken();
+
+    /**
+     * For a refresh token, authorization_endpoint from /v2/info endpoint
+     * should be used
+     */
+    @Override
+    Mono<String> getAuthorizationEndpoint(ConnectionContext connectionContext) {
+        return connectionContext
+            .getRoot(AUTHORIZATION_ENDPOINT);
+    }
 
     @Override
     Mono<Void> tokenRequestTransformer(Mono<HttpClientRequest> outbound) {


### PR DESCRIPTION
Fixes #684 

The fix is to use the authorization_endpoint from /v2/info endpoint for grant_type of password and default to token_endpoint for everything else.