### PR TITLE
Fix for comparison of unauthorised check

### DIFF
--- a/cloudfoundry-client-reactor/src/main/java/org/cloudfoundry/reactor/util/Operator.java
+++ b/cloudfoundry-client-reactor/src/main/java/org/cloudfoundry/reactor/util/Operator.java
@@ -214,7 +214,7 @@ public class Operator extends OperatorContextAware {
         }
 
         private static boolean isUnauthorized(HttpClientResponseWithConnection response) {
-            return response.getResponse().status() == HttpResponseStatus.UNAUTHORIZED;
+            return HttpResponseStatus.UNAUTHORIZED.equals(response.getResponse().status()); 
         }
 
         private void addJsonDecoderToChannelHandlers() {


### PR DESCRIPTION
Changes comparison type from == to .equals when checking if the response is 'unauthorised'/401