### PR TITLE
Remove explicit printStackTrace

### DIFF
--- a/cloudfoundry-client-reactor/src/main/java/org/cloudfoundry/reactor/doppler/ReactorDopplerEndpoints.java
+++ b/cloudfoundry-client-reactor/src/main/java/org/cloudfoundry/reactor/doppler/ReactorDopplerEndpoints.java
@@ -81,7 +81,6 @@ final class ReactorDopplerEndpoints extends AbstractDopplerOperations {
         try {
             return Envelope.from(org.cloudfoundry.dropsonde.events.Envelope.ADAPTER.decode(bytes));
         } catch (IOException e) {
-            e.printStackTrace();
             throw Exceptions.propagate(e);
         }
     }


### PR DESCRIPTION
This is tangentially related to https://github.com/cloudfoundry/cf-java-client/issues/688. When an error occurs, it'll be passed to the `doOnError` method and it should be left to the developer whether or not to print it.