### PR TITLE
Ensure that http client is always configured

### DIFF
--- a/cloudfoundry-client-reactor/src/main/java/org/cloudfoundry/reactor/_DefaultConnectionContext.java
+++ b/cloudfoundry-client-reactor/src/main/java/org/cloudfoundry/reactor/_DefaultConnectionContext.java
@@ -36,7 +36,6 @@ import reactor.netty.http.client.HttpClient;
 import reactor.netty.resources.ConnectionProvider;
 import reactor.netty.resources.LoopResources;
 import reactor.netty.tcp.SslProvider;
-import reactor.netty.tcp.SslProvider.DefaultConfigurationType;
 
 import javax.annotation.PostConstruct;
 import javax.annotation.PreDestroy;
@@ -103,10 +102,10 @@ abstract class _DefaultConnectionContext implements ConnectionContext {
     @Override
     @Value.Default
     public HttpClient getHttpClient() {
-        HttpClient client = createHttpClient().compress(true)
-            .secure(this::configureSsl);
+        HttpClient client = configureHttpClient(createHttpClient().compress(true)
+            .secure(this::configureSsl));
 
-        return getAdditionalHttpClientConfiguration().map(configuration -> configuration.apply(configureHttpClient(client)))
+        return getAdditionalHttpClientConfiguration().map(configuration -> configuration.apply(client))
             .orElse(client);
     }
 


### PR DESCRIPTION
Previously, if no additional http configuration was set then the default http client configuration would not be applied either. This resulted in settings like the proxy settings and wire tap settings not being applied by default, which is the intention.

Resolves #1143

Signed-off-by: Daniel Mikusa <dmikusa@vmware.com>