### PR TITLE
Use asMemoryInteger when parsing disk_quota from manifest files.

### DIFF
--- a/cloudfoundry-operations/src/main/java/org/cloudfoundry/operations/applications/ApplicationManifestUtils.java
+++ b/cloudfoundry-operations/src/main/java/org/cloudfoundry/operations/applications/ApplicationManifestUtils.java
@@ -163,10 +163,14 @@ public final class ApplicationManifestUtils {
             } else if (raw.isTextual()) {
                 String text = raw.asText();
 
-                if (text.endsWith("G")) {
+                if (text.toUpperCase().endsWith("G")) {
                     return Integer.parseInt(text.substring(0, text.length() - 1)) * GIBI;
-                } else if (text.endsWith("M")) {
+                } else if (text.toUpperCase().endsWith("GB")) {
+                    return Integer.parseInt(text.substring(0, text.length() - 2)) * GIBI;
+                } else if (text.toUpperCase().endsWith("M")) {
                     return Integer.parseInt(text.substring(0, text.length() - 1));
+                } else if (text.toUpperCase().endsWith("MB")) {
+                    return Integer.parseInt(text.substring(0, text.length() - 2));
                 } else {
                     return 0;
                 }
@@ -247,7 +251,7 @@ public final class ApplicationManifestUtils {
     private static ApplicationManifest.Builder toApplicationManifest(JsonNode application, ApplicationManifest.Builder builder, Path root) {
         asString(application, "buildpack", builder::buildpack);
         asString(application, "command", builder::command);
-        asInteger(application, "disk_quota", builder::disk);
+        asMemoryInteger(application, "disk_quota", builder::disk);
         asString(application, "domain", builder::domain);
         asListOfString(application, "domains", builder::domain);
         asMapOfStringString(application, "env", builder::environmentVariable);

--- a/cloudfoundry-operations/src/main/java/org/cloudfoundry/operations/applications/ApplicationManifestUtils.java
+++ b/cloudfoundry-operations/src/main/java/org/cloudfoundry/operations/applications/ApplicationManifestUtils.java
@@ -163,7 +163,7 @@ public final class ApplicationManifestUtils {
             } else if (raw.isTextual()) {
                 String text = raw.asText().toUpperCase();
 
-                if (text.tendsWith("G")) {
+                if (text.endsWith("G")) {
                     return Integer.parseInt(text.substring(0, text.length() - 1)) * GIBI;
                 } else if (text.endsWith("GB")) {
                     return Integer.parseInt(text.substring(0, text.length() - 2)) * GIBI;

--- a/cloudfoundry-operations/src/main/java/org/cloudfoundry/operations/applications/ApplicationManifestUtils.java
+++ b/cloudfoundry-operations/src/main/java/org/cloudfoundry/operations/applications/ApplicationManifestUtils.java
@@ -161,15 +161,15 @@ public final class ApplicationManifestUtils {
             if (raw.isNumber()) {
                 return raw.asInt();
             } else if (raw.isTextual()) {
-                String text = raw.asText();
+                String text = raw.asText().toUpperCase();
 
-                if (text.toUpperCase().endsWith("G")) {
+                if (text.tendsWith("G")) {
                     return Integer.parseInt(text.substring(0, text.length() - 1)) * GIBI;
-                } else if (text.toUpperCase().endsWith("GB")) {
+                } else if (text.endsWith("GB")) {
                     return Integer.parseInt(text.substring(0, text.length() - 2)) * GIBI;
-                } else if (text.toUpperCase().endsWith("M")) {
+                } else if (text.endsWith("M")) {
                     return Integer.parseInt(text.substring(0, text.length() - 1));
-                } else if (text.toUpperCase().endsWith("MB")) {
+                } else if (text.endsWith("MB")) {
                     return Integer.parseInt(text.substring(0, text.length() - 2));
                 } else {
                     return 0;

--- a/cloudfoundry-operations/src/test/java/org/cloudfoundry/operations/applications/ApplicationManifestUtilsTest.java
+++ b/cloudfoundry-operations/src/test/java/org/cloudfoundry/operations/applications/ApplicationManifestUtilsTest.java
@@ -449,4 +449,58 @@ public final class ApplicationManifestUtilsTest {
         assertThat(actual).isEqualTo(expected);
     }
 
+    @Test
+    public void testDiskQuotaAndMemoryParsing() throws Exception {
+        List<ApplicationManifest> expected = Arrays.asList(
+            ApplicationManifest.builder()
+                .name("quota-test-1")
+                .memory(1)
+                .disk(2)
+                .build(),
+            ApplicationManifest.builder()
+                .name("quota-test-2")
+                .memory(3)
+                .disk(4)
+                .build(),
+            ApplicationManifest.builder()
+                .name("quota-test-3")
+                .memory(5)
+                .disk(6)
+                .build(),
+            ApplicationManifest.builder()
+                .name("quota-test-4")
+                .memory(7)
+                .disk(8)
+                .build(),
+            ApplicationManifest.builder()
+                .name("quota-test-5")
+                .memory(1024)
+                .disk(2048)
+                .build(),
+            ApplicationManifest.builder()
+                .name("quota-test-6")
+                .memory(3072)
+                .disk(4096)
+                .build(),
+            ApplicationManifest.builder()
+                .name("quota-test-7")
+                .memory(5120)
+                .disk(6144)
+                .build(),
+            ApplicationManifest.builder()
+                .name("quota-test-8")
+                .memory(7168)
+                .disk(8192)
+                .build(),
+            ApplicationManifest.builder()
+              .name("quota-test-9")
+              .memory(1234)
+              .disk(5678)
+              .build()
+        );
+
+        List<ApplicationManifest> actual = ApplicationManifestUtils.read(new ClassPathResource("fixtures/manifest-quota.yml").getFile().toPath());
+
+        assertThat(actual).isEqualTo(expected);
+    }
 }

--- a/cloudfoundry-operations/src/test/resources/fixtures/manifest-quota.yml
+++ b/cloudfoundry-operations/src/test/resources/fixtures/manifest-quota.yml
@@ -1,0 +1,30 @@
+---
+applications:
+  - name: quota-test-1
+    memory: 1m
+    disk_quota: 2m
+  - name: quota-test-2
+    memory: 3mb
+    disk_quota: 4mb
+  - name: quota-test-3
+    memory: 5M
+    disk_quota: 6M
+  - name: quota-test-4
+    memory: 7MB
+    disk_quota: 8MB
+  - name: quota-test-5
+    memory: 1g
+    disk_quota: 2g
+  - name: quota-test-6
+    memory: 3gb
+    disk_quota: 4gb
+  - name: quota-test-7
+    memory: 5G
+    disk_quota: 6G
+  - name: quota-test-8
+    memory: 7GB
+    disk_quota: 8GB
+  - name: quota-test-9
+    memory: 1234
+    disk_quota: 5678
+


### PR DESCRIPTION
Handle lowercase units and two-character units (i.e. 'mb'/'gb') in asMemoryInteger.
Fixes #792.