### PR TITLE
Add unit test for failing manifest inheritance case

### DIFF
--- a/cloudfoundry-operations/src/test/java/org/cloudfoundry/operations/applications/ApplicationManifestUtilsTest.java
+++ b/cloudfoundry-operations/src/test/java/org/cloudfoundry/operations/applications/ApplicationManifestUtilsTest.java
@@ -372,6 +372,25 @@ public final class ApplicationManifestUtilsTest {
     }
 
     @Test
+    public void readCommonInheritance() throws IOException {
+        List<ApplicationManifest> expected = Arrays.asList(
+            ApplicationManifest.builder()
+                .buildpack("https://github.com/cloudfoundry/java-buildpack#v4.5.2")
+                .memory(1024)
+                .path(Paths.get("/target/demo.jar"))
+                .environmentVariable("JBP_CONFIG_OPEN_JDK_JRE", "{ jre: { version: 1.8.0_+ } }")
+                .name("demo")
+                .instances(2)
+                .stack("dev")
+                .environmentVariable("SOME_ENV", "test")
+            .build());
+
+        List<ApplicationManifest> actual = ApplicationManifestUtils.read(new ClassPathResource("fixtures/manifest-dev.yml").getFile().toPath());
+
+        assertThat(actual).isEqualTo(expected);
+    }
+
+    @Test
     public void readNoApplications() throws IOException {
         List<ApplicationManifest> actual = ApplicationManifestUtils.read(new ClassPathResource("fixtures/manifest-hotel.yml").getFile().toPath());
 

--- a/cloudfoundry-operations/src/test/resources/fixtures/base-manifest.yml
+++ b/cloudfoundry-operations/src/test/resources/fixtures/base-manifest.yml
@@ -1,0 +1,9 @@
+---
+buildpack: https://github.com/cloudfoundry/java-buildpack#v4.5.2
+memory: 1G
+path: /target/demo.jar
+env:
+  JBP_CONFIG_OPEN_JDK_JRE: '{ jre: { version: 1.8.0_+ } }'
+
+#applications:
+#- name: demo

--- a/cloudfoundry-operations/src/test/resources/fixtures/manifest-dev.yml
+++ b/cloudfoundry-operations/src/test/resources/fixtures/manifest-dev.yml
@@ -1,0 +1,8 @@
+---
+inherit: base-manifest.yml
+applications:
+- name: demo
+  instances: 2
+  stack: dev
+  env:
+    SOME_ENV: "test"


### PR DESCRIPTION
There are existing tests for manifest inheritance and common properties, but there is an assumption that the application will be named in the base manifest. This is not documented[1] and is not an assumption held by the CF CLI - the test case added works with the CF CLI. This will need to be fixed to allow the Cloud Foundry Jenkins plugin[2] to easily support this use case.

[1] https://docs.cloudfoundry.org/devguide/deploy-apps/manifest.html#multi-manifests
[2] https://issues.jenkins-ci.org/browse/JENKINS-47271

---

When specifying only common properties in the base manifest, there will be no applications present, which causes the following logic to skip adding any of the common properties from the base manifest.

https://github.com/cloudfoundry/cf-java-client/blob/2f9c7eb99da6026545de49c3c67c07eb348c6305/cloudfoundry-operations/src/main/java/org/cloudfoundry/operations/applications/ApplicationManifestUtils.java#L200-L210