### PR TITLE
Fix parse of ProcessStatisticsResource with nullable fields

### DIFF
--- a/cloudfoundry-client-reactor/src/test/java/org/cloudfoundry/reactor/client/v3/processes/ReactorProcessesTest.java
+++ b/cloudfoundry-client-reactor/src/test/java/org/cloudfoundry/reactor/client/v3/processes/ReactorProcessesTest.java
@@ -185,6 +185,38 @@ public final class ReactorProcessesTest extends AbstractClientApiTest {
             .expectComplete()
             .verify(Duration.ofSeconds(5));
     }
+    
+    @Test
+    public void getProcessStatisticsWithNullFields() {
+        mockRequest(InteractionContext.builder()
+            .request(TestRequest.builder()
+                .method(GET).path("/processes/test-id/stats")
+                .build())
+            .response(TestResponse.builder()
+                .status(OK)
+                .payload("fixtures/client/v3/processes/GET_{id}_stats_with_null_fields_response.json")
+                .build())
+            .build());
+
+        this.processes
+            .getStatistics(GetProcessStatisticsRequest.builder()
+                .processId("test-id")
+                .build())
+            .as(StepVerifier::create)
+            .expectNext(GetProcessStatisticsResponse.builder()
+                .resource(ProcessStatisticsResource.builder()
+                    .type("web")
+                    .index(0)
+                    .state(ProcessState.STARTING)
+                    .usage(ProcessUsage.builder().build())
+                    .host("")
+                    .uptime(4L)
+                    .fileDescriptorQuota(16384L)
+                    .build())
+                .build())
+            .expectComplete()
+            .verify(Duration.ofSeconds(5));
+    }
 
     @Test
     public void list() {

--- a/cloudfoundry-client-reactor/src/test/resources/fixtures/client/v3/processes/GET_{id}_stats_with_null_fields_response.json
+++ b/cloudfoundry-client-reactor/src/test/resources/fixtures/client/v3/processes/GET_{id}_stats_with_null_fields_response.json
@@ -1,0 +1,16 @@
+{
+  "resources": [
+    {
+      "type": "web",
+      "index": 0,
+      "state": "STARTING",
+      "usage": {},
+      "host": "",
+      "instance_ports": [],
+      "uptime": 4,
+      "mem_quota": null,
+      "disk_quota": null,
+      "fds_quota": 16384
+    }
+  ]
+}

--- a/cloudfoundry-client/src/main/java/org/cloudfoundry/client/v3/processes/_ProcessStatisticsResource.java
+++ b/cloudfoundry-client/src/main/java/org/cloudfoundry/client/v3/processes/_ProcessStatisticsResource.java
@@ -31,20 +31,11 @@ abstract class _ProcessStatisticsResource extends ProcessStatistics {
         if (getState() == ProcessState.STARTING || getState() == ProcessState.RUNNING || getState() == ProcessState.CRASHED) {
             List<String> missing = new ArrayList<>();
 
-            if (getDiskQuota() == null) {
-                missing.add("diskQuota");
-            }
             if (getFileDescriptorQuota() == null) {
                 missing.add("fileDescriptorQuota");
             }
             if (getHost() == null) {
                 missing.add("host");
-            }
-            if (getMemoryQuota() == null) {
-                missing.add("memoryQuota");
-            }
-            if (getUsage() == null) {
-                missing.add("usage");
             }
 
             if (!missing.isEmpty()) {

--- a/cloudfoundry-client/src/main/java/org/cloudfoundry/client/v3/processes/_ProcessUsage.java
+++ b/cloudfoundry-client/src/main/java/org/cloudfoundry/client/v3/processes/_ProcessUsage.java
@@ -18,6 +18,7 @@ package org.cloudfoundry.client.v3.processes;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import org.cloudfoundry.Nullable;
 import org.immutables.value.Value;
 
 /**
@@ -31,24 +32,28 @@ abstract class _ProcessUsage {
      * The CPU
      */
     @JsonProperty("cpu")
+    @Nullable
     abstract Double getCpu();
 
     /**
      * The disk
      */
     @JsonProperty("disk")
+    @Nullable
     abstract Long getDisk();
 
     /**
      * The memory
      */
     @JsonProperty("mem")
+    @Nullable
     abstract Long getMemory();
 
     /**
      * The time
      */
     @JsonProperty("time")
+    @Nullable
     abstract String getTime();
 
 }


### PR DESCRIPTION
Fixes https://github.com/cloudfoundry/cf-java-client/issues/1133
Additionally I find out that `usage` field can be also nullable(empty)

> Object containing actual usage data for the instance; the value is {} when usage data is unavailable[[1]](https://v3-apidocs.cloudfoundry.org/version/3.111.0/#the-process-stats-object)