### PR TITLE
Add automatic module names (JPMS)

### DIFF
--- a/cloudfoundry-client-reactor/pom.xml
+++ b/cloudfoundry-client-reactor/pom.xml
@@ -162,6 +162,17 @@
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-jar-plugin</artifactId>
+                <configuration>
+                    <archive>
+                        <manifestEntries>
+                            <Automatic-Module-Name>org.cloudfoundry.client.reactor</Automatic-Module-Name>
+                        </manifestEntries>
+                    </archive>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-deploy-plugin</artifactId>
             </plugin>
             <plugin>

--- a/cloudfoundry-client/pom.xml
+++ b/cloudfoundry-client/pom.xml
@@ -91,6 +91,17 @@
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-jar-plugin</artifactId>
+                <configuration>
+                    <archive>
+                        <manifestEntries>
+                            <Automatic-Module-Name>org.cloudfoundry.client</Automatic-Module-Name>
+                        </manifestEntries>
+                    </archive>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-deploy-plugin</artifactId>
             </plugin>
             <plugin>

--- a/cloudfoundry-operations/pom.xml
+++ b/cloudfoundry-operations/pom.xml
@@ -105,6 +105,17 @@
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-jar-plugin</artifactId>
+                <configuration>
+                    <archive>
+                        <manifestEntries>
+                            <Automatic-Module-Name>org.cloudfoundry.operations</Automatic-Module-Name>
+                        </manifestEntries>
+                    </archive>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-deploy-plugin</artifactId>
             </plugin>
             <plugin>

--- a/cloudfoundry-util/pom.xml
+++ b/cloudfoundry-util/pom.xml
@@ -101,6 +101,17 @@
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-jar-plugin</artifactId>
+                <configuration>
+                    <archive>
+                        <manifestEntries>
+                            <Automatic-Module-Name>org.cloudfoundry.util</Automatic-Module-Name>
+                        </manifestEntries>
+                    </archive>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-deploy-plugin</artifactId>
             </plugin>
             <plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -158,6 +158,11 @@
                 </plugin>
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-jar-plugin</artifactId>
+                    <version>3.2.0</version>
+                </plugin>
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-deploy-plugin</artifactId>
                     <version>2.8.2</version>
                 </plugin>


### PR DESCRIPTION
This is how this library is consumed in a Java 11 project:
```
module foo {
    requires cloudfoundry.client;
    requires cloudfoundry.client.reactor;
    // And the rest of the modules...
}
```
Unfortunately, this produces the following warning:
>Name of automatic module 'cloudfoundry.client' is unstable, it is derived from the module's file name.

That's because when a JAR does not contain a `module-info.class` Java assigns an automatic module name based on the JAR's name (for example, `cloudfoundry-client-4.10.0.RELEASE.jar` -> `cloudfoundry.client`). The cheapest way to remove this warning is to define a custom automatic module name with the help of the `maven-jar-plugin`. That way, Java wouldn't have to infer the module's name from the name of the JAR.

See http://branchandbound.net/blog/java/2017/12/automatic-module-name/ for more info.

I've used the package names as module names (kind-of), since that's what's recommended by Mark Reinhold (see [Proposal: #AutomaticModuleNames (revised)](http://mail.openjdk.java.net/pipermail/jpms-spec-experts/2017-May/000687.html)):
>Strongly recommend that all modules be named according to the reverse Internet domain-name convention.  A module's name should correspond to the name of its principal exported API package, which should also follow that convention.  If a module does not have such a package, or if for legacy reasons it must have a name that does not correspond to one of its exported packages, then its name should at least start with the reversed form of an Internet domain with which the author is associated.

With this PR, the library would be consumable in the following way:
```
module foo {
    requires org.cloudfoundry.client;
    requires org.cloudfoundry.client.reactor;
    requires org.cloudfoundry.operations;
    requires org.cloudfoundry.util;
}
```