### PR TITLE
added DOWN process state fixes cf-java-client/issues/1062

### DIFF
--- a/cloudfoundry-client/src/main/java/org/cloudfoundry/client/v3/processes/ProcessStatistics.java
+++ b/cloudfoundry-client/src/main/java/org/cloudfoundry/client/v3/processes/ProcessStatistics.java
@@ -37,18 +37,21 @@ public abstract class ProcessStatistics {
      * The disk quota
      */
     @JsonProperty("disk_quota")
+    @Nullable
     public abstract Integer getDiskQuota();
 
     /**
      * The file descriptor quota
      */
     @JsonProperty("fds_quota")
+    @Nullable
     public abstract Integer getFileDescriptorQuota();
 
     /**
      * The host
      */
     @JsonProperty("host")
+    @Nullable
     public abstract String getHost();
 
     /**
@@ -61,6 +64,7 @@ public abstract class ProcessStatistics {
      * The instance port mappings
      */
     @JsonProperty("instance_ports")
+    @Nullable
     public abstract List<PortMapping> getInstancePorts();
 
     /**
@@ -74,6 +78,7 @@ public abstract class ProcessStatistics {
      * The memory quota
      */
     @JsonProperty("mem_quota")
+    @Nullable
     public abstract Integer getMemoryQuota();
 
     /**
@@ -99,6 +104,7 @@ public abstract class ProcessStatistics {
      * The usage
      */
     @JsonProperty("usage")
+    @Nullable
     public abstract ProcessUsage getUsage();
 
 }

--- a/cloudfoundry-client/src/test/java/org/cloudfoundry/client/v3/applications/GetApplicationProcessStatisticsRequestTest.java
+++ b/cloudfoundry-client/src/test/java/org/cloudfoundry/client/v3/applications/GetApplicationProcessStatisticsRequestTest.java
@@ -16,6 +16,9 @@
 
 package org.cloudfoundry.client.v3.applications;
 
+import org.cloudfoundry.client.v3.processes.ProcessState;
+import org.cloudfoundry.client.v3.processes.ProcessStatisticsResource;
+import org.cloudfoundry.client.v3.processes.ProcessUsage;
 import org.junit.Test;
 
 public final class GetApplicationProcessStatisticsRequestTest {
@@ -42,4 +45,40 @@ public final class GetApplicationProcessStatisticsRequestTest {
             .build();
     }
 
+    @Test
+    public void validDownResponse() {
+    	ProcessStatisticsResource processStatisticsResource = ProcessStatisticsResource.builder()
+    			.type("web")
+    			.index(0)
+    			.state(ProcessState.DOWN)
+    			.uptime(new Integer(0))
+    			.build();
+        GetApplicationProcessStatisticsResponse.builder()
+        	.resource(processStatisticsResource)
+            .build();
+    }
+
+    @Test
+    public void validRunningResponse() {
+    	ProcessUsage processUsage = ProcessUsage.builder()
+    			.time("")
+    			.cpu(new Double("0.00038711029163348665"))
+    			.memory(new Integer(19177472))
+    			.disk(new Integer(69705728))
+    			.build();
+    	ProcessStatisticsResource processStatisticsResource = ProcessStatisticsResource.builder()
+    			.type("web")
+    			.index(0)
+    			.state(ProcessState.RUNNING)
+    			.host("10.244.16.10")
+    			.usage(processUsage)
+    			.uptime(new Integer(9042))
+    			.memoryQuota(new Integer(268435456))
+    			.diskQuota(new Integer(1073741824))
+    			.fileDescriptorQuota(new Integer(16384))
+    			.build();
+        GetApplicationProcessStatisticsResponse.builder()
+        	.resource(processStatisticsResource)
+            .build();
+    }
 }


### PR DESCRIPTION
ProcessStatisticsResource is inconsistent with possible responses from https://v3-apidocs.cloudfoundry.org/version/3.87.0/index.html#the-process-stats-object for processes in a DOWN state