### PR TITLE
Updating methods in DefaultApplications to accommodate V3 specific implementation

### DIFF
--- a/cloudfoundry-operations/src/main/java/org/cloudfoundry/operations/applications/DefaultApplications.java
+++ b/cloudfoundry-operations/src/main/java/org/cloudfoundry/operations/applications/DefaultApplications.java
@@ -83,6 +83,7 @@ import org.cloudfoundry.client.v2.stacks.StackResource;
 import org.cloudfoundry.client.v3.BuildpackData;
 import org.cloudfoundry.client.v3.Lifecycle;
 import org.cloudfoundry.client.v3.Resource;
+import org.cloudfoundry.client.v3.applications.ApplicationFeature;
 import org.cloudfoundry.client.v3.applications.ApplicationResource;
 import org.cloudfoundry.client.v3.applications.GetApplicationEnvironmentRequest;
 import org.cloudfoundry.client.v3.applications.GetApplicationEnvironmentResponse;
@@ -1688,16 +1689,16 @@ public final class DefaultApplications implements Applications {
         return requestUpdateApplication(cloudFoundryClient, applicationId, builder -> builder.diskQuota(disk).instances(instances).memory(memory));
     }
 
-    private static Mono<ApplicationResource> requestUpdateApplicationSsh(CloudFoundryClient cloudFoundryClient, String applicationId, boolean enabled) {
+    private static Mono<ApplicationFeature> requestUpdateApplicationSsh(CloudFoundryClient cloudFoundryClient, String applicationId, boolean enabled) {
         return requestUpdateApplicationFeature(cloudFoundryClient, applicationId,builder -> builder.featureName(APP_FEATURE_SSH).enabled(enabled));
     }
 
-    private static Mono<ApplicationResource> requestUpdateApplicationFeature(CloudFoundryClient cloudFoundryClient, String applicationId, UnaryOperator<UpdateApplicationFeatureRequest.Builder> modifier) {
+    private static Mono<ApplicationFeature> requestUpdateApplicationFeature(CloudFoundryClient cloudFoundryClient, String applicationId, UnaryOperator<UpdateApplicationFeatureRequest.Builder> modifier) {
         return cloudFoundryClient.applicationsV3()
             .updateFeature(modifier.apply(org.cloudfoundry.client.v3.applications.UpdateApplicationFeatureRequest.builder()
                 .applicationId(applicationId))
                 .build())
-            .cast(ApplicationResource.class);
+            .cast(ApplicationFeature.class);
     }
 
     private static Mono<AbstractApplicationResource> requestUpdateApplicationState(CloudFoundryClient cloudFoundryClient, String applicationId, String state) {

--- a/cloudfoundry-operations/src/main/java/org/cloudfoundry/operations/applications/DefaultApplications.java
+++ b/cloudfoundry-operations/src/main/java/org/cloudfoundry/operations/applications/DefaultApplications.java
@@ -173,6 +173,8 @@ public final class DefaultApplications implements Applications {
 
     private static final String STOPPED_STATE = "STOPPED";
 
+    private static final String APP_FEATURE_SSH = "ssh";
+
     private final Mono<CloudFoundryClient> cloudFoundryClient;
 
     private final Mono<DopplerClient> dopplerClient;
@@ -1687,7 +1689,7 @@ public final class DefaultApplications implements Applications {
     }
 
     private static Mono<ApplicationResource> requestUpdateApplicationSsh(CloudFoundryClient cloudFoundryClient, String applicationId, boolean enabled) {
-        return requestUpdateApplicationFeature(cloudFoundryClient, applicationId,builder -> builder.featureName("ssh").enabled(enabled));
+        return requestUpdateApplicationFeature(cloudFoundryClient, applicationId,builder -> builder.featureName(APP_FEATURE_SSH).enabled(enabled));
     }
 
     private static Mono<ApplicationResource> requestUpdateApplicationFeature(CloudFoundryClient cloudFoundryClient, String applicationId, UnaryOperator<UpdateApplicationFeatureRequest.Builder> modifier) {

--- a/cloudfoundry-operations/src/test/java/org/cloudfoundry/operations/AbstractOperationsTest.java
+++ b/cloudfoundry-operations/src/test/java/org/cloudfoundry/operations/AbstractOperationsTest.java
@@ -76,6 +76,8 @@ public abstract class AbstractOperationsTest {
 
     protected static final String TEST_USERNAME = "test-username";
 
+    protected static final String APP_FEATURE_SSH = "ssh";
+
     protected final ApplicationsV2 applications = mock(ApplicationsV2.class, RETURNS_SMART_NULLS);
 
     protected final ApplicationsV3 applicationsV3 = mock(ApplicationsV3.class, RETURNS_SMART_NULLS);


### PR DESCRIPTION
Updated following methods in DefaultApplications to accommodate V3 specific implementation.
1.)sshEnabled
2.)enableSsh
3.)disableSsh
4.)getEnvironments
