### PR TITLE
Make docker credentials Nullable to match API definition

### DIFF
--- a/cloudfoundry-client/src/main/java/org/cloudfoundry/client/v3/packages/_DockerData.java
+++ b/cloudfoundry-client/src/main/java/org/cloudfoundry/client/v3/packages/_DockerData.java
@@ -16,9 +16,11 @@
 
 package org.cloudfoundry.client.v3.packages;
 
+import org.cloudfoundry.Nullable;
+import org.immutables.value.Value;
+
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
-import org.immutables.value.Value;
 
 /**
  * Data type for docker packages
@@ -37,12 +39,14 @@ abstract class _DockerData implements PackageData {
      * The password for the image's registry
      */
     @JsonProperty("password")
+    @Nullable
     abstract String getPassword();
 
     /**
      * The username for the image's registry
      */
     @JsonProperty("username")
+    @Nullable
     abstract String getUsername();
 
 }


### PR DESCRIPTION
According to the documentation https://v3-apidocs.cloudfoundry.org/version/3.77.0/index.html#create-a-package, the username and password should be optional when creating package of type docker.