### PR TITLE
Allow empty query parameters

### DIFF
--- a/cloudfoundry-client-reactor/src/main/java/org/cloudfoundry/reactor/client/QueryBuilder.java
+++ b/cloudfoundry-client-reactor/src/main/java/org/cloudfoundry/reactor/client/QueryBuilder.java
@@ -66,7 +66,6 @@ public final class QueryBuilder {
         processValue(builder, queryParameter.value(),
             ((Collection<?>) value).stream()
                 .map(o -> o.toString().trim())
-                .filter(s -> !s.isEmpty())
                 .collect(Collectors.joining(queryParameter.delimiter())));
     }
 
@@ -76,9 +75,7 @@ public final class QueryBuilder {
     }
 
     private static void processValue(UriComponentsBuilder builder, String name, String value) {
-        if (!value.isEmpty()) {
-            builder.queryParam(name, value);
-        }
+        builder.queryParam(name, value);
     }
 
     private static Consumer<Object> processValue(UriComponentsBuilder builder, QueryParameter queryParameter) {

--- a/cloudfoundry-client-reactor/src/main/java/org/cloudfoundry/reactor/client/v2/FilterBuilder.java
+++ b/cloudfoundry-client-reactor/src/main/java/org/cloudfoundry/reactor/client/v2/FilterBuilder.java
@@ -67,15 +67,12 @@ final class FilterBuilder {
     private static void processCollection(UriComponentsBuilder builder, FilterParameter filterParameter, Object value) {
         List<String> collection = ((Collection<?>) value).stream()
             .map(o -> o.toString().trim())
-            .filter(s -> !s.isEmpty())
             .collect(Collectors.toList());
 
         if (collection.size() == 1) {
             processValue(builder, filterParameter.value(), filterParameter.operation(), collection.get(0));
         } else if (collection.size() > 1) {
-            processValue(builder, filterParameter.value(), filterParameter.collectionOperation(),
-                collection.stream()
-                    .collect(Collectors.joining(",")));
+            processValue(builder, filterParameter.value(), filterParameter.collectionOperation(), collection);
         }
     }
 
@@ -94,10 +91,15 @@ final class FilterBuilder {
         };
     }
 
-    private static void processValue(UriComponentsBuilder builder, String name, FilterParameter.Operation operation, String value) {
+    private static void processValue(UriComponentsBuilder builder, String name, FilterParameter.Operation operation, Collection<String> collection) {
+        String value = String.join(",", collection);
         if (!value.isEmpty()) {
-            builder.queryParam("q", String.format("%s%s%s", name, operation, value));
+            processValue(builder, name, operation, value);
         }
+    }
+
+    private static void processValue(UriComponentsBuilder builder, String name, FilterParameter.Operation operation, String value) {
+        builder.queryParam("q", String.format("%s%s%s", name, operation, value));
     }
 
 }

--- a/cloudfoundry-client-reactor/src/main/java/org/cloudfoundry/reactor/client/v3/FilterBuilder.java
+++ b/cloudfoundry-client-reactor/src/main/java/org/cloudfoundry/reactor/client/v3/FilterBuilder.java
@@ -64,8 +64,7 @@ final class FilterBuilder {
         processValue(builder, name,
             ((Collection<?>) value).stream()
                 .map(o -> o.toString().trim())
-                .filter(s -> !s.isEmpty())
-                .collect(Collectors.joining(",")));
+                .collect(Collectors.toList()));
     }
 
     private static Consumer<Method> processMethod(UriComponentsBuilder builder, Object instance) {
@@ -73,10 +72,15 @@ final class FilterBuilder {
             .ifPresent(processAnnotation(builder, method, instance));
     }
 
-    private static void processValue(UriComponentsBuilder builder, String name, String value) {
+    private static void processValue(UriComponentsBuilder builder, String name, Collection<String> collection) {
+        String value = String.join(",", collection);
         if (!value.isEmpty()) {
-            builder.queryParam(name, value);
+            processValue(builder, name, value);
         }
+    }
+
+    private static void processValue(UriComponentsBuilder builder, String name, String value) {
+        builder.queryParam(name, value);
     }
 
     private static Consumer<Object> processValue(UriComponentsBuilder builder, FilterParameter filterParameter) {

--- a/cloudfoundry-client-reactor/src/test/java/org/cloudfoundry/reactor/client/QueryBuilderTest.java
+++ b/cloudfoundry-client-reactor/src/test/java/org/cloudfoundry/reactor/client/QueryBuilderTest.java
@@ -37,14 +37,14 @@ public final class QueryBuilderTest {
 
         MultiValueMap<String, String> queryParams = builder.build().encode().getQueryParams();
 
-        assertThat(queryParams).hasSize(5);
+        assertThat(queryParams).hasSize(7);
         assertThat(queryParams.getFirst("test-single")).isEqualTo("test-value-1");
         assertThat(queryParams.getFirst("test-collection")).isEqualTo("test-value-2,test-value-3");
         assertThat(queryParams.getFirst("test-collection-custom-delimiter")).isEqualTo("test-value-4%20test-value-5");
         assertThat(queryParams.getFirst("test-subclass")).isEqualTo("test-value-6");
         assertThat(queryParams.getFirst("test-override")).isEqualTo("test-value-7");
     }
-
+    
     public static abstract class StubQueryParams {
 
         @QueryParameter("test-collection")

--- a/cloudfoundry-client-reactor/src/test/java/org/cloudfoundry/reactor/client/v2/FilterBuilderTest.java
+++ b/cloudfoundry-client-reactor/src/test/java/org/cloudfoundry/reactor/client/v2/FilterBuilderTest.java
@@ -43,8 +43,9 @@ public final class FilterBuilderTest {
         List<String> q = queryParams.get("q");
 
         assertThat(q)
-            .hasSize(8)
-            .containsOnly("test-greater-than%3Etest-value-1",
+            .hasSize(9)
+            .containsOnly("test-empty-value:",
+                "test-greater-than%3Etest-value-1",
                 "test-greater-than-or-equal-to%3E%3Dtest-value-2",
                 "test-in%20IN%20test-value-3,test-value-4",
                 "test-is:test-value-5",

--- a/cloudfoundry-client-reactor/src/test/java/org/cloudfoundry/reactor/client/v3/FilterBuilderTest.java
+++ b/cloudfoundry-client-reactor/src/test/java/org/cloudfoundry/reactor/client/v3/FilterBuilderTest.java
@@ -37,7 +37,7 @@ public final class FilterBuilderTest {
 
         MultiValueMap<String, String> queryParams = builder.build().encode().getQueryParams();
 
-        assertThat(queryParams).hasSize(4);
+        assertThat(queryParams).hasSize(5);
         assertThat(queryParams.getFirst("test-single")).isEqualTo("test-value-1");
         assertThat(queryParams.getFirst("test-collection")).isEqualTo("test-value-2,test-value-3");
         assertThat(queryParams.getFirst("test-subclass")).isEqualTo("test-value-4");


### PR DESCRIPTION
Hello,
The cf command-line client supports mapping of empty hosts.
For instance (getting an empty host for domain, one result): /v2/routes?inline-relations-depth=1&q=host%3A%3Bdomain_guid%3A6906bee2-0115-47f6-b7d1-3ef1e455e8e1
"%3A%3B" -> ":;"
The v3 client does not support this feature. Empty parameters are skiped and not set as parameters in the request url.
The following problem occurrs. You have two hosts mapped to domain and application.
When you try to get this empty host all of the hosts for this domain are returned.
Example:
ListSpaceRoutesRequest.Builder requestBuilder = ListSpaceRoutesRequest.builder();
requestBuilder.host("");   -> Ignored in the request (all host are returned)
This pull request removes the checks for empty parameters and allows using empty parametrs.
Could you please review it?
Regards,
Ivan