### PR TITLE
CC API version 2.171.0

### DIFF
--- a/cloudfoundry-client/src/main/java/org/cloudfoundry/client/CloudFoundryClient.java
+++ b/cloudfoundry-client/src/main/java/org/cloudfoundry/client/CloudFoundryClient.java
@@ -79,7 +79,7 @@ public interface CloudFoundryClient {
     /**
      * The currently supported Cloud Controller API version
      */
-    String SUPPORTED_API_VERSION = "2.150.0";
+    String SUPPORTED_API_VERSION = "2.171.0";
 
     /**
      * Main entry point to the Cloud Foundry Application Usage Events Client API

--- a/cloudfoundry-client/src/main/java/org/cloudfoundry/client/v3/deployments/_DeploymentRelationships.java
+++ b/cloudfoundry-client/src/main/java/org/cloudfoundry/client/v3/deployments/_DeploymentRelationships.java
@@ -18,6 +18,7 @@ package org.cloudfoundry.client.v3.deployments;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import org.cloudfoundry.Nullable;
 import org.cloudfoundry.client.v3.ToOneRelationship;
 import org.immutables.value.Value;
 
@@ -32,6 +33,7 @@ abstract class _DeploymentRelationships {
      * The app relationship
      */
     @JsonProperty("app")
+    @Nullable
     abstract ToOneRelationship getApp();
 
 }

--- a/integration-test/src/test/java/org/cloudfoundry/CloudFoundryVersion.java
+++ b/integration-test/src/test/java/org/cloudfoundry/CloudFoundryVersion.java
@@ -52,6 +52,8 @@ public enum CloudFoundryVersion {
 
     PCF_2_11(Version.forIntegers(2, 164, 0)),
 
+    PCF_2_12(Version.forIntegers(2, 171, 0)),
+
     UNSPECIFIED(Version.forIntegers(0));
 
     private final Version version;


### PR DESCRIPTION
1. Adds support for CC API version 2.171.0
2. Handles the removal of the Deployment Resource's 'state' property - this data is now present in the 'status' property
3. Adds test accounting for # 2