### PR TITLE
The Rest api for changing a users password can also be used to reset …

### DIFF
--- a/cloudfoundry-client/src/main/java/org/cloudfoundry/uaa/users/_ChangeUserPasswordRequest.java
+++ b/cloudfoundry-client/src/main/java/org/cloudfoundry/uaa/users/_ChangeUserPasswordRequest.java
@@ -18,6 +18,7 @@ package org.cloudfoundry.uaa.users;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import org.cloudfoundry.Nullable;
 import org.cloudfoundry.uaa.IdentityZoned;
 import org.immutables.value.Value;
 
@@ -31,6 +32,7 @@ abstract class _ChangeUserPasswordRequest implements IdentityZoned {
      * The user's existing password
      */
     @JsonProperty("oldPassword")
+    @Nullable
     abstract String getOldPassword();
 
     /**

--- a/cloudfoundry-client/src/test/java/org/cloudfoundry/uaa/users/ChangeUserPasswordRequestTest.java
+++ b/cloudfoundry-client/src/test/java/org/cloudfoundry/uaa/users/ChangeUserPasswordRequestTest.java
@@ -21,14 +21,6 @@ import org.junit.Test;
 public final class ChangeUserPasswordRequestTest {
 
     @Test(expected = IllegalStateException.class)
-    public void noOldPassword() {
-        ChangeUserPasswordRequest.builder()
-            .password("test-password")
-            .userId("test-user-id")
-            .build();
-    }
-
-    @Test(expected = IllegalStateException.class)
     public void noPassword() {
         ChangeUserPasswordRequest.builder()
             .oldPassword("test-old-password")
@@ -48,6 +40,14 @@ public final class ChangeUserPasswordRequestTest {
     public void valid() {
         ChangeUserPasswordRequest.builder()
             .oldPassword("test-old-password")
+            .password("test-password")
+            .userId("test-user-id")
+            .build();
+    }
+
+    @Test
+    public void noOldPasswordAlsoValid() {
+        ChangeUserPasswordRequest.builder()
             .password("test-password")
             .userId("test-user-id")
             .build();


### PR DESCRIPTION
…the password if the user has appropriate credentials (i.e. uaa.admin + password.write). However the ChangeUserPasswordRequest builder insisted on the 'oldPassword' value being specified and that needs to be omitted when resetting another users password.

This pull request addresses defect: https://github.com/cloudfoundry/cf-java-client/issues/761