### PR TITLE
Fixes issue where test was not waiting for the creation of service in stance to complete

### DIFF
--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -14,7 +14,7 @@
       </list>
     </option>
   </component>
-  <component name="ProjectRootManager" version="2" languageLevel="JDK_1_8" project-jdk-name="1.8" project-jdk-type="JavaSDK">
+  <component name="ProjectRootManager" version="2" languageLevel="JDK_1_8" project-jdk-name="1.8 (2)" project-jdk-type="JavaSDK">
     <output url="file://$PROJECT_DIR$/out" />
   </component>
 </project>


### PR DESCRIPTION
The `update` test does two things: 1.) it creates a managed service instance and 2.) it updates the managed service instance. The second part was failing because CloudController will refuse to update a service that's still being created.

The update job was calling a method `waitForCompletionOnCreate` which was looking at the CreateServiceInstanceResponse object to see if it had an job id, if it did, then it would call `JobUtils.waitForCompletion(cloudFoundryClient, Duration.ofMinutes(1), createServiceInstanceResponse.getJobId().get())` and then return `getServiceInstanceIdByName(cloudFoundryClient, serviceInstanceName)`. The problem is that the call to `JobUtils.waitForCompletion` was creating a flow but nothing was subscribing to it, so it never actually ran and the test would not pause until the creation finished.

The test has been modified such that it assumes the creation request will be asynch and return a job id. If it does not for some reason, the test would fail as wel call `.get()` on an optional object and calling that if the optional is empty will generate a NoSuchElementException. Then with the jobId, we call `JobUtils.waitForCompletion` wrapped in a flatMap, which ensures it's part of the overall flow which is being subscribed to.

The same change was made after the update request, which also returns an asynch response and needs to be polled.

Signed-off-by: Daniel Mikusa <dmikusa@vmware.com>