### PR TITLE
Fix scale application request in Applications V3 client

### DIFF
--- a/cloudfoundry-client-reactor/src/main/java/org/cloudfoundry/reactor/client/v3/applications/ReactorApplicationsV3.java
+++ b/cloudfoundry-client-reactor/src/main/java/org/cloudfoundry/reactor/client/v3/applications/ReactorApplicationsV3.java
@@ -62,6 +62,7 @@ import org.cloudfoundry.client.v3.applications.UpdateApplicationResponse;
 import org.cloudfoundry.reactor.ConnectionContext;
 import org.cloudfoundry.reactor.TokenProvider;
 import org.cloudfoundry.reactor.client.v3.AbstractClientV3Operations;
+
 import reactor.core.publisher.Mono;
 
 /**
@@ -172,7 +173,7 @@ public final class ReactorApplicationsV3 extends AbstractClientV3Operations impl
 
     @Override
     public Mono<ScaleApplicationResponse> scale(ScaleApplicationRequest request) {
-        return put(request, ScaleApplicationResponse.class, builder -> builder.pathSegment("apps", request.getApplicationId(), "processes", request.getType(), "actions", "scale"))
+        return post(request, ScaleApplicationResponse.class, builder -> builder.pathSegment("apps", request.getApplicationId(), "processes", request.getType(), "actions", "scale"))
             .checkpoint();
     }
 


### PR DESCRIPTION
This PR is intended to fix the scale of the application.
The problem is that the current request is executing PUT request agains the API and the API definition is requiring a POST request.
API definition: https://v3-apidocs.cloudfoundry.org/version/3.77.0/index.html#scale-a-process