### PR TITLE
Fix indefinite retry on invalid token - configurable retry

### DIFF
--- a/cloudfoundry-client-reactor/src/main/java/org/cloudfoundry/reactor/ConnectionContext.java
+++ b/cloudfoundry-client-reactor/src/main/java/org/cloudfoundry/reactor/ConnectionContext.java
@@ -56,4 +56,9 @@ public interface ConnectionContext {
      */
     Mono<Void> trust(String host, int port);
 
+    /**
+     * The number of retries after an unsuccessful request
+     */
+    Long getInvalidTokenRetries();
+
 }

--- a/cloudfoundry-client-reactor/src/main/java/org/cloudfoundry/reactor/_DefaultConnectionContext.java
+++ b/cloudfoundry-client-reactor/src/main/java/org/cloudfoundry/reactor/_DefaultConnectionContext.java
@@ -146,6 +146,12 @@ abstract class _DefaultConnectionContext implements ConnectionContext {
             .orElse(Mono.empty());
     }
 
+    @Override
+    @Value.Default
+    public Long getInvalidTokenRetries() {
+        return 5L;
+    }
+
     /**
      * The hostname of the API root. Typically something like {@code api.run.pivotal.io}.
      */

--- a/cloudfoundry-client-reactor/src/main/java/org/cloudfoundry/reactor/util/Operator.java
+++ b/cloudfoundry-client-reactor/src/main/java/org/cloudfoundry/reactor/util/Operator.java
@@ -206,7 +206,8 @@ public class Operator extends OperatorContextAware {
         private Flux<HttpClientResponseWithBody> processResponse(Flux<HttpClientResponseWithBody> inbound) {
             return inbound
                 .transform(this::invalidateToken)
-                .retry(t -> t instanceof InvalidTokenException)
+                .retry(this.context.getConnectionContext().getInvalidTokenRetries(),
+                    t -> t instanceof InvalidTokenException)
                 .transform(this.context.getErrorPayloadMapper()
                     .orElse(ErrorPayloadMappers.fallback()));
         }


### PR DESCRIPTION
Currently, on an InvalidTokenException the Operator retries the request indefinitely, which might be problematic as it'd lead to other issues if abused - IP based (unauthenticated requests) Rate Limit Exceeded for example.