### PR TITLE
Adopting API v3 Security Groups

### DIFF
--- a/cloudfoundry-client/src/main/java/org/cloudfoundry/client/v3/securitygroups/Protocol.java
+++ b/cloudfoundry-client/src/main/java/org/cloudfoundry/client/v3/securitygroups/Protocol.java
@@ -1,0 +1,79 @@
+/*
+ * Copyright 2013-2021 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.cloudfoundry.client.v3.securitygroups;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonValue;
+
+/**
+ * The protocol of a {@link RuleEntity}
+ */
+public enum Protocol {
+
+    /**
+     * All protocols
+     */
+    ALL("all"),
+
+    /**
+     * ICMP protocol
+     */
+    ICMP("icmp"),
+
+    /**
+     * TCP protocol
+     */
+    TCP("tcp"),
+
+    /**
+     * UDP protocol
+     */
+    UDP("udp");
+
+    private final String value;
+
+    Protocol(String value) {
+        this.value = value;
+    }
+
+    @JsonCreator
+    public static Protocol from(String s) {
+        switch (s.toLowerCase()) {
+            case "all":
+                return ALL;
+            case "icmp":
+                return ICMP;
+            case "tcp":
+                return TCP;
+            case "udp":
+                return UDP;
+            default:
+                throw new IllegalArgumentException(String.format("Unknown protocol: %s", s));
+        }
+    }
+
+    @JsonValue
+    public String getValue() {
+        return this.value;
+    }
+
+    @Override
+    public String toString() {
+        return getValue();
+    }
+
+}

--- a/cloudfoundry-client/src/main/java/org/cloudfoundry/client/v3/securitygroups/SecurityGroup.java
+++ b/cloudfoundry-client/src/main/java/org/cloudfoundry/client/v3/securitygroups/SecurityGroup.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright 2013-2021 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.cloudfoundry.client.v3.securitygroups;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import org.cloudfoundry.Nullable;
+import org.immutables.value.Value;
+import org.cloudfoundry.client.v3.Resource;
+import java.util.List;
+
+/**
+ * The entity response payload for the Security Group resource
+ */
+@JsonDeserialize
+public abstract class SecurityGroup extends Resource {
+
+    /**
+     * The name
+     */
+    @JsonProperty("name")
+    abstract String getName();
+
+    /**
+     * The globally enabled
+     */
+    @JsonProperty("globally_enabled")
+    @Nullable
+    abstract GloballyEnabled getGloballyEnabled();
+
+    /**
+     * The rules
+     */
+    @JsonProperty("rules")
+    @Nullable
+    abstract List<Rule> getRules();
+
+    /**
+     * The space relationships
+     */
+    @JsonProperty("relationships")
+    @Nullable
+    abstract Relationships getRelationships();
+
+}

--- a/cloudfoundry-client/src/main/java/org/cloudfoundry/client/v3/securitygroups/_CreateSecurityGroupRequest.java
+++ b/cloudfoundry-client/src/main/java/org/cloudfoundry/client/v3/securitygroups/_CreateSecurityGroupRequest.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright 2013-2021 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.cloudfoundry.client.v3.securitygroups;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+import org.cloudfoundry.Nullable;
+import org.immutables.value.Value;
+
+import java.util.List;
+
+/**
+ * The request payload for the Create a Security Group operation
+ */
+@JsonSerialize
+@Value.Immutable
+abstract class _CreateSecurityGroupRequest {
+
+    /**
+     * The security group name
+     */
+    @JsonProperty("name")
+    abstract String getName();
+
+    /**
+     * the security group glbally enabled field
+     */
+    @JsonProperty("globally_enabled")
+    @Nullable
+    abstract GloballyEnabled getGloballyEnabled();
+
+    /**
+     * The security group rules
+     */
+    @JsonProperty("rules")
+    @Nullable
+    abstract List<Rule> getRules();
+
+    /**
+     * The security group relationships
+     */
+    @JsonProperty("relationships")
+    @Nullable
+    abstract Relationships getRelationships();
+
+}

--- a/cloudfoundry-client/src/main/java/org/cloudfoundry/client/v3/securitygroups/_CreateSecurityGroupResponse.java
+++ b/cloudfoundry-client/src/main/java/org/cloudfoundry/client/v3/securitygroups/_CreateSecurityGroupResponse.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright 2013-2021 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.cloudfoundry.client.v3.securitygroups;
+
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import org.immutables.value.Value;
+
+/**
+ * The response payload for the Creating a Security Group operation
+ */
+@JsonDeserialize
+@Value.Immutable
+abstract class _CreateSecurityGroupResponse extends SecurityGroup {
+
+}

--- a/cloudfoundry-client/src/main/java/org/cloudfoundry/client/v3/securitygroups/_GloballyEnabled.java
+++ b/cloudfoundry-client/src/main/java/org/cloudfoundry/client/v3/securitygroups/_GloballyEnabled.java
@@ -1,0 +1,29 @@
+package org.cloudfoundry.client.v3.securitygroups;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import org.immutables.value.Value;
+
+/**
+ * Controls if the group is applied globally to the lifecycle of all
+ * applications
+ */
+@JsonDeserialize
+@Value.Immutable
+abstract class _GloballyEnabled {
+
+    /**
+     * Specifies whether the group should be applied globally to all running
+     * applications
+     */
+    @JsonProperty("running")
+    abstract Boolean getRunning();
+
+    /**
+     * Specifies whether the group should be applied globally to all staging
+     * applications
+     */
+    @JsonProperty("staging")
+    abstract Boolean getStaging();
+
+}

--- a/cloudfoundry-client/src/main/java/org/cloudfoundry/client/v3/securitygroups/_Relationships.java
+++ b/cloudfoundry-client/src/main/java/org/cloudfoundry/client/v3/securitygroups/_Relationships.java
@@ -1,0 +1,30 @@
+package org.cloudfoundry.client.v3.securitygroups;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import org.cloudfoundry.client.v3.ToManyRelationship;
+import org.immutables.value.Value;
+
+/**
+ * Holds relationships to running/staging spaces where security groups is
+ * applied
+ */
+@JsonDeserialize
+@Value.Immutable
+abstract class _Relationships {
+
+    /**
+     * A relationship to the spaces where the security_group is applied to
+     * applications during runtime
+     */
+    @JsonProperty("running_spaces")
+    abstract ToManyRelationship getRunningSpaces();
+
+    /**
+     * A relationship to the spaces where the security_group is applied to
+     * applications during runtime
+     */
+    @JsonProperty("staging_spaces")
+    abstract ToManyRelationship getStagingSpaces();
+
+}

--- a/cloudfoundry-client/src/main/java/org/cloudfoundry/client/v3/securitygroups/_Rule.java
+++ b/cloudfoundry-client/src/main/java/org/cloudfoundry/client/v3/securitygroups/_Rule.java
@@ -1,0 +1,80 @@
+/*
+ * Copyright 2013-2021 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.cloudfoundry.client.v3.securitygroups;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import org.cloudfoundry.Nullable;
+import org.immutables.value.Value;
+
+/**
+ * A security group rule
+ */
+@JsonDeserialize
+@Value.Immutable
+abstract class _Rule {
+
+    /**
+     * The code control signal for icmp
+     */
+    @JsonProperty("code")
+    @Nullable
+    abstract Integer getCode();
+
+    /**
+     * The description of the rule
+     */
+    @JsonProperty("description")
+    @Nullable
+    abstract String getDescription();
+
+    /**
+     * The destination
+     */
+    @JsonProperty("destination")
+    @Nullable
+    abstract String getDestination();
+
+    /**
+     * Enables logging for the egress rule
+     */
+    @JsonProperty("log")
+    @Nullable
+    abstract Boolean getLog();
+
+    /**
+     * The ports
+     */
+    @JsonProperty("ports")
+    @Nullable
+    abstract String getPorts();
+
+    /**
+     * The protocol
+     */
+    @JsonProperty("protocol")
+    @Nullable
+    abstract Protocol getProtocol();
+
+    /**
+     * The type control signal for icmp
+     */
+    @JsonProperty("type")
+    @Nullable
+    abstract Integer getType();
+
+}

--- a/cloudfoundry-client/src/test/java/org/cloudfoundry/client/v3/securitygroups/CreateSecurityGroupRequestTest.java
+++ b/cloudfoundry-client/src/test/java/org/cloudfoundry/client/v3/securitygroups/CreateSecurityGroupRequestTest.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2013-2021 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.cloudfoundry.client.v3.securitygroups;
+
+import org.junit.Test;
+
+public class CreateSecurityGroupRequestTest {
+
+    @Test(expected = IllegalStateException.class)
+    public void noName() {
+        CreateSecurityGroupRequest.builder()
+                .rule(Rule.builder().build())
+                .build();
+    }
+
+}


### PR DESCRIPTION
Security Groups [API v3](https://v3-apidocs.cloudfoundry.org/version/3.140.0/index.html#security-groups) was missing.  