### PR TITLE
Better customization options for the underlying HTTP client

### DIFF
--- a/cloudfoundry-client-reactor/src/main/java/org/cloudfoundry/reactor/_DefaultConnectionContext.java
+++ b/cloudfoundry-client-reactor/src/main/java/org/cloudfoundry/reactor/_DefaultConnectionContext.java
@@ -49,6 +49,7 @@ import java.lang.management.ManagementFactory;
 import java.time.Duration;
 import java.util.List;
 import java.util.Optional;
+import java.util.function.UnaryOperator;
 
 import static com.fasterxml.jackson.annotation.JsonInclude.Include.NON_NULL;
 import static io.netty.channel.ChannelOption.CONNECT_TIMEOUT_MILLIS;
@@ -102,9 +103,11 @@ abstract class _DefaultConnectionContext implements ConnectionContext {
     @Override
     @Value.Default
     public HttpClient getHttpClient() {
-        return createHttpClient().compress(true)
+        HttpClient client = createHttpClient().compress(true)
             .tcpConfiguration(this::configureTcpClient)
             .secure(this::configureSsl);
+        return getAdditionalHttpClientConfiguration().map(configuration -> configuration.apply(client))
+            .orElse(client);
     }
 
     @Override
@@ -225,6 +228,11 @@ abstract class _DefaultConnectionContext implements ConnectionContext {
      * The timeout for the SSL handshake negotiation
      */
     abstract Optional<Duration> getSslHandshakeTimeout();
+    
+    /**
+     * Additional configuration to the underlying HttpClient 
+     */
+    abstract Optional<UnaryOperator<HttpClient>> getAdditionalHttpClientConfiguration();
 
     @Value.Derived
     LoopResources getThreadPool() {


### PR DESCRIPTION
This change would provide an easy way to plugin in any extra custom configuration to the underlying HTTP client in the connection context. In my case I would want to be able to enable micrometer metrics.