### PR TITLE
Enable backwards compatibility of deprecated HealthCheckType value of none

### DIFF
--- a/cloudfoundry-client/src/main/java/org/cloudfoundry/client/v3/processes/HealthCheckType.java
+++ b/cloudfoundry-client/src/main/java/org/cloudfoundry/client/v3/processes/HealthCheckType.java
@@ -56,6 +56,8 @@ public enum HealthCheckType {
         switch (s.toLowerCase()) {
             case "http":
                 return HTTP;
+            case "none":
+            	return NONE;
             case "port":
                 return PORT;
             case "process":

--- a/cloudfoundry-client/src/test/java/org/cloudfoundry/client/v3/processes/HealthCheckTypeTest.java
+++ b/cloudfoundry-client/src/test/java/org/cloudfoundry/client/v3/processes/HealthCheckTypeTest.java
@@ -1,0 +1,11 @@
+package org.cloudfoundry.client.v3.processes;
+
+import org.junit.Test;
+
+public class HealthCheckTypeTest {
+
+    @Test
+    public void ensureJsonBackwardsCompatibilityForNone() throws Exception {
+    	HealthCheckType.from("none");
+    }
+}


### PR DESCRIPTION
Commercially supported versions of Cloud Foundry still includes deprecated use of the v2 value of none for the health check type in processes.

Conversation in #909 suggests that this is likely from creating the application using the v2 api.

#909 
#980

Addresses IllegalArgumentException failure during
`		PaginationUtils
			.requestClientV3Resources(
				page -> cloudFoundryClient.processes().list(ListProcessesRequest.builder().build()))
			.collectList()
...
`
when at least 1 process has 
`
        "health_check": {
            "type": "none",
            "data": {
               "timeout": null,
               "invocation_timeout": null
            }
         }
`
