### PR TITLE
Fix polling of async v3 jobs and make getLastOperation method public

### DIFF
--- a/cloudfoundry-client/src/main/java/org/cloudfoundry/client/v3/servicebindings/ServiceBinding.java
+++ b/cloudfoundry-client/src/main/java/org/cloudfoundry/client/v3/servicebindings/ServiceBinding.java
@@ -45,7 +45,7 @@ public abstract class ServiceBinding extends Resource {
      */
     @JsonProperty("last_operation")
     @Nullable
-    abstract LastOperation getLastOperation();
+    public abstract LastOperation getLastOperation();
 
     /**
      * The relationships


### PR DESCRIPTION
The fix related with `waitForCompletion` method is related to state [POLLING ](https://v3-apidocs.cloudfoundry.org/version/3.128.0/#jobs).

Second change is related with ability to use "lastOperation" field from [ServiceBinding](https://github.com/cloudfoundry/cf-java-client/blob/main/cloudfoundry-client/src/main/java/org/cloudfoundry/client/v3/servicebindings/ServiceBinding.java)