### PR TITLE
Make state field nullable

### DIFF
--- a/cloudfoundry-client/src/main/java/org/cloudfoundry/client/v3/deployments/Deployment.java
+++ b/cloudfoundry-client/src/main/java/org/cloudfoundry/client/v3/deployments/Deployment.java
@@ -84,6 +84,7 @@ public abstract class Deployment extends Resource {
      */
     @Deprecated
     @JsonProperty("state")
+    @Nullable
     public abstract DeploymentState getState();
 
     /**


### PR DESCRIPTION
`state` field was long deprecated and finally removed in [CAPI v3.92](https://v3-apidocs.cloudfoundry.org/version/3.92.0/#the-deployment-object). To keep CFJC compatible with CAPI versions below 3.92,  `state` field should remain in `Deployment` object but be nullable. 