### PR TITLE
Adopting  Security Groups API V3 

### DIFF
--- a/cloudfoundry-client-reactor/src/main/java/org/cloudfoundry/reactor/client/_ReactorCloudFoundryClient.java
+++ b/cloudfoundry-client-reactor/src/main/java/org/cloudfoundry/reactor/client/_ReactorCloudFoundryClient.java
@@ -34,6 +34,7 @@ import org.cloudfoundry.client.v2.resourcematch.ResourceMatch;
 import org.cloudfoundry.client.v2.routemappings.RouteMappings;
 import org.cloudfoundry.client.v2.routes.Routes;
 import org.cloudfoundry.client.v2.securitygroups.SecurityGroups;
+import org.cloudfoundry.client.v3.securitygroups.SecurityGroupsV3;
 import org.cloudfoundry.client.v2.servicebindings.ServiceBindingsV2;
 import org.cloudfoundry.client.v2.servicebrokers.ServiceBrokers;
 import org.cloudfoundry.client.v2.serviceinstances.ServiceInstances;
@@ -91,6 +92,7 @@ import org.cloudfoundry.reactor.client.v2.resourcematch.ReactorResourceMatch;
 import org.cloudfoundry.reactor.client.v2.routemappings.ReactorRouteMappings;
 import org.cloudfoundry.reactor.client.v2.routes.ReactorRoutes;
 import org.cloudfoundry.reactor.client.v2.securitygroups.ReactorSecurityGroups;
+import org.cloudfoundry.reactor.client.v3.securitygroups.ReactorSecurityGroupsV3;
 import org.cloudfoundry.reactor.client.v2.servicebindings.ReactorServiceBindingsV2;
 import org.cloudfoundry.reactor.client.v2.servicebrokers.ReactorServiceBrokers;
 import org.cloudfoundry.reactor.client.v2.serviceinstances.ReactorServiceInstances;
@@ -151,7 +153,8 @@ abstract class _ReactorCloudFoundryClient implements CloudFoundryClient {
     @Override
     @Value.Derived
     public ApplicationUsageEvents applicationUsageEvents() {
-        return new ReactorApplicationUsageEvents(getConnectionContext(), getRootV2(), getTokenProvider(), getRequestTags());
+        return new ReactorApplicationUsageEvents(getConnectionContext(), getRootV2(), getTokenProvider(),
+                getRequestTags());
     }
 
     @Override
@@ -228,7 +231,8 @@ abstract class _ReactorCloudFoundryClient implements CloudFoundryClient {
     @Override
     @Value.Derived
     public EnvironmentVariableGroups environmentVariableGroups() {
-        return new ReactorEnvironmentVariableGroups(getConnectionContext(), getRootV2(), getTokenProvider(), getRequestTags());
+        return new ReactorEnvironmentVariableGroups(getConnectionContext(), getRootV2(), getTokenProvider(),
+                getRequestTags());
     }
 
     @Override
@@ -270,7 +274,8 @@ abstract class _ReactorCloudFoundryClient implements CloudFoundryClient {
     @Override
     @Value.Derived
     public OrganizationQuotaDefinitions organizationQuotaDefinitions() {
-        return new ReactorOrganizationQuotaDefinitions(getConnectionContext(), getRootV2(), getTokenProvider(), getRequestTags());
+        return new ReactorOrganizationQuotaDefinitions(getConnectionContext(), getRootV2(), getTokenProvider(),
+                getRequestTags());
     }
 
     @Override
@@ -347,6 +352,12 @@ abstract class _ReactorCloudFoundryClient implements CloudFoundryClient {
 
     @Override
     @Value.Derived
+    public SecurityGroupsV3 securityGroupsV3() {
+        return new ReactorSecurityGroupsV3(getConnectionContext(), getRootV2(), getTokenProvider(), getRequestTags());
+    }
+
+    @Override
+    @Value.Derived
     public ServiceBindingsV2 serviceBindingsV2() {
         return new ReactorServiceBindingsV2(getConnectionContext(), getRootV2(), getTokenProvider(), getRequestTags());
     }
@@ -366,7 +377,7 @@ abstract class _ReactorCloudFoundryClient implements CloudFoundryClient {
     @Override
     @Value.Derived
     public ServiceBrokersV3 serviceBrokersV3() {
-	return new ReactorServiceBrokersV3(getConnectionContext(), getRootV3(), getTokenProvider(), getRequestTags());
+        return new ReactorServiceBrokersV3(getConnectionContext(), getRootV3(), getTokenProvider(), getRequestTags());
     }
 
     @Override
@@ -396,7 +407,8 @@ abstract class _ReactorCloudFoundryClient implements CloudFoundryClient {
     @Override
     @Value.Derived
     public ServicePlanVisibilities servicePlanVisibilities() {
-        return new ReactorServicePlanVisibilities(getConnectionContext(), getRootV2(), getTokenProvider(), getRequestTags());
+        return new ReactorServicePlanVisibilities(getConnectionContext(), getRootV2(), getTokenProvider(),
+                getRequestTags());
     }
 
     @Override
@@ -432,7 +444,8 @@ abstract class _ReactorCloudFoundryClient implements CloudFoundryClient {
     @Override
     @Value.Derived
     public SpaceQuotaDefinitions spaceQuotaDefinitions() {
-        return new ReactorSpaceQuotaDefinitions(getConnectionContext(), getRootV2(), getTokenProvider(), getRequestTags());
+        return new ReactorSpaceQuotaDefinitions(getConnectionContext(), getRootV2(), getTokenProvider(),
+                getRequestTags());
     }
 
     @Override
@@ -468,7 +481,8 @@ abstract class _ReactorCloudFoundryClient implements CloudFoundryClient {
     @Override
     @Value.Derived
     public UserProvidedServiceInstances userProvidedServiceInstances() {
-        return new ReactorUserProvidedServiceInstances(getConnectionContext(), getRootV2(), getTokenProvider(), getRequestTags());
+        return new ReactorUserProvidedServiceInstances(getConnectionContext(), getRootV2(), getTokenProvider(),
+                getRequestTags());
     }
 
     @Override
@@ -483,7 +497,8 @@ abstract class _ReactorCloudFoundryClient implements CloudFoundryClient {
     abstract ConnectionContext getConnectionContext();
 
     /**
-     * Map of http header name and value which will be added to every request to the controller
+     * Map of http header name and value which will be added to every request to the
+     * controller
      */
     @Value.Default
     Map<String, String> getRequestTags() {

--- a/cloudfoundry-client-reactor/src/main/java/org/cloudfoundry/reactor/client/_ReactorCloudFoundryClient.java
+++ b/cloudfoundry-client-reactor/src/main/java/org/cloudfoundry/reactor/client/_ReactorCloudFoundryClient.java
@@ -353,7 +353,7 @@ abstract class _ReactorCloudFoundryClient implements CloudFoundryClient {
     @Override
     @Value.Derived
     public SecurityGroupsV3 securityGroupsV3() {
-        return new ReactorSecurityGroupsV3(getConnectionContext(), getRootV2(), getTokenProvider(), getRequestTags());
+        return new ReactorSecurityGroupsV3(getConnectionContext(), getRootV3(), getTokenProvider(), getRequestTags());
     }
 
     @Override

--- a/cloudfoundry-client-reactor/src/main/java/org/cloudfoundry/reactor/client/v3/securitygroups/ReactorSecurityGroupsV3.java
+++ b/cloudfoundry-client-reactor/src/main/java/org/cloudfoundry/reactor/client/v3/securitygroups/ReactorSecurityGroupsV3.java
@@ -24,12 +24,15 @@ import org.cloudfoundry.client.v3.securitygroups.DeleteSecurityGroupRequest;
 import org.cloudfoundry.client.v3.securitygroups.UpdateSecurityGroupRequest;
 import org.cloudfoundry.client.v3.securitygroups.GetSecurityGroupResponse;
 import org.cloudfoundry.client.v3.securitygroups.UpdateSecurityGroupResponse;
+import org.cloudfoundry.client.v3.servicebindings.ServiceBindingsV3;
 import org.cloudfoundry.client.v3.securitygroups.ListSecurityGroupsRequest;
 import org.cloudfoundry.client.v3.securitygroups.ListSecurityGroupsResponse;
 import org.cloudfoundry.client.v3.securitygroups.BindRunningSecurityGroupRequest;
 import org.cloudfoundry.client.v3.securitygroups.BindRunningSecurityGroupResponse;
 import org.cloudfoundry.client.v3.securitygroups.BindStagingSecurityGroupRequest;
 import org.cloudfoundry.client.v3.securitygroups.BindStagingSecurityGroupResponse;
+import org.cloudfoundry.client.v3.securitygroups.UnbindRunningSecurityGroupRequest;
+import org.cloudfoundry.client.v3.securitygroups.UnbindStagingSecurityGroupRequest;
 import org.cloudfoundry.reactor.ConnectionContext;
 import org.cloudfoundry.reactor.TokenProvider;
 import org.cloudfoundry.reactor.client.v3.AbstractClientV3Operations;
@@ -114,6 +117,26 @@ public final class ReactorSecurityGroupsV3 extends AbstractClientV3Operations im
                                 builder -> builder.pathSegment("security_groups", request.getSecurityGroupId(),
                                                 "relationships",
                                                 "staging_spaces"))
+                                .checkpoint();
+        }
+
+        @Override
+        public Mono<Void> unbindStagingSecurityGroup(
+                        UnbindStagingSecurityGroupRequest request) {
+                return delete(request, Void.class,
+                                builder -> builder.pathSegment("security_groups", request.getSecurityGroupId(),
+                                                "relationships",
+                                                "staging_spaces", request.getSpaceId()))
+                                .checkpoint();
+        }
+
+        @Override
+        public Mono<Void> unbindRunningSecurityGroup(
+                        UnbindRunningSecurityGroupRequest request) {
+                return delete(request, Void.class,
+                                builder -> builder.pathSegment("security_groups", request.getSecurityGroupId(),
+                                                "relationships",
+                                                "running_spaces", request.getSpaceId()))
                                 .checkpoint();
         }
 }

--- a/cloudfoundry-client-reactor/src/main/java/org/cloudfoundry/reactor/client/v3/securitygroups/ReactorSecurityGroupsV3.java
+++ b/cloudfoundry-client-reactor/src/main/java/org/cloudfoundry/reactor/client/v3/securitygroups/ReactorSecurityGroupsV3.java
@@ -21,6 +21,8 @@ import org.cloudfoundry.client.v3.securitygroups.CreateSecurityGroupRequest;
 import org.cloudfoundry.client.v3.securitygroups.CreateSecurityGroupResponse;
 import org.cloudfoundry.client.v3.securitygroups.GetSecurityGroupRequest;
 import org.cloudfoundry.client.v3.securitygroups.GetSecurityGroupResponse;
+import org.cloudfoundry.client.v3.securitygroups.ListSecurityGroupsRequest;
+import org.cloudfoundry.client.v3.securitygroups.ListSecurityGroupsResponse;
 import org.cloudfoundry.reactor.ConnectionContext;
 import org.cloudfoundry.reactor.TokenProvider;
 import org.cloudfoundry.reactor.client.v3.AbstractClientV3Operations;
@@ -64,4 +66,10 @@ public final class ReactorSecurityGroupsV3 extends AbstractClientV3Operations im
 
     }
 
+    @Override
+    public Mono<ListSecurityGroupsResponse> list(ListSecurityGroupsRequest request) {
+        return get(request, ListSecurityGroupsResponse.class,
+                builder -> builder.pathSegment("security_groups"))
+                .checkpoint();
+    }
 }

--- a/cloudfoundry-client-reactor/src/main/java/org/cloudfoundry/reactor/client/v3/securitygroups/ReactorSecurityGroupsV3.java
+++ b/cloudfoundry-client-reactor/src/main/java/org/cloudfoundry/reactor/client/v3/securitygroups/ReactorSecurityGroupsV3.java
@@ -26,6 +26,10 @@ import org.cloudfoundry.client.v3.securitygroups.GetSecurityGroupResponse;
 import org.cloudfoundry.client.v3.securitygroups.UpdateSecurityGroupResponse;
 import org.cloudfoundry.client.v3.securitygroups.ListSecurityGroupsRequest;
 import org.cloudfoundry.client.v3.securitygroups.ListSecurityGroupsResponse;
+import org.cloudfoundry.client.v3.securitygroups.BindRunningSecurityGroupRequest;
+import org.cloudfoundry.client.v3.securitygroups.BindRunningSecurityGroupResponse;
+import org.cloudfoundry.client.v3.securitygroups.BindStagingSecurityGroupRequest;
+import org.cloudfoundry.client.v3.securitygroups.BindStagingSecurityGroupResponse;
 import org.cloudfoundry.reactor.ConnectionContext;
 import org.cloudfoundry.reactor.TokenProvider;
 import org.cloudfoundry.reactor.client.v3.AbstractClientV3Operations;
@@ -89,5 +93,21 @@ public final class ReactorSecurityGroupsV3 extends AbstractClientV3Operations im
                 builder -> builder.pathSegment("security_groups", request.getSecurityGroupId()))
                 .checkpoint();
 
+    }
+
+    @Override
+    public Mono<BindRunningSecurityGroupResponse> bindRunningSecurityGroup(BindRunningSecurityGroupRequest request) {
+        return post(request, BindRunningSecurityGroupResponse.class,
+                builder -> builder.pathSegment("security_groups", request.getSecurityGroupId(), "relationships",
+                        "running_spaces"))
+                .checkpoint();
+    }
+
+    @Override
+    public Mono<BindStagingSecurityGroupResponse> bindStagingSecurityGroup(BindStagingSecurityGroupRequest request) {
+        return post(request, BindStagingSecurityGroupResponse.class,
+                builder -> builder.pathSegment("security_groups", request.getSecurityGroupId(), "relationships",
+                        "staging_spaces"))
+                .checkpoint();
     }
 }

--- a/cloudfoundry-client-reactor/src/main/java/org/cloudfoundry/reactor/client/v3/securitygroups/ReactorSecurityGroupsV3.java
+++ b/cloudfoundry-client-reactor/src/main/java/org/cloudfoundry/reactor/client/v3/securitygroups/ReactorSecurityGroupsV3.java
@@ -41,73 +41,79 @@ import java.util.Map;
  */
 public final class ReactorSecurityGroupsV3 extends AbstractClientV3Operations implements SecurityGroupsV3 {
 
-    /**
-     * Creates an instance
-     *
-     * @param connectionContext the {@link ConnectionContext} to use when
-     *                          communicating with the server
-     * @param root              the root URI of the server. Typically something like
-     *                          {@code https://api.run.pivotal.io}.
-     * @param tokenProvider     the {@link TokenProvider} to use when communicating
-     *                          with the server
-     * @param requestTags       map with custom http headers which will be added to
-     *                          web request
-     */
-    public ReactorSecurityGroupsV3(ConnectionContext connectionContext, Mono<String> root, TokenProvider tokenProvider,
-            Map<String, String> requestTags) {
-        super(connectionContext, root, tokenProvider, requestTags);
-    }
+        /**
+         * Creates an instance
+         *
+         * @param connectionContext the {@link ConnectionContext} to use when
+         *                          communicating with the server
+         * @param root              the root URI of the server. Typically something like
+         *                          {@code https://api.run.pivotal.io}.
+         * @param tokenProvider     the {@link TokenProvider} to use when communicating
+         *                          with the server
+         * @param requestTags       map with custom http headers which will be added to
+         *                          web request
+         */
+        public ReactorSecurityGroupsV3(ConnectionContext connectionContext, Mono<String> root,
+                        TokenProvider tokenProvider,
+                        Map<String, String> requestTags) {
+                super(connectionContext, root, tokenProvider, requestTags);
+        }
 
-    @Override
-    public Mono<CreateSecurityGroupResponse> create(CreateSecurityGroupRequest request) {
-        return post(request, CreateSecurityGroupResponse.class, builder -> builder.pathSegment("security_groups"))
-                .checkpoint();
+        @Override
+        public Mono<CreateSecurityGroupResponse> create(CreateSecurityGroupRequest request) {
+                return post(request, CreateSecurityGroupResponse.class,
+                                builder -> builder.pathSegment("security_groups"))
+                                .checkpoint();
 
-    }
+        }
 
-    @Override
-    public Mono<GetSecurityGroupResponse> get(GetSecurityGroupRequest request) {
-        return get(request, GetSecurityGroupResponse.class,
-                builder -> builder.pathSegment("security_groups", request.getSecurityGroupId()))
-                .checkpoint();
+        @Override
+        public Mono<GetSecurityGroupResponse> get(GetSecurityGroupRequest request) {
+                return get(request, GetSecurityGroupResponse.class,
+                                builder -> builder.pathSegment("security_groups", request.getSecurityGroupId()))
+                                .checkpoint();
 
-    }
+        }
 
-    @Override
-    public Mono<ListSecurityGroupsResponse> list(ListSecurityGroupsRequest request) {
-        return get(request, ListSecurityGroupsResponse.class,
-                builder -> builder.pathSegment("security_groups"))
-                .checkpoint();
-    }
+        @Override
+        public Mono<ListSecurityGroupsResponse> list(ListSecurityGroupsRequest request) {
+                return get(request, ListSecurityGroupsResponse.class,
+                                builder -> builder.pathSegment("security_groups"))
+                                .checkpoint();
+        }
 
-    @Override
-    public Mono<UpdateSecurityGroupResponse> update(UpdateSecurityGroupRequest request) {
-        return patch(request, UpdateSecurityGroupResponse.class,
-                builder -> builder.pathSegment("security_groups", request.getSecurityGroupId()))
-                .checkpoint();
-    }
+        @Override
+        public Mono<UpdateSecurityGroupResponse> update(UpdateSecurityGroupRequest request) {
+                return patch(request, UpdateSecurityGroupResponse.class,
+                                builder -> builder.pathSegment("security_groups", request.getSecurityGroupId()))
+                                .checkpoint();
+        }
 
-    @Override
-    public Mono<String> delete(DeleteSecurityGroupRequest request) {
-        return delete(request, String.class,
-                builder -> builder.pathSegment("security_groups", request.getSecurityGroupId()))
-                .checkpoint();
+        @Override
+        public Mono<String> delete(DeleteSecurityGroupRequest request) {
+                return delete(request,
+                                builder -> builder.pathSegment("security_groups", request.getSecurityGroupId()))
+                                .checkpoint();
 
-    }
+        }
 
-    @Override
-    public Mono<BindRunningSecurityGroupResponse> bindRunningSecurityGroup(BindRunningSecurityGroupRequest request) {
-        return post(request, BindRunningSecurityGroupResponse.class,
-                builder -> builder.pathSegment("security_groups", request.getSecurityGroupId(), "relationships",
-                        "running_spaces"))
-                .checkpoint();
-    }
+        @Override
+        public Mono<BindRunningSecurityGroupResponse> bindRunningSecurityGroup(
+                        BindRunningSecurityGroupRequest request) {
+                return post(request, BindRunningSecurityGroupResponse.class,
+                                builder -> builder.pathSegment("security_groups", request.getSecurityGroupId(),
+                                                "relationships",
+                                                "running_spaces"))
+                                .checkpoint();
+        }
 
-    @Override
-    public Mono<BindStagingSecurityGroupResponse> bindStagingSecurityGroup(BindStagingSecurityGroupRequest request) {
-        return post(request, BindStagingSecurityGroupResponse.class,
-                builder -> builder.pathSegment("security_groups", request.getSecurityGroupId(), "relationships",
-                        "staging_spaces"))
-                .checkpoint();
-    }
+        @Override
+        public Mono<BindStagingSecurityGroupResponse> bindStagingSecurityGroup(
+                        BindStagingSecurityGroupRequest request) {
+                return post(request, BindStagingSecurityGroupResponse.class,
+                                builder -> builder.pathSegment("security_groups", request.getSecurityGroupId(),
+                                                "relationships",
+                                                "staging_spaces"))
+                                .checkpoint();
+        }
 }

--- a/cloudfoundry-client-reactor/src/main/java/org/cloudfoundry/reactor/client/v3/securitygroups/ReactorSecurityGroupsV3.java
+++ b/cloudfoundry-client-reactor/src/main/java/org/cloudfoundry/reactor/client/v3/securitygroups/ReactorSecurityGroupsV3.java
@@ -1,17 +1,15 @@
 /*
- * Copyright 2013-2021 the original author or authors.
+ * Copyright 2013-2023 the original author or authors.
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ * http://www.apache.org/licenses/LICENSE-2.0
  *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
  */
 
 package org.cloudfoundry.reactor.client.v3.securitygroups;
@@ -46,61 +44,56 @@ import java.util.Map;
 /**
  * The Reactor-based implementation of {@link ServiceBindingsV3}
  */
-public final class ReactorSecurityGroupsV3 extends AbstractClientV3Operations implements SecurityGroupsV3 {
+public final class ReactorSecurityGroupsV3 extends AbstractClientV3Operations
+                implements SecurityGroupsV3 {
 
         /**
          * Creates an instance
          *
-         * @param connectionContext the {@link ConnectionContext} to use when
-         *                          communicating with the server
-         * @param root              the root URI of the server. Typically something like
-         *                          {@code https://api.run.pivotal.io}.
-         * @param tokenProvider     the {@link TokenProvider} to use when communicating
-         *                          with the server
-         * @param requestTags       map with custom http headers which will be added to
-         *                          web request
+         * @param connectionContext the {@link ConnectionContext} to use when communicating with the
+         *        server
+         * @param root the root URI of the server. Typically something like
+         *        {@code https://api.run.pivotal.io}.
+         * @param tokenProvider the {@link TokenProvider} to use when communicating with the server
+         * @param requestTags map with custom http headers which will be added to web request
          */
         public ReactorSecurityGroupsV3(ConnectionContext connectionContext, Mono<String> root,
-                        TokenProvider tokenProvider,
-                        Map<String, String> requestTags) {
+                        TokenProvider tokenProvider, Map<String, String> requestTags) {
                 super(connectionContext, root, tokenProvider, requestTags);
         }
 
         @Override
         public Mono<CreateSecurityGroupResponse> create(CreateSecurityGroupRequest request) {
                 return post(request, CreateSecurityGroupResponse.class,
-                                builder -> builder.pathSegment("security_groups"))
-                                .checkpoint();
+                                builder -> builder.pathSegment("security_groups")).checkpoint();
 
         }
 
         @Override
         public Mono<GetSecurityGroupResponse> get(GetSecurityGroupRequest request) {
-                return get(request, GetSecurityGroupResponse.class,
-                                builder -> builder.pathSegment("security_groups", request.getSecurityGroupId()))
-                                .checkpoint();
+                return get(request, GetSecurityGroupResponse.class, builder -> builder
+                                .pathSegment("security_groups", request.getSecurityGroupId()))
+                                                .checkpoint();
 
         }
 
         @Override
         public Mono<ListSecurityGroupsResponse> list(ListSecurityGroupsRequest request) {
                 return get(request, ListSecurityGroupsResponse.class,
-                                builder -> builder.pathSegment("security_groups"))
-                                .checkpoint();
+                                builder -> builder.pathSegment("security_groups")).checkpoint();
         }
 
         @Override
         public Mono<UpdateSecurityGroupResponse> update(UpdateSecurityGroupRequest request) {
-                return patch(request, UpdateSecurityGroupResponse.class,
-                                builder -> builder.pathSegment("security_groups", request.getSecurityGroupId()))
-                                .checkpoint();
+                return patch(request, UpdateSecurityGroupResponse.class, builder -> builder
+                                .pathSegment("security_groups", request.getSecurityGroupId()))
+                                                .checkpoint();
         }
 
         @Override
         public Mono<String> delete(DeleteSecurityGroupRequest request) {
-                return delete(request,
-                                builder -> builder.pathSegment("security_groups", request.getSecurityGroupId()))
-                                .checkpoint();
+                return delete(request, builder -> builder.pathSegment("security_groups",
+                                request.getSecurityGroupId())).checkpoint();
 
         }
 
@@ -108,55 +101,51 @@ public final class ReactorSecurityGroupsV3 extends AbstractClientV3Operations im
         public Mono<BindRunningSecurityGroupResponse> bindRunningSecurityGroup(
                         BindRunningSecurityGroupRequest request) {
                 return post(request, BindRunningSecurityGroupResponse.class,
-                                builder -> builder.pathSegment("security_groups", request.getSecurityGroupId(),
-                                                "relationships",
-                                                "running_spaces"))
-                                .checkpoint();
+                                builder -> builder.pathSegment("security_groups",
+                                                request.getSecurityGroupId(), "relationships",
+                                                "running_spaces")).checkpoint();
         }
 
         @Override
         public Mono<BindStagingSecurityGroupResponse> bindStagingSecurityGroup(
                         BindStagingSecurityGroupRequest request) {
                 return post(request, BindStagingSecurityGroupResponse.class,
-                                builder -> builder.pathSegment("security_groups", request.getSecurityGroupId(),
-                                                "relationships",
-                                                "staging_spaces"))
-                                .checkpoint();
+                                builder -> builder.pathSegment("security_groups",
+                                                request.getSecurityGroupId(), "relationships",
+                                                "staging_spaces")).checkpoint();
         }
 
         @Override
-        public Mono<Void> unbindStagingSecurityGroup(
-                        UnbindStagingSecurityGroupRequest request) {
+        public Mono<Void> unbindStagingSecurityGroup(UnbindStagingSecurityGroupRequest request) {
                 return delete(request, Void.class,
-                                builder -> builder.pathSegment("security_groups", request.getSecurityGroupId(),
-                                                "relationships",
+                                builder -> builder.pathSegment("security_groups",
+                                                request.getSecurityGroupId(), "relationships",
                                                 "staging_spaces", request.getSpaceId()))
-                                .checkpoint();
+                                                                .checkpoint();
         }
 
         @Override
-        public Mono<Void> unbindRunningSecurityGroup(
-                        UnbindRunningSecurityGroupRequest request) {
+        public Mono<Void> unbindRunningSecurityGroup(UnbindRunningSecurityGroupRequest request) {
                 return delete(request, Void.class,
-                                builder -> builder.pathSegment("security_groups", request.getSecurityGroupId(),
-                                                "relationships",
+                                builder -> builder.pathSegment("security_groups",
+                                                request.getSecurityGroupId(), "relationships",
                                                 "running_spaces", request.getSpaceId()))
-                                .checkpoint();
+                                                                .checkpoint();
         }
 
         @Override
-        public Mono<ListRunningSecurityGroupsResponse> listRunning(ListRunningSecurityGroupsRequest request) {
+        public Mono<ListRunningSecurityGroupsResponse> listRunning(
+                        ListRunningSecurityGroupsRequest request) {
                 return get(request, ListRunningSecurityGroupsResponse.class,
                                 builder -> builder.pathSegment("spaces", request.getSpaceId(),
-                                                "running_security_groups"))
-                                .checkpoint();
+                                                "running_security_groups")).checkpoint();
         }
 
         @Override
-        public Mono<ListStagingSecurityGroupsResponse> listStaging(ListStagingSecurityGroupsRequest request) {
+        public Mono<ListStagingSecurityGroupsResponse> listStaging(
+                        ListStagingSecurityGroupsRequest request) {
                 return get(request, ListStagingSecurityGroupsResponse.class,
                                 builder -> builder.pathSegment("spaces", request.getSpaceId(),
-                                                "staging_security_groups"))
-                                .checkpoint();
+                                                "staging_security_groups")).checkpoint();
         }
 }

--- a/cloudfoundry-client-reactor/src/main/java/org/cloudfoundry/reactor/client/v3/securitygroups/ReactorSecurityGroupsV3.java
+++ b/cloudfoundry-client-reactor/src/main/java/org/cloudfoundry/reactor/client/v3/securitygroups/ReactorSecurityGroupsV3.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright 2013-2021 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.cloudfoundry.reactor.client.v3.securitygroups;
+
+import org.cloudfoundry.client.v3.securitygroups.SecurityGroupsV3;
+import org.cloudfoundry.client.v3.securitygroups.CreateSecurityGroupRequest;
+import org.cloudfoundry.client.v3.securitygroups.CreateSecurityGroupResponse;
+import org.cloudfoundry.reactor.ConnectionContext;
+import org.cloudfoundry.reactor.TokenProvider;
+import org.cloudfoundry.reactor.client.v3.AbstractClientV3Operations;
+import reactor.core.publisher.Mono;
+import java.util.Map;
+
+/**
+ * The Reactor-based implementation of {@link ServiceBindingsV3}
+ */
+public final class ReactorSecurityGroupsV3 extends AbstractClientV3Operations implements SecurityGroupsV3 {
+
+    /**
+     * Creates an instance
+     *
+     * @param connectionContext the {@link ConnectionContext} to use when
+     *                          communicating with the server
+     * @param root              the root URI of the server. Typically something like
+     *                          {@code https://api.run.pivotal.io}.
+     * @param tokenProvider     the {@link TokenProvider} to use when communicating
+     *                          with the server
+     * @param requestTags       map with custom http headers which will be added to
+     *                          web request
+     */
+    public ReactorSecurityGroupsV3(ConnectionContext connectionContext, Mono<String> root, TokenProvider tokenProvider,
+            Map<String, String> requestTags) {
+        super(connectionContext, root, tokenProvider, requestTags);
+    }
+
+    @Override
+    public Mono<CreateSecurityGroupResponse> create(CreateSecurityGroupRequest request) {
+        return post(request, CreateSecurityGroupResponse.class, builder -> builder.pathSegment("security_groups"))
+                .checkpoint();
+
+    }
+
+}

--- a/cloudfoundry-client-reactor/src/main/java/org/cloudfoundry/reactor/client/v3/securitygroups/ReactorSecurityGroupsV3.java
+++ b/cloudfoundry-client-reactor/src/main/java/org/cloudfoundry/reactor/client/v3/securitygroups/ReactorSecurityGroupsV3.java
@@ -27,6 +27,10 @@ import org.cloudfoundry.client.v3.securitygroups.UpdateSecurityGroupResponse;
 import org.cloudfoundry.client.v3.servicebindings.ServiceBindingsV3;
 import org.cloudfoundry.client.v3.securitygroups.ListSecurityGroupsRequest;
 import org.cloudfoundry.client.v3.securitygroups.ListSecurityGroupsResponse;
+import org.cloudfoundry.client.v3.securitygroups.ListRunningSecurityGroupsRequest;
+import org.cloudfoundry.client.v3.securitygroups.ListRunningSecurityGroupsResponse;
+import org.cloudfoundry.client.v3.securitygroups.ListStagingSecurityGroupsRequest;
+import org.cloudfoundry.client.v3.securitygroups.ListStagingSecurityGroupsResponse;
 import org.cloudfoundry.client.v3.securitygroups.BindRunningSecurityGroupRequest;
 import org.cloudfoundry.client.v3.securitygroups.BindRunningSecurityGroupResponse;
 import org.cloudfoundry.client.v3.securitygroups.BindStagingSecurityGroupRequest;
@@ -137,6 +141,22 @@ public final class ReactorSecurityGroupsV3 extends AbstractClientV3Operations im
                                 builder -> builder.pathSegment("security_groups", request.getSecurityGroupId(),
                                                 "relationships",
                                                 "running_spaces", request.getSpaceId()))
+                                .checkpoint();
+        }
+
+        @Override
+        public Mono<ListRunningSecurityGroupsResponse> listRunning(ListRunningSecurityGroupsRequest request) {
+                return get(request, ListRunningSecurityGroupsResponse.class,
+                                builder -> builder.pathSegment("spaces", request.getSpaceId(),
+                                                "running_security_groups"))
+                                .checkpoint();
+        }
+
+        @Override
+        public Mono<ListStagingSecurityGroupsResponse> listStaging(ListStagingSecurityGroupsRequest request) {
+                return get(request, ListStagingSecurityGroupsResponse.class,
+                                builder -> builder.pathSegment("spaces", request.getSpaceId(),
+                                                "staging_security_groups"))
                                 .checkpoint();
         }
 }

--- a/cloudfoundry-client-reactor/src/main/java/org/cloudfoundry/reactor/client/v3/securitygroups/ReactorSecurityGroupsV3.java
+++ b/cloudfoundry-client-reactor/src/main/java/org/cloudfoundry/reactor/client/v3/securitygroups/ReactorSecurityGroupsV3.java
@@ -20,7 +20,9 @@ import org.cloudfoundry.client.v3.securitygroups.SecurityGroupsV3;
 import org.cloudfoundry.client.v3.securitygroups.CreateSecurityGroupRequest;
 import org.cloudfoundry.client.v3.securitygroups.CreateSecurityGroupResponse;
 import org.cloudfoundry.client.v3.securitygroups.GetSecurityGroupRequest;
+import org.cloudfoundry.client.v3.securitygroups.UpdateSecurityGroupRequest;
 import org.cloudfoundry.client.v3.securitygroups.GetSecurityGroupResponse;
+import org.cloudfoundry.client.v3.securitygroups.UpdateSecurityGroupResponse;
 import org.cloudfoundry.client.v3.securitygroups.ListSecurityGroupsRequest;
 import org.cloudfoundry.client.v3.securitygroups.ListSecurityGroupsResponse;
 import org.cloudfoundry.reactor.ConnectionContext;
@@ -70,6 +72,13 @@ public final class ReactorSecurityGroupsV3 extends AbstractClientV3Operations im
     public Mono<ListSecurityGroupsResponse> list(ListSecurityGroupsRequest request) {
         return get(request, ListSecurityGroupsResponse.class,
                 builder -> builder.pathSegment("security_groups"))
+                .checkpoint();
+    }
+
+    @Override
+    public Mono<UpdateSecurityGroupResponse> update(UpdateSecurityGroupRequest request) {
+        return patch(request, UpdateSecurityGroupResponse.class,
+                builder -> builder.pathSegment("security_groups", request.getSecurityGroupId()))
                 .checkpoint();
     }
 }

--- a/cloudfoundry-client-reactor/src/main/java/org/cloudfoundry/reactor/client/v3/securitygroups/ReactorSecurityGroupsV3.java
+++ b/cloudfoundry-client-reactor/src/main/java/org/cloudfoundry/reactor/client/v3/securitygroups/ReactorSecurityGroupsV3.java
@@ -19,6 +19,8 @@ package org.cloudfoundry.reactor.client.v3.securitygroups;
 import org.cloudfoundry.client.v3.securitygroups.SecurityGroupsV3;
 import org.cloudfoundry.client.v3.securitygroups.CreateSecurityGroupRequest;
 import org.cloudfoundry.client.v3.securitygroups.CreateSecurityGroupResponse;
+import org.cloudfoundry.client.v3.securitygroups.GetSecurityGroupRequest;
+import org.cloudfoundry.client.v3.securitygroups.GetSecurityGroupResponse;
 import org.cloudfoundry.reactor.ConnectionContext;
 import org.cloudfoundry.reactor.TokenProvider;
 import org.cloudfoundry.reactor.client.v3.AbstractClientV3Operations;
@@ -50,6 +52,14 @@ public final class ReactorSecurityGroupsV3 extends AbstractClientV3Operations im
     @Override
     public Mono<CreateSecurityGroupResponse> create(CreateSecurityGroupRequest request) {
         return post(request, CreateSecurityGroupResponse.class, builder -> builder.pathSegment("security_groups"))
+                .checkpoint();
+
+    }
+
+    @Override
+    public Mono<GetSecurityGroupResponse> get(GetSecurityGroupRequest request) {
+        return get(request, GetSecurityGroupResponse.class,
+                builder -> builder.pathSegment("security_groups", request.getSecurityGroupId()))
                 .checkpoint();
 
     }

--- a/cloudfoundry-client-reactor/src/main/java/org/cloudfoundry/reactor/client/v3/securitygroups/ReactorSecurityGroupsV3.java
+++ b/cloudfoundry-client-reactor/src/main/java/org/cloudfoundry/reactor/client/v3/securitygroups/ReactorSecurityGroupsV3.java
@@ -20,6 +20,7 @@ import org.cloudfoundry.client.v3.securitygroups.SecurityGroupsV3;
 import org.cloudfoundry.client.v3.securitygroups.CreateSecurityGroupRequest;
 import org.cloudfoundry.client.v3.securitygroups.CreateSecurityGroupResponse;
 import org.cloudfoundry.client.v3.securitygroups.GetSecurityGroupRequest;
+import org.cloudfoundry.client.v3.securitygroups.DeleteSecurityGroupRequest;
 import org.cloudfoundry.client.v3.securitygroups.UpdateSecurityGroupRequest;
 import org.cloudfoundry.client.v3.securitygroups.GetSecurityGroupResponse;
 import org.cloudfoundry.client.v3.securitygroups.UpdateSecurityGroupResponse;
@@ -80,5 +81,13 @@ public final class ReactorSecurityGroupsV3 extends AbstractClientV3Operations im
         return patch(request, UpdateSecurityGroupResponse.class,
                 builder -> builder.pathSegment("security_groups", request.getSecurityGroupId()))
                 .checkpoint();
+    }
+
+    @Override
+    public Mono<String> delete(DeleteSecurityGroupRequest request) {
+        return delete(request, String.class,
+                builder -> builder.pathSegment("security_groups", request.getSecurityGroupId()))
+                .checkpoint();
+
     }
 }

--- a/cloudfoundry-client-reactor/src/test/java/org/cloudfoundry/reactor/client/v3/securitygroups/ReactorSecurityGroupsV3Test.java
+++ b/cloudfoundry-client-reactor/src/test/java/org/cloudfoundry/reactor/client/v3/securitygroups/ReactorSecurityGroupsV3Test.java
@@ -55,13 +55,13 @@ import java.time.Duration;
 import java.util.Collections;
 
 import static io.netty.handler.codec.http.HttpMethod.GET;
-import static io.netty.handler.codec.http.HttpMethod.DELETE;;
+import static io.netty.handler.codec.http.HttpMethod.DELETE;
 import static io.netty.handler.codec.http.HttpMethod.PATCH;
 import static io.netty.handler.codec.http.HttpMethod.POST;
 import static io.netty.handler.codec.http.HttpResponseStatus.CREATED;
 import static io.netty.handler.codec.http.HttpResponseStatus.OK;
 import static io.netty.handler.codec.http.HttpResponseStatus.ACCEPTED;
-import static io.netty.handler.codec.http.HttpResponseStatus.NO_CONTENT;;
+import static io.netty.handler.codec.http.HttpResponseStatus.NO_CONTENT;
 
 public final class ReactorSecurityGroupsV3Test extends AbstractClientApiTest {
 

--- a/cloudfoundry-client-reactor/src/test/java/org/cloudfoundry/reactor/client/v3/securitygroups/ReactorSecurityGroupsV3Test.java
+++ b/cloudfoundry-client-reactor/src/test/java/org/cloudfoundry/reactor/client/v3/securitygroups/ReactorSecurityGroupsV3Test.java
@@ -1,0 +1,120 @@
+/*
+ * Copyright 2013-2021 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.cloudfoundry.reactor.client.v3.securitygroups;
+
+import org.cloudfoundry.reactor.InteractionContext;
+import org.cloudfoundry.reactor.TestRequest;
+import org.cloudfoundry.reactor.TestResponse;
+import org.cloudfoundry.client.v3.securitygroups.Relationships;
+import org.cloudfoundry.client.v3.securitygroups.CreateSecurityGroupRequest;
+import org.cloudfoundry.client.v3.securitygroups.CreateSecurityGroupResponse;
+import org.cloudfoundry.client.v3.securitygroups.GloballyEnabled;
+import org.cloudfoundry.client.v3.securitygroups.Protocol;
+import org.cloudfoundry.client.v3.securitygroups.Rule;
+import org.cloudfoundry.client.v3.securitygroups.CreateSecurityGroupRequest;
+import org.cloudfoundry.client.v3.ToManyRelationship;
+import org.cloudfoundry.reactor.client.AbstractClientApiTest;
+import org.junit.Test;
+import reactor.test.StepVerifier;
+import org.cloudfoundry.client.v3.Link;
+import org.cloudfoundry.client.v3.Relationship;
+
+import java.time.Duration;
+import java.util.Collections;
+
+import static io.netty.handler.codec.http.HttpMethod.POST;
+import static io.netty.handler.codec.http.HttpResponseStatus.ACCEPTED;
+import static io.netty.handler.codec.http.HttpResponseStatus.CREATED;
+
+public final class ReactorSecurityGroupsV3Test extends AbstractClientApiTest {
+
+        private final ReactorSecurityGroupsV3 securityGroups = new ReactorSecurityGroupsV3(CONNECTION_CONTEXT,
+                        this.root,
+                        TOKEN_PROVIDER, Collections.emptyMap());
+
+        @Test
+        public void create() {
+                mockRequest(InteractionContext.builder()
+                                .request(TestRequest.builder()
+                                                .method(POST).path("/security_groups")
+                                                .payload("fixtures/client/v3/security_groups/POST_request.json")
+                                                .build())
+                                .response(TestResponse.builder()
+                                                .status(CREATED)
+                                                .payload("fixtures/client/v3/security_groups/POST_response.json")
+                                                .build())
+                                .build());
+                this.securityGroups
+                                .create(CreateSecurityGroupRequest.builder()
+
+                                                .rules(Rule.builder()
+                                                                .protocol(Protocol.TCP)
+                                                                .destination("10.10.10.0/24")
+                                                                .ports("443,80,8080")
+                                                                .build())
+                                                .name("my-group0")
+                                                .rules(Rule.builder()
+                                                                .protocol(Protocol.ICMP)
+                                                                .destination("10.10.10.0/24")
+                                                                .description("Allow ping requests to private services")
+                                                                .type(8)
+                                                                .code(0)
+                                                                .build())
+                                                .build())
+                                .as(StepVerifier::create)
+                                .expectNext(CreateSecurityGroupResponse.builder()
+                                                .name("my-group0")
+                                                .id("b85a788e-671f-4549-814d-e34cdb2f539a")
+                                                .createdAt("2020-02-20T17:42:08Z")
+                                                .updatedAt("2020-02-20T17:42:08Z")
+                                                .globallyEnabled(GloballyEnabled.builder()
+                                                                .staging(false)
+                                                                .running(true)
+                                                                .build())
+                                                .rules(Rule.builder()
+                                                                .protocol(Protocol.TCP)
+                                                                .destination("10.10.10.0/24")
+                                                                .ports("443,80,8080")
+                                                                .build())
+                                                .rules(Rule.builder()
+                                                                .protocol(Protocol.ICMP)
+                                                                .destination("10.10.10.0/24")
+                                                                .description("Allow ping requests to private services")
+                                                                .type(8)
+                                                                .code(0)
+                                                                .build())
+                                                .relationships(Relationships.builder()
+                                                                .stagingSpaces(ToManyRelationship.builder()
+                                                                                .data(Relationship.builder()
+                                                                                                .id("space-guid-1")
+                                                                                                .build())
+                                                                                .data(Relationship.builder()
+                                                                                                .id("space-guid-2")
+                                                                                                .build())
+                                                                                .build())
+                                                                .runningSpaces(ToManyRelationship.builder().build())
+                                                                .build())
+                                                .link("self", Link.builder()
+                                                                .href("https://api.example.org/v3/security_groups/b85a788e-671f-4549-814d-e34cdb2f539a")
+                                                                .build())
+                                                .build())
+                                .expectComplete()
+                                .verify(Duration.ofSeconds(5));
+
+        }
+
+}

--- a/cloudfoundry-client-reactor/src/test/java/org/cloudfoundry/reactor/client/v3/securitygroups/ReactorSecurityGroupsV3Test.java
+++ b/cloudfoundry-client-reactor/src/test/java/org/cloudfoundry/reactor/client/v3/securitygroups/ReactorSecurityGroupsV3Test.java
@@ -252,6 +252,7 @@ public final class ReactorSecurityGroupsV3Test extends AbstractClientApiTest {
                                                                 .id("a89a788e-671f-4549-814d-e34c1b2f533a")
                                                                 .createdAt("2020-02-20T17:42:08Z")
                                                                 .updatedAt("2020-02-20T17:42:08Z")
+                                                                .relationships(Relationships.builder().build())
                                                                 .globallyEnabled(GloballyEnabled
                                                                                 .builder()
                                                                                 .staging(true)

--- a/cloudfoundry-client-reactor/src/test/java/org/cloudfoundry/reactor/client/v3/securitygroups/ReactorSecurityGroupsV3Test.java
+++ b/cloudfoundry-client-reactor/src/test/java/org/cloudfoundry/reactor/client/v3/securitygroups/ReactorSecurityGroupsV3Test.java
@@ -21,6 +21,8 @@ import org.cloudfoundry.reactor.InteractionContext;
 import org.cloudfoundry.reactor.TestRequest;
 import org.cloudfoundry.reactor.TestResponse;
 import org.cloudfoundry.client.v3.securitygroups.Relationships;
+import org.cloudfoundry.client.v3.securitygroups.UnbindRunningSecurityGroupRequest;
+import org.cloudfoundry.client.v3.securitygroups.UnbindStagingSecurityGroupRequest;
 import org.cloudfoundry.client.v3.securitygroups.BindStagingSecurityGroupRequest;
 import org.cloudfoundry.client.v3.securitygroups.BindStagingSecurityGroupResponse;
 import org.cloudfoundry.client.v3.securitygroups.BindRunningSecurityGroupRequest;
@@ -54,7 +56,8 @@ import static io.netty.handler.codec.http.HttpMethod.PATCH;
 import static io.netty.handler.codec.http.HttpMethod.POST;
 import static io.netty.handler.codec.http.HttpResponseStatus.CREATED;
 import static io.netty.handler.codec.http.HttpResponseStatus.OK;
-import static io.netty.handler.codec.http.HttpResponseStatus.ACCEPTED;;
+import static io.netty.handler.codec.http.HttpResponseStatus.ACCEPTED;
+import static io.netty.handler.codec.http.HttpResponseStatus.NO_CONTENT;;
 
 public final class ReactorSecurityGroupsV3Test extends AbstractClientApiTest {
 
@@ -452,4 +455,45 @@ public final class ReactorSecurityGroupsV3Test extends AbstractClientApiTest {
                                 .verify(Duration.ofSeconds(5));
         }
 
+        @Test
+        public void unbindStagingSecurityGroup() {
+                mockRequest(InteractionContext.builder()
+                                .request(TestRequest.builder()
+                                                .method(DELETE)
+                                                .path("/security_groups/b85a788e-671f-4549-814d-e34cdb2f539a/relationships/staging_spaces/space-guid-1")
+                                                .build())
+                                .response(TestResponse.builder()
+                                                .status(NO_CONTENT)
+                                                .build())
+                                .build());
+                this.securityGroups
+                                .unbindStagingSecurityGroup(UnbindStagingSecurityGroupRequest.builder()
+                                                .securityGroupId("b85a788e-671f-4549-814d-e34cdb2f539a")
+                                                .spaceId("space-guid-1")
+                                                .build())
+                                .as(StepVerifier::create)
+                                .expectNextCount(0)
+                                .verifyComplete();
+        }
+
+        @Test
+        public void unbindRunningSecurityGroup() {
+                mockRequest(InteractionContext.builder()
+                                .request(TestRequest.builder()
+                                                .method(DELETE)
+                                                .path("/security_groups/b85a788e-671f-4549-814d-e34cdb2f539a/relationships/running_spaces/space-guid-1")
+                                                .build())
+                                .response(TestResponse.builder()
+                                                .status(NO_CONTENT)
+                                                .build())
+                                .build());
+                this.securityGroups
+                                .unbindRunningSecurityGroup(UnbindRunningSecurityGroupRequest.builder()
+                                                .securityGroupId("b85a788e-671f-4549-814d-e34cdb2f539a")
+                                                .spaceId("space-guid-1")
+                                                .build())
+                                .as(StepVerifier::create)
+                                .expectNextCount(0)
+                                .verifyComplete();
+        }
 }

--- a/cloudfoundry-client-reactor/src/test/java/org/cloudfoundry/reactor/client/v3/securitygroups/ReactorSecurityGroupsV3Test.java
+++ b/cloudfoundry-client-reactor/src/test/java/org/cloudfoundry/reactor/client/v3/securitygroups/ReactorSecurityGroupsV3Test.java
@@ -262,7 +262,13 @@ public final class ReactorSecurityGroupsV3Test extends AbstractClientApiTest {
                                                                 .id("a89a788e-671f-4549-814d-e34c1b2f533a")
                                                                 .createdAt("2020-02-20T17:42:08Z")
                                                                 .updatedAt("2020-02-20T17:42:08Z")
-                                                                .relationships(Relationships.builder().build())
+                                                                .relationships(Relationships.builder()
+                                                                                .stagingSpaces(ToManyRelationship
+                                                                                                .builder().build())
+                                                                                .runningSpaces(ToManyRelationship
+                                                                                                .builder().build())
+
+                                                                                .build())
                                                                 .globallyEnabled(GloballyEnabled
                                                                                 .builder()
                                                                                 .staging(true)
@@ -286,7 +292,8 @@ public final class ReactorSecurityGroupsV3Test extends AbstractClientApiTest {
         public void update() {
                 mockRequest(InteractionContext.builder()
                                 .request(TestRequest.builder()
-                                                .method(PATCH).path("/security_groups")
+                                                .method(PATCH)
+                                                .path("/security_groups/b85a788e-671f-4549-814d-e34cdb2f539a")
                                                 .payload("fixtures/client/v3/security_groups/PATCH_{id}_request.json")
                                                 .build())
                                 .response(TestResponse.builder()
@@ -368,7 +375,7 @@ public final class ReactorSecurityGroupsV3Test extends AbstractClientApiTest {
                                 .response(TestResponse.builder()
                                                 .status(ACCEPTED)
                                                 .header("Location",
-                                                                "https://api.example.org/v3/security_groups/b85a788e-671f-4549-814d-e34cdb2f539a")
+                                                                "https://api.example.org/v3/jobs/b85a788e-671f-4549-814d-e34cdb2f539a")
                                                 .build())
                                 .build());
 
@@ -397,21 +404,15 @@ public final class ReactorSecurityGroupsV3Test extends AbstractClientApiTest {
                                 .build());
                 this.securityGroups.bindStagingSecurityGroup(BindStagingSecurityGroupRequest.builder()
                                 .securityGroupId("b85a788e-671f-4549-814d-e34cdb2f539a")
-                                .boundSpaces(ToManyRelationship.builder()
-                                                .data(Relationship.builder().id("space-guid1").build())
-                                                .data(Relationship.builder().id("space-guid2").build())
-                                                .build())
+                                .boundSpaces(Relationship.builder().id("space-guid1").build())
+                                .boundSpaces(Relationship.builder().id("space-guid2").build())
+
                                 .build())
                                 .as(StepVerifier::create)
                                 .expectNext(BindStagingSecurityGroupResponse.builder()
-                                                .boundSpaces(ToManyRelationship.builder()
-                                                                .data(Relationship.builder().id("space-guid1").build())
-                                                                .data(Relationship.builder().id("space-guid2").build())
-                                                                .data(Relationship.builder().id("previous-space-guid")
-                                                                                .build())
-                                                                .build()
-
-                                                )
+                                                .boundSpaces(Relationship.builder().id("space-guid1").build())
+                                                .boundSpaces(Relationship.builder().id("space-guid2").build())
+                                                .boundSpaces(Relationship.builder().id("previous-space-guid").build())
                                                 .link("self", Link.builder()
                                                                 .href("https://api.example.org/v3/security_groups/b85a788e-671f-4549-814d-e34cdb2f539a/relationships/staging_spaces")
                                                                 .build())
@@ -435,21 +436,14 @@ public final class ReactorSecurityGroupsV3Test extends AbstractClientApiTest {
                                 .build());
                 this.securityGroups.bindRunningSecurityGroup(BindRunningSecurityGroupRequest.builder()
                                 .securityGroupId("b85a788e-671f-4549-814d-e34cdb2f539a")
-                                .boundSpaces(ToManyRelationship.builder()
-                                                .data(Relationship.builder().id("space-guid1").build())
-                                                .data(Relationship.builder().id("space-guid2").build())
-                                                .build())
+                                .boundSpaces(Relationship.builder().id("space-guid1").build())
+                                .boundSpaces(Relationship.builder().id("space-guid2").build())
                                 .build())
                                 .as(StepVerifier::create)
                                 .expectNext(BindRunningSecurityGroupResponse.builder()
-                                                .boundSpaces(ToManyRelationship.builder()
-                                                                .data(Relationship.builder().id("space-guid1").build())
-                                                                .data(Relationship.builder().id("space-guid2").build())
-                                                                .data(Relationship.builder().id("previous-space-guid")
-                                                                                .build())
-                                                                .build()
-
-                                                )
+                                                .boundSpaces(Relationship.builder().id("space-guid1").build())
+                                                .boundSpaces(Relationship.builder().id("space-guid2").build())
+                                                .boundSpaces(Relationship.builder().id("previous-space-guid").build())
                                                 .link("self", Link.builder()
                                                                 .href("https://api.example.org/v3/security_groups/b85a788e-671f-4549-814d-e34cdb2f539a/relationships/running_spaces")
                                                                 .build())

--- a/cloudfoundry-client-reactor/src/test/java/org/cloudfoundry/reactor/client/v3/securitygroups/ReactorSecurityGroupsV3Test.java
+++ b/cloudfoundry-client-reactor/src/test/java/org/cloudfoundry/reactor/client/v3/securitygroups/ReactorSecurityGroupsV3Test.java
@@ -21,6 +21,10 @@ import org.cloudfoundry.reactor.InteractionContext;
 import org.cloudfoundry.reactor.TestRequest;
 import org.cloudfoundry.reactor.TestResponse;
 import org.cloudfoundry.client.v3.securitygroups.Relationships;
+import org.cloudfoundry.client.v3.securitygroups.BindStagingSecurityGroupRequest;
+import org.cloudfoundry.client.v3.securitygroups.BindStagingSecurityGroupResponse;
+import org.cloudfoundry.client.v3.securitygroups.BindRunningSecurityGroupRequest;
+import org.cloudfoundry.client.v3.securitygroups.BindRunningSecurityGroupResponse;
 import org.cloudfoundry.client.v3.securitygroups.CreateSecurityGroupRequest;
 import org.cloudfoundry.client.v3.securitygroups.CreateSecurityGroupResponse;
 import org.cloudfoundry.client.v3.securitygroups.SecurityGroupResource;
@@ -377,4 +381,81 @@ public final class ReactorSecurityGroupsV3Test extends AbstractClientApiTest {
                                 .expectComplete()
                                 .verify(Duration.ofSeconds(5));
         }
+
+        @Test
+        public void bindStagingSecurityGroup() {
+                mockRequest(InteractionContext.builder()
+                                .request(TestRequest.builder()
+                                                .method(POST)
+                                                .path("/security_groups/b85a788e-671f-4549-814d-e34cdb2f539a/relationships/staging_spaces")
+                                                .payload("fixtures/client/v3/security_groups/bind_staging/POST_request.json")
+                                                .build())
+                                .response(TestResponse.builder()
+                                                .status(OK)
+                                                .payload("fixtures/client/v3/security_groups/bind_staging/POST_response.json")
+                                                .build())
+                                .build());
+                this.securityGroups.bindStagingSecurityGroup(BindStagingSecurityGroupRequest.builder()
+                                .securityGroupId("b85a788e-671f-4549-814d-e34cdb2f539a")
+                                .boundSpaces(ToManyRelationship.builder()
+                                                .data(Relationship.builder().id("space-guid1").build())
+                                                .data(Relationship.builder().id("space-guid2").build())
+                                                .build())
+                                .build())
+                                .as(StepVerifier::create)
+                                .expectNext(BindStagingSecurityGroupResponse.builder()
+                                                .boundSpaces(ToManyRelationship.builder()
+                                                                .data(Relationship.builder().id("space-guid1").build())
+                                                                .data(Relationship.builder().id("space-guid2").build())
+                                                                .data(Relationship.builder().id("previous-space-guid")
+                                                                                .build())
+                                                                .build()
+
+                                                )
+                                                .link("self", Link.builder()
+                                                                .href("https://api.example.org/v3/security_groups/b85a788e-671f-4549-814d-e34cdb2f539a/relationships/staging_spaces")
+                                                                .build())
+                                                .build())
+                                .expectComplete()
+                                .verify(Duration.ofSeconds(5));
+        }
+
+        @Test
+        public void bindRunningSecurityGroup() {
+                mockRequest(InteractionContext.builder()
+                                .request(TestRequest.builder()
+                                                .method(POST)
+                                                .path("/security_groups/b85a788e-671f-4549-814d-e34cdb2f539a/relationships/running_spaces")
+                                                .payload("fixtures/client/v3/security_groups/bind_running/POST_request.json")
+                                                .build())
+                                .response(TestResponse.builder()
+                                                .status(OK)
+                                                .payload("fixtures/client/v3/security_groups/bind_running/POST_response.json")
+                                                .build())
+                                .build());
+                this.securityGroups.bindRunningSecurityGroup(BindRunningSecurityGroupRequest.builder()
+                                .securityGroupId("b85a788e-671f-4549-814d-e34cdb2f539a")
+                                .boundSpaces(ToManyRelationship.builder()
+                                                .data(Relationship.builder().id("space-guid1").build())
+                                                .data(Relationship.builder().id("space-guid2").build())
+                                                .build())
+                                .build())
+                                .as(StepVerifier::create)
+                                .expectNext(BindRunningSecurityGroupResponse.builder()
+                                                .boundSpaces(ToManyRelationship.builder()
+                                                                .data(Relationship.builder().id("space-guid1").build())
+                                                                .data(Relationship.builder().id("space-guid2").build())
+                                                                .data(Relationship.builder().id("previous-space-guid")
+                                                                                .build())
+                                                                .build()
+
+                                                )
+                                                .link("self", Link.builder()
+                                                                .href("https://api.example.org/v3/security_groups/b85a788e-671f-4549-814d-e34cdb2f539a/relationships/running_spaces")
+                                                                .build())
+                                                .build())
+                                .expectComplete()
+                                .verify(Duration.ofSeconds(5));
+        }
+
 }

--- a/cloudfoundry-client-reactor/src/test/java/org/cloudfoundry/reactor/client/v3/securitygroups/ReactorSecurityGroupsV3Test.java
+++ b/cloudfoundry-client-reactor/src/test/java/org/cloudfoundry/reactor/client/v3/securitygroups/ReactorSecurityGroupsV3Test.java
@@ -16,13 +16,17 @@
 
 package org.cloudfoundry.reactor.client.v3.securitygroups;
 
+import org.cloudfoundry.client.v3.Pagination;
 import org.cloudfoundry.reactor.InteractionContext;
 import org.cloudfoundry.reactor.TestRequest;
 import org.cloudfoundry.reactor.TestResponse;
 import org.cloudfoundry.client.v3.securitygroups.Relationships;
 import org.cloudfoundry.client.v3.securitygroups.CreateSecurityGroupRequest;
 import org.cloudfoundry.client.v3.securitygroups.CreateSecurityGroupResponse;
+import org.cloudfoundry.client.v3.securitygroups.SecurityGroupResource;
 import org.cloudfoundry.client.v3.securitygroups.GloballyEnabled;
+import org.cloudfoundry.client.v3.securitygroups.ListSecurityGroupsRequest;
+import org.cloudfoundry.client.v3.securitygroups.ListSecurityGroupsResponse;
 import org.cloudfoundry.client.v3.securitygroups.Protocol;
 import org.cloudfoundry.client.v3.securitygroups.Rule;
 import org.cloudfoundry.client.v3.securitygroups.GetSecurityGroupRequest;
@@ -39,7 +43,6 @@ import java.util.Collections;
 
 import static io.netty.handler.codec.http.HttpMethod.GET;
 import static io.netty.handler.codec.http.HttpMethod.POST;
-import static io.netty.handler.codec.http.HttpResponseStatus.ACCEPTED;
 import static io.netty.handler.codec.http.HttpResponseStatus.CREATED;
 import static io.netty.handler.codec.http.HttpResponseStatus.OK;
 
@@ -177,4 +180,89 @@ public final class ReactorSecurityGroupsV3Test extends AbstractClientApiTest {
                                 .verify(Duration.ofSeconds(5));
         }
 
+        @Test
+        public void list() {
+                mockRequest(InteractionContext.builder()
+                                .request(TestRequest.builder()
+                                                .method(GET).path("/security_groups")
+                                                .build())
+                                .response(TestResponse.builder()
+                                                .status(OK)
+                                                .payload("fixtures/client/v3/security_groups/GET_response.json")
+                                                .build())
+                                .build());
+
+                this.securityGroups.list(ListSecurityGroupsRequest.builder().build())
+                                .as(StepVerifier::create)
+                                .expectNext(ListSecurityGroupsResponse.builder()
+                                                .pagination(Pagination.builder()
+                                                                .totalResults(1)
+                                                                .totalPages(1)
+                                                                .first(Link.builder()
+                                                                                .href("https://api.example.org/v3/security_groups?page=1&per_page=50")
+                                                                                .build())
+                                                                .last(Link.builder()
+                                                                                .href("https://api.example.org/v3/security_groups?page=1&per_page=50")
+                                                                                .build())
+                                                                .build())
+                                                .resource(SecurityGroupResource.builder()
+                                                                .name("my-group0")
+                                                                .id("b85a788e-671f-4549-814d-e34cdb2f539a")
+                                                                .createdAt("2020-02-20T17:42:08Z")
+                                                                .updatedAt("2020-02-20T17:42:08Z")
+                                                                .globallyEnabled(GloballyEnabled
+                                                                                .builder()
+                                                                                .staging(false)
+                                                                                .running(true)
+                                                                                .build())
+                                                                .rules(Rule.builder()
+                                                                                .protocol(Protocol.TCP)
+                                                                                .destination("10.10.10.0/24")
+                                                                                .ports("443,80,8080")
+                                                                                .build())
+                                                                .rules(Rule.builder()
+                                                                                .protocol(Protocol.ICMP)
+                                                                                .destination("10.10.10.0/24")
+                                                                                .description("Allow ping requests to private services")
+                                                                                .type(8)
+                                                                                .code(0)
+                                                                                .build())
+                                                                .relationships(Relationships.builder()
+                                                                                .stagingSpaces(ToManyRelationship
+                                                                                                .builder()
+                                                                                                .data(Relationship
+                                                                                                                .builder()
+                                                                                                                .id("space-guid-1")
+                                                                                                                .build())
+                                                                                                .data(Relationship
+                                                                                                                .builder()
+                                                                                                                .id("space-guid-2")
+                                                                                                                .build())
+                                                                                                .build())
+                                                                                .runningSpaces(ToManyRelationship
+                                                                                                .builder()
+                                                                                                .build())
+                                                                                .build())
+                                                                .link("self", Link.builder()
+                                                                                .href("https://api.example.org/v3/security_groups/b85a788e-671f-4549-814d-e34cdb2f539a")
+                                                                                .build())
+                                                                .build())
+                                                .resource(SecurityGroupResource.builder()
+                                                                .name("my-group1")
+                                                                .id("a89a788e-671f-4549-814d-e34c1b2f533a")
+                                                                .createdAt("2020-02-20T17:42:08Z")
+                                                                .updatedAt("2020-02-20T17:42:08Z")
+                                                                .globallyEnabled(GloballyEnabled
+                                                                                .builder()
+                                                                                .staging(true)
+                                                                                .running(true)
+                                                                                .build())
+                                                                .link("self", Link.builder()
+                                                                                .href("https://api.example.org/v3/security_groups/a89a788e-671f-4549-814d-e34c1b2f533a")
+                                                                                .build())
+                                                                .build())
+                                                .build())
+                                .expectComplete()
+                                .verify(Duration.ofSeconds(5));
+        }
 }

--- a/cloudfoundry-client-reactor/src/test/java/org/cloudfoundry/reactor/client/v3/securitygroups/ReactorSecurityGroupsV3Test.java
+++ b/cloudfoundry-client-reactor/src/test/java/org/cloudfoundry/reactor/client/v3/securitygroups/ReactorSecurityGroupsV3Test.java
@@ -29,6 +29,7 @@ import org.cloudfoundry.client.v3.securitygroups.ListSecurityGroupsRequest;
 import org.cloudfoundry.client.v3.securitygroups.ListSecurityGroupsResponse;
 import org.cloudfoundry.client.v3.securitygroups.Protocol;
 import org.cloudfoundry.client.v3.securitygroups.Rule;
+import org.cloudfoundry.client.v3.securitygroups.DeleteSecurityGroupRequest;
 import org.cloudfoundry.client.v3.securitygroups.GetSecurityGroupRequest;
 import org.cloudfoundry.client.v3.securitygroups.UpdateSecurityGroupRequest;
 import org.cloudfoundry.client.v3.securitygroups.UpdateSecurityGroupResponse;
@@ -44,10 +45,12 @@ import java.time.Duration;
 import java.util.Collections;
 
 import static io.netty.handler.codec.http.HttpMethod.GET;
+import static io.netty.handler.codec.http.HttpMethod.DELETE;;
 import static io.netty.handler.codec.http.HttpMethod.PATCH;
 import static io.netty.handler.codec.http.HttpMethod.POST;
 import static io.netty.handler.codec.http.HttpResponseStatus.CREATED;
 import static io.netty.handler.codec.http.HttpResponseStatus.OK;
+import static io.netty.handler.codec.http.HttpResponseStatus.ACCEPTED;;
 
 public final class ReactorSecurityGroupsV3Test extends AbstractClientApiTest {
 
@@ -349,5 +352,29 @@ public final class ReactorSecurityGroupsV3Test extends AbstractClientApiTest {
                                 .expectComplete()
                                 .verify(Duration.ofSeconds(5));
 
+        }
+
+        @Test
+        public void delete() {
+                mockRequest(InteractionContext.builder()
+                                .request(TestRequest.builder()
+                                                .method(DELETE)
+                                                .path("/security_groups/b85a788e-671f-4549-814d-e34cdb2f539a")
+                                                .build())
+                                .response(TestResponse.builder()
+                                                .status(ACCEPTED)
+                                                .header("Location",
+                                                                "https://api.example.org/v3/security_groups/b85a788e-671f-4549-814d-e34cdb2f539a")
+                                                .build())
+                                .build());
+
+                this.securityGroups
+                                .delete(DeleteSecurityGroupRequest.builder()
+                                                .securityGroupId("b85a788e-671f-4549-814d-e34cdb2f539a")
+                                                .build())
+                                .as(StepVerifier::create)
+                                .expectNext("b85a788e-671f-4549-814d-e34cdb2f539a")
+                                .expectComplete()
+                                .verify(Duration.ofSeconds(5));
         }
 }

--- a/cloudfoundry-client-reactor/src/test/java/org/cloudfoundry/reactor/client/v3/securitygroups/ReactorSecurityGroupsV3Test.java
+++ b/cloudfoundry-client-reactor/src/test/java/org/cloudfoundry/reactor/client/v3/securitygroups/ReactorSecurityGroupsV3Test.java
@@ -32,6 +32,10 @@ import org.cloudfoundry.client.v3.securitygroups.CreateSecurityGroupResponse;
 import org.cloudfoundry.client.v3.securitygroups.SecurityGroupResource;
 import org.cloudfoundry.client.v3.securitygroups.GloballyEnabled;
 import org.cloudfoundry.client.v3.securitygroups.ListSecurityGroupsRequest;
+import org.cloudfoundry.client.v3.securitygroups.ListRunningSecurityGroupsRequest;
+import org.cloudfoundry.client.v3.securitygroups.ListRunningSecurityGroupsResponse;
+import org.cloudfoundry.client.v3.securitygroups.ListStagingSecurityGroupsRequest;
+import org.cloudfoundry.client.v3.securitygroups.ListStagingSecurityGroupsResponse;
 import org.cloudfoundry.client.v3.securitygroups.ListSecurityGroupsResponse;
 import org.cloudfoundry.client.v3.securitygroups.Protocol;
 import org.cloudfoundry.client.v3.securitygroups.Rule;
@@ -495,5 +499,209 @@ public final class ReactorSecurityGroupsV3Test extends AbstractClientApiTest {
                                 .as(StepVerifier::create)
                                 .expectNextCount(0)
                                 .verifyComplete();
+        }
+
+        @Test
+        public void listRunning() {
+                mockRequest(InteractionContext.builder()
+                                .request(TestRequest.builder()
+                                                .method(GET)
+                                                .path("/spaces/c5048979-53b9-4d2a-9fca-78e6bc07c041/running_security_groups")
+                                                .build())
+                                .response(TestResponse.builder()
+                                                .status(OK)
+                                                .payload("fixtures/client/v3/security_groups/GET_running_{id}_response.json")
+                                                .build())
+                                .build());
+
+                this.securityGroups
+                                .listRunning(ListRunningSecurityGroupsRequest.builder()
+                                                .spaceId("c5048979-53b9-4d2a-9fca-78e6bc07c041").build())
+                                .as(StepVerifier::create)
+                                .expectNext(ListRunningSecurityGroupsResponse.builder()
+                                                .pagination(Pagination.builder()
+                                                                .totalResults(1)
+                                                                .totalPages(1)
+                                                                .first(Link.builder()
+                                                                                .href("https://api.example.org/v3/spaces/c5048979-53b9-4d2a-9fca-78e6bc07c041/running_security_groups?page=1&per_page=50")
+                                                                                .build())
+                                                                .last(Link.builder()
+                                                                                .href("https://api.example.org/v3/spaces/c5048979-53b9-4d2a-9fca-78e6bc07c041/running_security_groups?page=1&per_page=50")
+                                                                                .build())
+                                                                .build())
+                                                .resource(SecurityGroupResource.builder()
+                                                                .name("my-group0")
+                                                                .id("b85a788e-671f-4549-814d-e34cdb2f539a")
+                                                                .createdAt("2020-02-20T17:42:08Z")
+                                                                .updatedAt("2020-02-20T17:42:08Z")
+                                                                .globallyEnabled(GloballyEnabled
+                                                                                .builder()
+                                                                                .staging(false)
+                                                                                .running(true)
+                                                                                .build())
+                                                                .rules(Rule.builder()
+                                                                                .protocol(Protocol.TCP)
+                                                                                .destination("10.10.10.0/24")
+                                                                                .ports("443,80,8080")
+                                                                                .build())
+                                                                .rules(Rule.builder()
+                                                                                .protocol(Protocol.ICMP)
+                                                                                .destination("10.10.10.0/24")
+                                                                                .description("Allow ping requests to private services")
+                                                                                .type(8)
+                                                                                .code(0)
+                                                                                .build())
+                                                                .relationships(Relationships.builder()
+                                                                                .stagingSpaces(ToManyRelationship
+                                                                                                .builder()
+
+                                                                                                .build())
+                                                                                .runningSpaces(ToManyRelationship
+                                                                                                .builder()
+                                                                                                .data(Relationship
+                                                                                                                .builder()
+                                                                                                                .id("space-guid-1")
+                                                                                                                .build())
+                                                                                                .data(Relationship
+                                                                                                                .builder()
+                                                                                                                .id("space-guid-2")
+                                                                                                                .build())
+                                                                                                .build())
+                                                                                .build())
+                                                                .link("self", Link.builder()
+                                                                                .href("https://api.example.org/v3/security_groups/b85a788e-671f-4549-814d-e34cdb2f539a")
+                                                                                .build())
+                                                                .build())
+                                                .resource(SecurityGroupResource.builder()
+                                                                .name("my-group1")
+                                                                .id("a89a788e-671f-4549-814d-e34c1b2f533a")
+                                                                .createdAt("2020-02-20T17:42:08Z")
+                                                                .updatedAt("2020-02-20T17:42:08Z")
+                                                                .relationships(Relationships.builder()
+                                                                                .stagingSpaces(ToManyRelationship
+                                                                                                .builder().build())
+                                                                                .runningSpaces(ToManyRelationship
+                                                                                                .builder().build())
+
+                                                                                .build())
+                                                                .globallyEnabled(GloballyEnabled
+                                                                                .builder()
+                                                                                .staging(true)
+                                                                                .running(true)
+                                                                                .build())
+                                                                .globallyEnabled(GloballyEnabled
+                                                                                .builder()
+                                                                                .staging(true)
+                                                                                .running(true)
+                                                                                .build())
+                                                                .link("self", Link.builder()
+                                                                                .href("https://api.example.org/v3/security_groups/a89a788e-671f-4549-814d-e34c1b2f533a")
+                                                                                .build())
+                                                                .build())
+                                                .build())
+                                .expectComplete()
+                                .verify(Duration.ofSeconds(5));
+        }
+
+        @Test
+        public void listStaging() {
+                mockRequest(InteractionContext.builder()
+                                .request(TestRequest.builder()
+                                                .method(GET)
+                                                .path("/spaces/c5048979-53b9-4d2a-9fca-78e6bc07c041/staging_security_groups")
+                                                .build())
+                                .response(TestResponse.builder()
+                                                .status(OK)
+                                                .payload("fixtures/client/v3/security_groups/GET_staging_{id}_response.json")
+                                                .build())
+                                .build());
+
+                this.securityGroups
+                                .listStaging(ListStagingSecurityGroupsRequest.builder()
+                                                .spaceId("c5048979-53b9-4d2a-9fca-78e6bc07c041").build())
+                                .as(StepVerifier::create)
+                                .expectNext(ListStagingSecurityGroupsResponse.builder()
+                                                .pagination(Pagination.builder()
+                                                                .totalResults(1)
+                                                                .totalPages(1)
+                                                                .first(Link.builder()
+                                                                                .href("https://api.example.org/v3/spaces/c5048979-53b9-4d2a-9fca-78e6bc07c041/staging_security_groups?page=1&per_page=50")
+                                                                                .build())
+                                                                .last(Link.builder()
+                                                                                .href("https://api.example.org/v3/spaces/c5048979-53b9-4d2a-9fca-78e6bc07c041/staging_security_groups?page=1&per_page=50")
+                                                                                .build())
+                                                                .build())
+                                                .resource(SecurityGroupResource.builder()
+                                                                .name("my-group0")
+                                                                .id("b85a788e-671f-4549-814d-e34cdb2f539a")
+                                                                .createdAt("2020-02-20T17:42:08Z")
+                                                                .updatedAt("2020-02-20T17:42:08Z")
+                                                                .globallyEnabled(GloballyEnabled
+                                                                                .builder()
+                                                                                .staging(true)
+                                                                                .running(false)
+                                                                                .build())
+                                                                .rules(Rule.builder()
+                                                                                .protocol(Protocol.TCP)
+                                                                                .destination("10.10.10.0/24")
+                                                                                .ports("443,80,8080")
+                                                                                .build())
+                                                                .rules(Rule.builder()
+                                                                                .protocol(Protocol.ICMP)
+                                                                                .destination("10.10.10.0/24")
+                                                                                .description("Allow ping requests to private services")
+                                                                                .type(8)
+                                                                                .code(0)
+                                                                                .build())
+                                                                .relationships(Relationships.builder()
+                                                                                .stagingSpaces(ToManyRelationship
+                                                                                                .builder()
+                                                                                                .data(Relationship
+                                                                                                                .builder()
+                                                                                                                .id("space-guid-1")
+                                                                                                                .build())
+                                                                                                .data(Relationship
+                                                                                                                .builder()
+                                                                                                                .id("space-guid-2")
+                                                                                                                .build())
+                                                                                                .build())
+                                                                                .runningSpaces(ToManyRelationship
+                                                                                                .builder()
+
+                                                                                                .build())
+                                                                                .build())
+                                                                .link("self", Link.builder()
+                                                                                .href("https://api.example.org/v3/security_groups/b85a788e-671f-4549-814d-e34cdb2f539a")
+                                                                                .build())
+                                                                .build())
+                                                .resource(SecurityGroupResource.builder()
+                                                                .name("my-group1")
+                                                                .id("a89a788e-671f-4549-814d-e34c1b2f533a")
+                                                                .createdAt("2020-02-20T17:42:08Z")
+                                                                .updatedAt("2020-02-20T17:42:08Z")
+                                                                .relationships(Relationships.builder()
+                                                                                .stagingSpaces(ToManyRelationship
+                                                                                                .builder().build())
+                                                                                .runningSpaces(ToManyRelationship
+                                                                                                .builder().build())
+
+                                                                                .build())
+                                                                .globallyEnabled(GloballyEnabled
+                                                                                .builder()
+                                                                                .staging(true)
+                                                                                .running(true)
+                                                                                .build())
+                                                                .globallyEnabled(GloballyEnabled
+                                                                                .builder()
+                                                                                .staging(true)
+                                                                                .running(true)
+                                                                                .build())
+                                                                .link("self", Link.builder()
+                                                                                .href("https://api.example.org/v3/security_groups/a89a788e-671f-4549-814d-e34c1b2f533a")
+                                                                                .build())
+                                                                .build())
+                                                .build())
+                                .expectComplete()
+                                .verify(Duration.ofSeconds(5));
         }
 }

--- a/cloudfoundry-client-reactor/src/test/resources/fixtures/client/v3/security_groups/GET_response.json
+++ b/cloudfoundry-client-reactor/src/test/resources/fixtures/client/v3/security_groups/GET_response.json
@@ -1,0 +1,84 @@
+{
+    "pagination": {
+        "total_results": 1,
+        "total_pages": 1,
+        "first": {
+            "href": "https://api.example.org/v3/security_groups?page=1&per_page=50"
+        },
+        "last": {
+            "href": "https://api.example.org/v3/security_groups?page=1&per_page=50"
+        },
+        "next": null,
+        "previous": null
+    },
+    "resources": [
+        {
+            "guid": "b85a788e-671f-4549-814d-e34cdb2f539a",
+            "created_at": "2020-02-20T17:42:08Z",
+            "updated_at": "2020-02-20T17:42:08Z",
+            "name": "my-group0",
+            "globally_enabled": {
+                "running": true,
+                "staging": false
+            },
+            "rules": [
+                {
+                    "protocol": "tcp",
+                    "destination": "10.10.10.0/24",
+                    "ports": "443,80,8080"
+                },
+                {
+                    "protocol": "icmp",
+                    "destination": "10.10.10.0/24",
+                    "type": 8,
+                    "code": 0,
+                    "description": "Allow ping requests to private services"
+                }
+            ],
+            "relationships": {
+                "staging_spaces": {
+                    "data": [
+                        {
+                            "guid": "space-guid-1"
+                        },
+                        {
+                            "guid": "space-guid-2"
+                        }
+                    ]
+                },
+                "running_spaces": {
+                    "data": []
+                }
+            },
+            "links": {
+                "self": {
+                    "href": "https://api.example.org/v3/security_groups/b85a788e-671f-4549-814d-e34cdb2f539a"
+                }
+            }
+        },
+        {
+            "guid": "a89a788e-671f-4549-814d-e34c1b2f533a",
+            "created_at": "2020-02-20T17:42:08Z",
+            "updated_at": "2020-02-20T17:42:08Z",
+            "name": "my-group1",
+            "globally_enabled": {
+                "running": true,
+                "staging": true
+            },
+            "rules": [],
+            "relationships": {
+                "staging_spaces": {
+                    "data": []
+                },
+                "running_spaces": {
+                    "data": []
+                }
+            },
+            "links": {
+                "self": {
+                    "href": "https://api.example.org/v3/security_groups/a89a788e-671f-4549-814d-e34c1b2f533a"
+                }
+            }
+        }
+    ]
+}

--- a/cloudfoundry-client-reactor/src/test/resources/fixtures/client/v3/security_groups/GET_running_{id}_response.json
+++ b/cloudfoundry-client-reactor/src/test/resources/fixtures/client/v3/security_groups/GET_running_{id}_response.json
@@ -1,0 +1,84 @@
+{
+    "pagination": {
+        "total_results": 1,
+        "total_pages": 1,
+        "first": {
+            "href": "https://api.example.org/v3/spaces/c5048979-53b9-4d2a-9fca-78e6bc07c041/running_security_groups?page=1&per_page=50"
+        },
+        "last": {
+            "href": "https://api.example.org/v3/spaces/c5048979-53b9-4d2a-9fca-78e6bc07c041/running_security_groups?page=1&per_page=50"
+        },
+        "next": null,
+        "previous": null
+    },
+    "resources": [
+        {
+            "guid": "b85a788e-671f-4549-814d-e34cdb2f539a",
+            "created_at": "2020-02-20T17:42:08Z",
+            "updated_at": "2020-02-20T17:42:08Z",
+            "name": "my-group0",
+            "globally_enabled": {
+                "running": true,
+                "staging": false
+            },
+            "rules": [
+                {
+                    "protocol": "tcp",
+                    "destination": "10.10.10.0/24",
+                    "ports": "443,80,8080"
+                },
+                {
+                    "protocol": "icmp",
+                    "destination": "10.10.10.0/24",
+                    "type": 8,
+                    "code": 0,
+                    "description": "Allow ping requests to private services"
+                }
+            ],
+            "relationships": {
+                "staging_spaces": {
+                    "data": []
+                },
+                "running_spaces": {
+                    "data": [
+                        {
+                            "guid": "space-guid-1"
+                        },
+                        {
+                            "guid": "space-guid-2"
+                        }
+                    ]
+                }
+            },
+            "links": {
+                "self": {
+                    "href": "https://api.example.org/v3/security_groups/b85a788e-671f-4549-814d-e34cdb2f539a"
+                }
+            }
+        },
+        {
+            "guid": "a89a788e-671f-4549-814d-e34c1b2f533a",
+            "created_at": "2020-02-20T17:42:08Z",
+            "updated_at": "2020-02-20T17:42:08Z",
+            "name": "my-group1",
+            "globally_enabled": {
+                "running": true,
+                "staging": true
+            },
+            "rules": [],
+            "relationships": {
+                "staging_spaces": {
+                    "data": []
+                },
+                "running_spaces": {
+                    "data": []
+                }
+            },
+            "links": {
+                "self": {
+                    "href": "https://api.example.org/v3/security_groups/a89a788e-671f-4549-814d-e34c1b2f533a"
+                }
+            }
+        }
+    ]
+}

--- a/cloudfoundry-client-reactor/src/test/resources/fixtures/client/v3/security_groups/GET_staging_{id}_response.json
+++ b/cloudfoundry-client-reactor/src/test/resources/fixtures/client/v3/security_groups/GET_staging_{id}_response.json
@@ -1,0 +1,84 @@
+{
+    "pagination": {
+        "total_results": 1,
+        "total_pages": 1,
+        "first": {
+            "href": "https://api.example.org/v3/spaces/c5048979-53b9-4d2a-9fca-78e6bc07c041/staging_security_groups?page=1&per_page=50"
+        },
+        "last": {
+            "href": "https://api.example.org/v3/spaces/c5048979-53b9-4d2a-9fca-78e6bc07c041/staging_security_groups?page=1&per_page=50"
+        },
+        "next": null,
+        "previous": null
+    },
+    "resources": [
+        {
+            "guid": "b85a788e-671f-4549-814d-e34cdb2f539a",
+            "created_at": "2020-02-20T17:42:08Z",
+            "updated_at": "2020-02-20T17:42:08Z",
+            "name": "my-group0",
+            "globally_enabled": {
+                "running": false,
+                "staging": true
+            },
+            "rules": [
+                {
+                    "protocol": "tcp",
+                    "destination": "10.10.10.0/24",
+                    "ports": "443,80,8080"
+                },
+                {
+                    "protocol": "icmp",
+                    "destination": "10.10.10.0/24",
+                    "type": 8,
+                    "code": 0,
+                    "description": "Allow ping requests to private services"
+                }
+            ],
+            "relationships": {
+                "staging_spaces": {
+                    "data": [
+                        {
+                            "guid": "space-guid-1"
+                        },
+                        {
+                            "guid": "space-guid-2"
+                        }
+                    ]
+                },
+                "running_spaces": {
+                    "data": []
+                }
+            },
+            "links": {
+                "self": {
+                    "href": "https://api.example.org/v3/security_groups/b85a788e-671f-4549-814d-e34cdb2f539a"
+                }
+            }
+        },
+        {
+            "guid": "a89a788e-671f-4549-814d-e34c1b2f533a",
+            "created_at": "2020-02-20T17:42:08Z",
+            "updated_at": "2020-02-20T17:42:08Z",
+            "name": "my-group1",
+            "globally_enabled": {
+                "running": true,
+                "staging": true
+            },
+            "rules": [],
+            "relationships": {
+                "staging_spaces": {
+                    "data": []
+                },
+                "running_spaces": {
+                    "data": []
+                }
+            },
+            "links": {
+                "self": {
+                    "href": "https://api.example.org/v3/security_groups/a89a788e-671f-4549-814d-e34c1b2f533a"
+                }
+            }
+        }
+    ]
+}

--- a/cloudfoundry-client-reactor/src/test/resources/fixtures/client/v3/security_groups/GET_{id}_response.json
+++ b/cloudfoundry-client-reactor/src/test/resources/fixtures/client/v3/security_groups/GET_{id}_response.json
@@ -1,0 +1,44 @@
+{
+    "guid": "b85a788e-671f-4549-814d-e34cdb2f539a",
+    "created_at": "2020-02-20T17:42:08Z",
+    "updated_at": "2020-02-20T17:42:08Z",
+    "name": "my-group0",
+    "globally_enabled": {
+        "running": true,
+        "staging": false
+    },
+    "rules": [
+        {
+            "protocol": "tcp",
+            "destination": "10.10.10.0/24",
+            "ports": "443,80,8080"
+        },
+        {
+            "protocol": "icmp",
+            "destination": "10.10.10.0/24",
+            "type": 8,
+            "code": 0,
+            "description": "Allow ping requests to private services"
+        }
+    ],
+    "relationships": {
+        "staging_spaces": {
+            "data": [
+                {
+                    "guid": "space-guid-1"
+                },
+                {
+                    "guid": "space-guid-2"
+                }
+            ]
+        },
+        "running_spaces": {
+            "data": []
+        }
+    },
+    "links": {
+        "self": {
+            "href": "https://api.example.org/v3/security_groups/b85a788e-671f-4549-814d-e34cdb2f539a"
+        }
+    }
+}

--- a/cloudfoundry-client-reactor/src/test/resources/fixtures/client/v3/security_groups/PATCH_{id}_request.json
+++ b/cloudfoundry-client-reactor/src/test/resources/fixtures/client/v3/security_groups/PATCH_{id}_request.json
@@ -1,0 +1,20 @@
+{
+    "name": "my-group0",
+    "globally_enabled": {
+        "running": true
+    },
+    "rules": [
+        {
+            "protocol": "tcp",
+            "destination": "10.10.10.0/24",
+            "ports": "443,80,8080"
+        },
+        {
+            "protocol": "icmp",
+            "destination": "10.10.10.0/24",
+            "type": 8,
+            "code": 0,
+            "description": "Allow ping requests to private services"
+        }
+    ]
+}

--- a/cloudfoundry-client-reactor/src/test/resources/fixtures/client/v3/security_groups/PATCH_{id}_response.json
+++ b/cloudfoundry-client-reactor/src/test/resources/fixtures/client/v3/security_groups/PATCH_{id}_response.json
@@ -1,0 +1,44 @@
+{
+    "guid": "b85a788e-671f-4549-814d-e34cdb2f539a",
+    "created_at": "2020-02-20T17:42:08Z",
+    "updated_at": "2020-02-20T17:42:08Z",
+    "name": "my-group0",
+    "globally_enabled": {
+        "running": true,
+        "staging": false
+    },
+    "rules": [
+        {
+            "protocol": "tcp",
+            "destination": "10.10.10.0/24",
+            "ports": "443,80,8080"
+        },
+        {
+            "protocol": "icmp",
+            "destination": "10.10.10.0/24",
+            "type": 8,
+            "code": 0,
+            "description": "Allow ping requests to private services"
+        }
+    ],
+    "relationships": {
+        "staging_spaces": {
+            "data": [
+                {
+                    "guid": "space-guid-1"
+                },
+                {
+                    "guid": "space-guid-2"
+                }
+            ]
+        },
+        "running_spaces": {
+            "data": []
+        }
+    },
+    "links": {
+        "self": {
+            "href": "https://api.example.org/v3/security_groups/b85a788e-671f-4549-814d-e34cdb2f539a"
+        }
+    }
+}

--- a/cloudfoundry-client-reactor/src/test/resources/fixtures/client/v3/security_groups/POST_request.json
+++ b/cloudfoundry-client-reactor/src/test/resources/fixtures/client/v3/security_groups/POST_request.json
@@ -1,0 +1,17 @@
+{
+    "name": "my-group0",
+    "rules": [
+        {
+            "protocol": "tcp",
+            "destination": "10.10.10.0/24",
+            "ports": "443,80,8080"
+        },
+        {
+            "protocol": "icmp",
+            "destination": "10.10.10.0/24",
+            "type": 8,
+            "code": 0,
+            "description": "Allow ping requests to private services"
+        }
+    ]
+}

--- a/cloudfoundry-client-reactor/src/test/resources/fixtures/client/v3/security_groups/POST_response.json
+++ b/cloudfoundry-client-reactor/src/test/resources/fixtures/client/v3/security_groups/POST_response.json
@@ -1,0 +1,44 @@
+{
+    "guid": "b85a788e-671f-4549-814d-e34cdb2f539a",
+    "created_at": "2020-02-20T17:42:08Z",
+    "updated_at": "2020-02-20T17:42:08Z",
+    "name": "my-group0",
+    "globally_enabled": {
+        "running": true,
+        "staging": false
+    },
+    "rules": [
+        {
+            "protocol": "tcp",
+            "destination": "10.10.10.0/24",
+            "ports": "443,80,8080"
+        },
+        {
+            "protocol": "icmp",
+            "destination": "10.10.10.0/24",
+            "type": 8,
+            "code": 0,
+            "description": "Allow ping requests to private services"
+        }
+    ],
+    "relationships": {
+        "staging_spaces": {
+            "data": [
+                {
+                    "guid": "space-guid-1"
+                },
+                {
+                    "guid": "space-guid-2"
+                }
+            ]
+        },
+        "running_spaces": {
+            "data": []
+        }
+    },
+    "links": {
+        "self": {
+            "href": "https://api.example.org/v3/security_groups/b85a788e-671f-4549-814d-e34cdb2f539a"
+        }
+    }
+}

--- a/cloudfoundry-client-reactor/src/test/resources/fixtures/client/v3/security_groups/bind_running/POST_request.json
+++ b/cloudfoundry-client-reactor/src/test/resources/fixtures/client/v3/security_groups/bind_running/POST_request.json
@@ -1,0 +1,10 @@
+{
+    "data": [
+        {
+            "guid": "space-guid1"
+        },
+        {
+            "guid": "space-guid2"
+        }
+    ]
+}

--- a/cloudfoundry-client-reactor/src/test/resources/fixtures/client/v3/security_groups/bind_running/POST_response.json
+++ b/cloudfoundry-client-reactor/src/test/resources/fixtures/client/v3/security_groups/bind_running/POST_response.json
@@ -1,0 +1,18 @@
+{
+    "data": [
+        {
+            "guid": "space-guid1"
+        },
+        {
+            "guid": "space-guid2"
+        },
+        {
+            "guid": "previous-space-guid"
+        }
+    ],
+    "links": {
+        "self": {
+            "href": "https://api.example.org/v3/security_groups/b85a788e-671f-4549-814d-e34cdb2f539a/relationships/running_spaces"
+        }
+    }
+}

--- a/cloudfoundry-client-reactor/src/test/resources/fixtures/client/v3/security_groups/bind_staging/POST_request.json
+++ b/cloudfoundry-client-reactor/src/test/resources/fixtures/client/v3/security_groups/bind_staging/POST_request.json
@@ -1,0 +1,10 @@
+{
+    "data": [
+        {
+            "guid": "space-guid1"
+        },
+        {
+            "guid": "space-guid2"
+        }
+    ]
+}

--- a/cloudfoundry-client-reactor/src/test/resources/fixtures/client/v3/security_groups/bind_staging/POST_response.json
+++ b/cloudfoundry-client-reactor/src/test/resources/fixtures/client/v3/security_groups/bind_staging/POST_response.json
@@ -1,0 +1,18 @@
+{
+    "data": [
+        {
+            "guid": "space-guid1"
+        },
+        {
+            "guid": "space-guid2"
+        },
+        {
+            "guid": "previous-space-guid"
+        }
+    ],
+    "links": {
+        "self": {
+            "href": "https://api.example.org/v3/security_groups/b85a788e-671f-4549-814d-e34cdb2f539a/relationships/staging_spaces"
+        }
+    }
+}

--- a/cloudfoundry-client/src/main/java/org/cloudfoundry/client/CloudFoundryClient.java
+++ b/cloudfoundry-client/src/main/java/org/cloudfoundry/client/CloudFoundryClient.java
@@ -63,6 +63,7 @@ import org.cloudfoundry.client.v3.processes.Processes;
 import org.cloudfoundry.client.v3.resourcematch.ResourceMatchV3;
 import org.cloudfoundry.client.v3.roles.RolesV3;
 import org.cloudfoundry.client.v3.routes.RoutesV3;
+import org.cloudfoundry.client.v3.securitygroups.SecurityGroupsV3;
 import org.cloudfoundry.client.v3.serviceinstances.ServiceInstancesV3;
 import org.cloudfoundry.client.v3.servicebindings.ServiceBindingsV3;
 import org.cloudfoundry.client.v3.servicebrokers.ServiceBrokersV3;
@@ -248,6 +249,11 @@ public interface CloudFoundryClient {
     SecurityGroups securityGroups();
 
     /**
+     * Main entry point to the Cloud Foundry Security Groups V3 Client API
+     */
+    SecurityGroupsV3 securityGroupsV3();
+
+    /**
      * Main entry point to the Cloud Foundry Service Bindings V2 Client API
      */
     ServiceBindingsV2 serviceBindingsV2();
@@ -348,7 +354,8 @@ public interface CloudFoundryClient {
     Tasks tasks();
 
     /**
-     * Main entry point to the Cloud Foundry User Provided Service Instances Client API
+     * Main entry point to the Cloud Foundry User Provided Service Instances Client
+     * API
      */
     UserProvidedServiceInstances userProvidedServiceInstances();
 

--- a/cloudfoundry-client/src/main/java/org/cloudfoundry/client/v3/securitygroups/AbstractBindSecurityGroupRequest.java
+++ b/cloudfoundry-client/src/main/java/org/cloudfoundry/client/v3/securitygroups/AbstractBindSecurityGroupRequest.java
@@ -1,26 +1,21 @@
 /*
- * Copyright 2013-2021 the original author or authors.
+ * Copyright 2013-2023 the original author or authors.
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ * http://www.apache.org/licenses/LICENSE-2.0
  *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
  */
 
 package org.cloudfoundry.client.v3.securitygroups;
 
 import java.util.List;
-
 import org.cloudfoundry.client.v3.Relationship;
-import org.cloudfoundry.client.v3.ToManyRelationship;
-
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;

--- a/cloudfoundry-client/src/main/java/org/cloudfoundry/client/v3/securitygroups/AbstractBindSecurityGroupRequest.java
+++ b/cloudfoundry-client/src/main/java/org/cloudfoundry/client/v3/securitygroups/AbstractBindSecurityGroupRequest.java
@@ -16,6 +16,9 @@
 
 package org.cloudfoundry.client.v3.securitygroups;
 
+import java.util.List;
+
+import org.cloudfoundry.client.v3.Relationship;
 import org.cloudfoundry.client.v3.ToManyRelationship;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
@@ -36,5 +39,5 @@ public abstract class AbstractBindSecurityGroupRequest {
      * applications during runtime
      */
     @JsonProperty("data")
-    abstract ToManyRelationship getBoundSpaces();
+    abstract List<Relationship> getBoundSpaces();
 }

--- a/cloudfoundry-client/src/main/java/org/cloudfoundry/client/v3/securitygroups/AbstractBindSecurityGroupRequest.java
+++ b/cloudfoundry-client/src/main/java/org/cloudfoundry/client/v3/securitygroups/AbstractBindSecurityGroupRequest.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2013-2021 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.cloudfoundry.client.v3.securitygroups;
+
+import org.cloudfoundry.client.v3.ToManyRelationship;
+
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+
+@JsonSerialize
+public abstract class AbstractBindSecurityGroupRequest {
+
+    /**
+     * The Security Group id
+     */
+    @JsonIgnore
+    abstract String getSecurityGroupId();
+
+    /**
+     * A relationship to the spaces where the security_group is applied to
+     * applications during runtime
+     */
+    @JsonProperty("data")
+    abstract ToManyRelationship getBoundSpaces();
+}

--- a/cloudfoundry-client/src/main/java/org/cloudfoundry/client/v3/securitygroups/AbstractBindSecurityGroupResponse.java
+++ b/cloudfoundry-client/src/main/java/org/cloudfoundry/client/v3/securitygroups/AbstractBindSecurityGroupResponse.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2013-2021 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.cloudfoundry.client.v3.securitygroups;
+
+import org.cloudfoundry.Nullable;
+import org.cloudfoundry.client.v3.ToManyRelationship;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+
+@JsonDeserialize
+public abstract class AbstractBindSecurityGroupResponse {
+
+    /**
+     * A relationship to the spaces where the security_group is applied to
+     * applications during runtime
+     */
+    @JsonProperty("data")
+    abstract ToManyRelationship getBoundSpaces();
+
+    /**
+     * When the resource was last updated
+     */
+    @JsonProperty("updated_at")
+    @Nullable
+    public abstract String getUpdatedAt();
+}

--- a/cloudfoundry-client/src/main/java/org/cloudfoundry/client/v3/securitygroups/AbstractBindSecurityGroupResponse.java
+++ b/cloudfoundry-client/src/main/java/org/cloudfoundry/client/v3/securitygroups/AbstractBindSecurityGroupResponse.java
@@ -1,29 +1,25 @@
 /*
- * Copyright 2013-2021 the original author or authors.
+ * Copyright 2013-2023 the original author or authors.
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ * http://www.apache.org/licenses/LICENSE-2.0
  *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
  */
 
 package org.cloudfoundry.client.v3.securitygroups;
 
 import java.util.List;
 import java.util.Map;
-
 import org.cloudfoundry.AllowNulls;
-import org.cloudfoundry.Nullable;
 import org.cloudfoundry.client.v3.Link;
 import org.cloudfoundry.client.v3.Relationship;
-import org.cloudfoundry.client.v3.ToManyRelationship;
+
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
@@ -32,8 +28,8 @@ import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 public abstract class AbstractBindSecurityGroupResponse {
 
     /**
-     * A relationship to the spaces where the security_group is applied to
-     * applications during runtime
+     * A relationship to the spaces where the security_group is applied to applications during
+     * runtime
      */
     @JsonProperty("data")
     abstract List<Relationship> getBoundSpaces();

--- a/cloudfoundry-client/src/main/java/org/cloudfoundry/client/v3/securitygroups/AbstractBindSecurityGroupResponse.java
+++ b/cloudfoundry-client/src/main/java/org/cloudfoundry/client/v3/securitygroups/AbstractBindSecurityGroupResponse.java
@@ -16,7 +16,11 @@
 
 package org.cloudfoundry.client.v3.securitygroups;
 
+import java.util.Map;
+
+import org.cloudfoundry.AllowNulls;
 import org.cloudfoundry.Nullable;
+import org.cloudfoundry.client.v3.Link;
 import org.cloudfoundry.client.v3.ToManyRelationship;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
@@ -33,9 +37,9 @@ public abstract class AbstractBindSecurityGroupResponse {
     abstract ToManyRelationship getBoundSpaces();
 
     /**
-     * When the resource was last updated
+     * The links
      */
-    @JsonProperty("updated_at")
-    @Nullable
-    public abstract String getUpdatedAt();
+    @AllowNulls
+    @JsonProperty("links")
+    public abstract Map<String, Link> getLinks();
 }

--- a/cloudfoundry-client/src/main/java/org/cloudfoundry/client/v3/securitygroups/AbstractBindSecurityGroupResponse.java
+++ b/cloudfoundry-client/src/main/java/org/cloudfoundry/client/v3/securitygroups/AbstractBindSecurityGroupResponse.java
@@ -16,11 +16,13 @@
 
 package org.cloudfoundry.client.v3.securitygroups;
 
+import java.util.List;
 import java.util.Map;
 
 import org.cloudfoundry.AllowNulls;
 import org.cloudfoundry.Nullable;
 import org.cloudfoundry.client.v3.Link;
+import org.cloudfoundry.client.v3.Relationship;
 import org.cloudfoundry.client.v3.ToManyRelationship;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
@@ -34,7 +36,7 @@ public abstract class AbstractBindSecurityGroupResponse {
      * applications during runtime
      */
     @JsonProperty("data")
-    abstract ToManyRelationship getBoundSpaces();
+    abstract List<Relationship> getBoundSpaces();
 
     /**
      * The links

--- a/cloudfoundry-client/src/main/java/org/cloudfoundry/client/v3/securitygroups/AbstractListSecurityGroupRequest.java
+++ b/cloudfoundry-client/src/main/java/org/cloudfoundry/client/v3/securitygroups/AbstractListSecurityGroupRequest.java
@@ -1,0 +1,33 @@
+package org.cloudfoundry.client.v3.securitygroups;
+
+import java.util.List;
+
+import org.cloudfoundry.Nullable;
+import org.cloudfoundry.client.v2.PaginatedRequest;
+import org.cloudfoundry.client.v3.FilterParameter;
+
+import com.fasterxml.jackson.annotation.JsonIgnore;
+
+public abstract class AbstractListSecurityGroupRequest extends PaginatedRequest {
+
+    /**
+     * The Space id
+     */
+    @JsonIgnore
+    abstract String getSpaceId();
+
+    /**
+     * The security group ids filter
+     */
+    @FilterParameter("guids")
+    @Nullable
+    abstract List<String> getSecurityGroupIds();
+
+    /**
+     * The security group names filter
+     */
+    @FilterParameter("names")
+    @Nullable
+    abstract List<String> getNames();
+
+}

--- a/cloudfoundry-client/src/main/java/org/cloudfoundry/client/v3/securitygroups/AbstractListSecurityGroupRequest.java
+++ b/cloudfoundry-client/src/main/java/org/cloudfoundry/client/v3/securitygroups/AbstractListSecurityGroupRequest.java
@@ -1,3 +1,16 @@
+/*
+ * Copyright 2013-2023 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
 package org.cloudfoundry.client.v3.securitygroups;
 
 import java.util.List;
@@ -5,7 +18,6 @@ import java.util.List;
 import org.cloudfoundry.Nullable;
 import org.cloudfoundry.client.v2.PaginatedRequest;
 import org.cloudfoundry.client.v3.FilterParameter;
-
 import com.fasterxml.jackson.annotation.JsonIgnore;
 
 public abstract class AbstractListSecurityGroupRequest extends PaginatedRequest {

--- a/cloudfoundry-client/src/main/java/org/cloudfoundry/client/v3/securitygroups/AbstractUnbindSecurityGroupRequest.java
+++ b/cloudfoundry-client/src/main/java/org/cloudfoundry/client/v3/securitygroups/AbstractUnbindSecurityGroupRequest.java
@@ -1,17 +1,15 @@
 /*
- * Copyright 2013-2021 the original author or authors.
+ * Copyright 2013-2023 the original author or authors.
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ * http://www.apache.org/licenses/LICENSE-2.0
  *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
  */
 
 package org.cloudfoundry.client.v3.securitygroups;

--- a/cloudfoundry-client/src/main/java/org/cloudfoundry/client/v3/securitygroups/AbstractUnbindSecurityGroupRequest.java
+++ b/cloudfoundry-client/src/main/java/org/cloudfoundry/client/v3/securitygroups/AbstractUnbindSecurityGroupRequest.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2013-2021 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.cloudfoundry.client.v3.securitygroups;
+
+import com.fasterxml.jackson.annotation.JsonIgnore;
+
+public abstract class AbstractUnbindSecurityGroupRequest {
+
+    /**
+     * The Security Group id
+     */
+    @JsonIgnore
+    abstract String getSecurityGroupId();
+
+    /**
+     * The Space id
+     */
+    @JsonIgnore
+    abstract String getSpaceId();
+}

--- a/cloudfoundry-client/src/main/java/org/cloudfoundry/client/v3/securitygroups/Protocol.java
+++ b/cloudfoundry-client/src/main/java/org/cloudfoundry/client/v3/securitygroups/Protocol.java
@@ -1,0 +1,79 @@
+/*
+ * Copyright 2013-2021 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.cloudfoundry.client.v3.securitygroups;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonValue;
+
+/**
+ * The protocol of a {@link RuleEntity}
+ */
+public enum Protocol {
+
+    /**
+     * All protocols
+     */
+    ALL("all"),
+
+    /**
+     * ICMP protocol
+     */
+    ICMP("icmp"),
+
+    /**
+     * TCP protocol
+     */
+    TCP("tcp"),
+
+    /**
+     * UDP protocol
+     */
+    UDP("udp");
+
+    private final String value;
+
+    Protocol(String value) {
+        this.value = value;
+    }
+
+    @JsonCreator
+    public static Protocol from(String s) {
+        switch (s.toLowerCase()) {
+            case "all":
+                return ALL;
+            case "icmp":
+                return ICMP;
+            case "tcp":
+                return TCP;
+            case "udp":
+                return UDP;
+            default:
+                throw new IllegalArgumentException(String.format("Unknown protocol: %s", s));
+        }
+    }
+
+    @JsonValue
+    public String getValue() {
+        return this.value;
+    }
+
+    @Override
+    public String toString() {
+        return getValue();
+    }
+
+}

--- a/cloudfoundry-client/src/main/java/org/cloudfoundry/client/v3/securitygroups/Protocol.java
+++ b/cloudfoundry-client/src/main/java/org/cloudfoundry/client/v3/securitygroups/Protocol.java
@@ -1,17 +1,15 @@
 /*
- * Copyright 2013-2021 the original author or authors.
+ * Copyright 2013-2023 the original author or authors.
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ * http://www.apache.org/licenses/LICENSE-2.0
  *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
  */
 
 package org.cloudfoundry.client.v3.securitygroups;
@@ -20,7 +18,7 @@ import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
 
 /**
- * The protocol of a {@link RuleEntity}
+ * The protocol of a Security Group
  */
 public enum Protocol {
 

--- a/cloudfoundry-client/src/main/java/org/cloudfoundry/client/v3/securitygroups/SecurityGroup.java
+++ b/cloudfoundry-client/src/main/java/org/cloudfoundry/client/v3/securitygroups/SecurityGroup.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright 2013-2021 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.cloudfoundry.client.v3.securitygroups;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import org.cloudfoundry.Nullable;
+import org.immutables.value.Value;
+import org.cloudfoundry.client.v3.Resource;
+import java.util.List;
+
+/**
+ * The entity response payload for the Security Group resource
+ */
+@JsonDeserialize
+public abstract class SecurityGroup extends Resource {
+
+    /**
+     * The name
+     */
+    @JsonProperty("name")
+    abstract String getName();
+
+    /**
+     * The globally enabled
+     */
+    @JsonProperty("globally_enabled")
+    @Nullable
+    abstract GloballyEnabled getGloballyEnabled();
+
+    /**
+     * The rules
+     */
+    @JsonProperty("rules")
+    @Nullable
+    abstract List<Rule> getRules();
+
+    /**
+     * The space relationships
+     */
+    @JsonProperty("relationships")
+    @Nullable
+    abstract Relationships getRelationships();
+
+}

--- a/cloudfoundry-client/src/main/java/org/cloudfoundry/client/v3/securitygroups/SecurityGroup.java
+++ b/cloudfoundry-client/src/main/java/org/cloudfoundry/client/v3/securitygroups/SecurityGroup.java
@@ -39,21 +39,18 @@ public abstract class SecurityGroup extends Resource {
      * The globally enabled
      */
     @JsonProperty("globally_enabled")
-    @Nullable
     abstract GloballyEnabled getGloballyEnabled();
 
     /**
      * The rules
      */
     @JsonProperty("rules")
-    @Nullable
     abstract List<Rule> getRules();
 
     /**
      * The space relationships
      */
     @JsonProperty("relationships")
-    @Nullable
     abstract Relationships getRelationships();
 
 }

--- a/cloudfoundry-client/src/main/java/org/cloudfoundry/client/v3/securitygroups/SecurityGroup.java
+++ b/cloudfoundry-client/src/main/java/org/cloudfoundry/client/v3/securitygroups/SecurityGroup.java
@@ -1,25 +1,21 @@
 /*
- * Copyright 2013-2021 the original author or authors.
+ * Copyright 2013-2023 the original author or authors.
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ * http://www.apache.org/licenses/LICENSE-2.0
  *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
  */
 
 package org.cloudfoundry.client.v3.securitygroups;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
-import org.cloudfoundry.Nullable;
-import org.immutables.value.Value;
 import org.cloudfoundry.client.v3.Resource;
 import java.util.List;
 

--- a/cloudfoundry-client/src/main/java/org/cloudfoundry/client/v3/securitygroups/SecurityGroupsV3.java
+++ b/cloudfoundry-client/src/main/java/org/cloudfoundry/client/v3/securitygroups/SecurityGroupsV3.java
@@ -69,4 +69,24 @@ public interface SecurityGroupsV3 {
      * @return the response from the List Security Group request
      */
     Mono<String> delete(DeleteSecurityGroupRequest request);
+
+    /**
+     * Makes the <a href=
+     * "https://v3-apidocs.cloudfoundry.org/version/3.140.0/index.html#bind-a-staging-security-group-to-spaces">Bind
+     * Staging Security Group</a> request
+     *
+     * @param request the Bind Staging Security Group request
+     * @return the response from the Bind Staging Security Group request
+     */
+    Mono<BindStagingSecurityGroupResponse> bindStagingSecurityGroup(BindStagingSecurityGroupRequest request);
+
+    /**
+     * Makes the <a href=
+     * "https://v3-apidocs.cloudfoundry.org/version/3.140.0/index.html#bind-a-running-security-group-to-spaces">Bind
+     * Running Security Group</a> request
+     *
+     * @param request the Bind Running Security Group request
+     * @return the response from the Bind Running Security Group request
+     */
+    Mono<BindStagingSecurityGroupResponse> bindRunningSecurityGroup(BindStagingSecurityGroupRequest request);
 }

--- a/cloudfoundry-client/src/main/java/org/cloudfoundry/client/v3/securitygroups/SecurityGroupsV3.java
+++ b/cloudfoundry-client/src/main/java/org/cloudfoundry/client/v3/securitygroups/SecurityGroupsV3.java
@@ -25,8 +25,8 @@ public interface SecurityGroupsV3 {
      * "https://apidocs.cloudfoundry.org/latest-release/security_groups/creating_a_security_group.html">Creating
      * a Security Group</a> request.
      *
-     * @param request the create security group request
-     * @return the response from the create security group request
+     * @param request the Create Security Group request
+     * @return the response from the Create Security Group request
      */
     Mono<CreateSecurityGroupResponse> create(CreateSecurityGroupRequest request);
 
@@ -35,9 +35,20 @@ public interface SecurityGroupsV3 {
      * "https://v3-apidocs.cloudfoundry.org/version/3.140.0/index.html#get-a-security-group">Get
      * a Security Group</a> request.
      *
-     * @param request the get security group request
-     * @return the response from the get security group request
+     * @param request the Get Security Group request
+     * @return the response from the Get Security Group request
      */
     Mono<GetSecurityGroupResponse> get(GetSecurityGroupRequest request);
+
+    /**
+     * Makes the <a href=
+     *
+     * "https://v3-apidocs.cloudfoundry.org/version/3.140.0/index.html#list-security-groups">List
+     * Security Groups</a> request
+     *
+     * @param request the List Security Group request
+     * @return the response from the List Security Group request
+     */
+    Mono<ListSecurityGroupsResponse> list(ListSecurityGroupsRequest request);
 
 }

--- a/cloudfoundry-client/src/main/java/org/cloudfoundry/client/v3/securitygroups/SecurityGroupsV3.java
+++ b/cloudfoundry-client/src/main/java/org/cloudfoundry/client/v3/securitygroups/SecurityGroupsV3.java
@@ -56,7 +56,7 @@ public interface SecurityGroupsV3 {
      * Security Groups</a> request
      *
      * @param request the Update Security Group request
-     * @return the response from the List Security Group request
+     * @return the response from the Update Security Group request
      */
     Mono<UpdateSecurityGroupResponse> update(UpdateSecurityGroupRequest request);
 
@@ -66,7 +66,7 @@ public interface SecurityGroupsV3 {
      * Security Groups</a> request
      *
      * @param request the Delete Security Group request
-     * @return the response from the List Security Group request
+     * @return the response from the Delete Security Group request
      */
     Mono<String> delete(DeleteSecurityGroupRequest request);
 
@@ -89,4 +89,26 @@ public interface SecurityGroupsV3 {
      * @return the response from the Bind Running Security Group request
      */
     Mono<BindRunningSecurityGroupResponse> bindRunningSecurityGroup(BindRunningSecurityGroupRequest request);
+
+    /**
+     * Makes the <a href=
+     * "https://v3-apidocs.cloudfoundry.org/version/3.140.0/index.html#unbind-a-staging-security-group-from-a-space">Unbind
+     * Staging
+     * Security Group</a> request
+     *
+     * @param request the Unbind Staging Security Group request
+     * @return the response from the Unbind staging Security Group request
+     */
+    Mono<Void> unbindStagingSecurityGroup(UnbindStagingSecurityGroupRequest request);
+
+    /**
+     * Makes the <a href=
+     * "https://v3-apidocs.cloudfoundry.org/version/3.140.0/index.html#delete-a-security-group">Unbind
+     * Running
+     * Security Groups</a> request
+     *
+     * @param request the Unbind Staging Running Security Group request
+     * @return the response from the Unbind Running Security Group request
+     */
+    Mono<Void> unbindRunningSecurityGroup(UnbindRunningSecurityGroupRequest request);
 }

--- a/cloudfoundry-client/src/main/java/org/cloudfoundry/client/v3/securitygroups/SecurityGroupsV3.java
+++ b/cloudfoundry-client/src/main/java/org/cloudfoundry/client/v3/securitygroups/SecurityGroupsV3.java
@@ -51,4 +51,14 @@ public interface SecurityGroupsV3 {
      */
     Mono<ListSecurityGroupsResponse> list(ListSecurityGroupsRequest request);
 
+    /**
+     * Makes the <a href=
+     *
+     * "https://v3-apidocs.cloudfoundry.org/version/3.140.0/index.html#update-a-security-group">Update
+     * Security Groups</a> request
+     *
+     * @param request the Update Security Group request
+     * @return the response from the List Security Group request
+     */
+    Mono<UpdateSecurityGroupResponse> update(UpdateSecurityGroupRequest request);
 }

--- a/cloudfoundry-client/src/main/java/org/cloudfoundry/client/v3/securitygroups/SecurityGroupsV3.java
+++ b/cloudfoundry-client/src/main/java/org/cloudfoundry/client/v3/securitygroups/SecurityGroupsV3.java
@@ -30,4 +30,14 @@ public interface SecurityGroupsV3 {
      */
     Mono<CreateSecurityGroupResponse> create(CreateSecurityGroupRequest request);
 
+    /**
+     * Makes the <a href=
+     * "https://v3-apidocs.cloudfoundry.org/version/3.140.0/index.html#get-a-security-group">Get
+     * a Security Group</a> request.
+     *
+     * @param request the get security group request
+     * @return the response from the get security group request
+     */
+    Mono<GetSecurityGroupResponse> get(GetSecurityGroupRequest request);
+
 }

--- a/cloudfoundry-client/src/main/java/org/cloudfoundry/client/v3/securitygroups/SecurityGroupsV3.java
+++ b/cloudfoundry-client/src/main/java/org/cloudfoundry/client/v3/securitygroups/SecurityGroupsV3.java
@@ -42,7 +42,6 @@ public interface SecurityGroupsV3 {
 
     /**
      * Makes the <a href=
-     *
      * "https://v3-apidocs.cloudfoundry.org/version/3.140.0/index.html#list-security-groups">List
      * Security Groups</a> request
      *
@@ -53,7 +52,6 @@ public interface SecurityGroupsV3 {
 
     /**
      * Makes the <a href=
-     *
      * "https://v3-apidocs.cloudfoundry.org/version/3.140.0/index.html#update-a-security-group">Update
      * Security Groups</a> request
      *
@@ -61,4 +59,14 @@ public interface SecurityGroupsV3 {
      * @return the response from the List Security Group request
      */
     Mono<UpdateSecurityGroupResponse> update(UpdateSecurityGroupRequest request);
+
+    /**
+     * Makes the <a href=
+     * "https://v3-apidocs.cloudfoundry.org/version/3.140.0/index.html#update-a-security-group">Delete
+     * Security Groups</a> request
+     *
+     * @param request the Delete Security Group request
+     * @return the response from the List Security Group request
+     */
+    Mono<String> delete(DeleteSecurityGroupRequest request);
 }

--- a/cloudfoundry-client/src/main/java/org/cloudfoundry/client/v3/securitygroups/SecurityGroupsV3.java
+++ b/cloudfoundry-client/src/main/java/org/cloudfoundry/client/v3/securitygroups/SecurityGroupsV3.java
@@ -88,5 +88,5 @@ public interface SecurityGroupsV3 {
      * @param request the Bind Running Security Group request
      * @return the response from the Bind Running Security Group request
      */
-    Mono<BindStagingSecurityGroupResponse> bindRunningSecurityGroup(BindStagingSecurityGroupRequest request);
+    Mono<BindRunningSecurityGroupResponse> bindRunningSecurityGroup(BindRunningSecurityGroupRequest request);
 }

--- a/cloudfoundry-client/src/main/java/org/cloudfoundry/client/v3/securitygroups/SecurityGroupsV3.java
+++ b/cloudfoundry-client/src/main/java/org/cloudfoundry/client/v3/securitygroups/SecurityGroupsV3.java
@@ -111,4 +111,24 @@ public interface SecurityGroupsV3 {
      * @return the response from the Unbind Running Security Group request
      */
     Mono<Void> unbindRunningSecurityGroup(UnbindRunningSecurityGroupRequest request);
+
+    /**
+     * Makes the <a href=
+     * "https://v3-apidocs.cloudfoundry.org/version/3.140.0/index.html#list-staging-security-groups-for-a-space">List
+     * Running Security Groups</a> request
+     *
+     * @param request the List Staging Security Group request
+     * @return the response from the List Staging Security Group request
+     */
+    Mono<ListStagingSecurityGroupsResponse> listStaging(ListStagingSecurityGroupsRequest request);
+
+    /**
+     * Makes the <a href=
+     * "https://v3-apidocs.cloudfoundry.org/version/3.140.0/index.html#list-running-security-groups-for-a-space">List
+     * Running Security Groups</a> request
+     *
+     * @param request the List Staging Security Group request
+     * @return the response from the List Running Security Group request
+     */
+    Mono<ListRunningSecurityGroupsResponse> listRunning(ListRunningSecurityGroupsRequest request);
 }

--- a/cloudfoundry-client/src/main/java/org/cloudfoundry/client/v3/securitygroups/SecurityGroupsV3.java
+++ b/cloudfoundry-client/src/main/java/org/cloudfoundry/client/v3/securitygroups/SecurityGroupsV3.java
@@ -62,7 +62,7 @@ public interface SecurityGroupsV3 {
 
     /**
      * Makes the <a href=
-     * "https://v3-apidocs.cloudfoundry.org/version/3.140.0/index.html#update-a-security-group">Delete
+     * "https://v3-apidocs.cloudfoundry.org/version/3.140.0/index.html#delete-a-security-group">Delete
      * Security Groups</a> request
      *
      * @param request the Delete Security Group request

--- a/cloudfoundry-client/src/main/java/org/cloudfoundry/client/v3/securitygroups/SecurityGroupsV3.java
+++ b/cloudfoundry-client/src/main/java/org/cloudfoundry/client/v3/securitygroups/SecurityGroupsV3.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2013-2021 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.cloudfoundry.client.v3.securitygroups;
+
+import reactor.core.publisher.Mono;
+
+public interface SecurityGroupsV3 {
+
+    /**
+     * Makes the <a href=
+     * "https://apidocs.cloudfoundry.org/latest-release/security_groups/creating_a_security_group.html">Creating
+     * a Security Group</a> request.
+     *
+     * @param request the create security group request
+     * @return the response from the create security group request
+     */
+    Mono<CreateSecurityGroupResponse> create(CreateSecurityGroupRequest request);
+
+}

--- a/cloudfoundry-client/src/main/java/org/cloudfoundry/client/v3/securitygroups/_BindRunningSecurityGroupRequest.java
+++ b/cloudfoundry-client/src/main/java/org/cloudfoundry/client/v3/securitygroups/_BindRunningSecurityGroupRequest.java
@@ -1,17 +1,15 @@
 /*
- * Copyright 2013-2021 the original author or authors.
+ * Copyright 2013-2023 the original author or authors.
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ * http://www.apache.org/licenses/LICENSE-2.0
  *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
  */
 
 package org.cloudfoundry.client.v3.securitygroups;

--- a/cloudfoundry-client/src/main/java/org/cloudfoundry/client/v3/securitygroups/_BindRunningSecurityGroupRequest.java
+++ b/cloudfoundry-client/src/main/java/org/cloudfoundry/client/v3/securitygroups/_BindRunningSecurityGroupRequest.java
@@ -1,0 +1,24 @@
+/*
+ * Copyright 2013-2021 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.cloudfoundry.client.v3.securitygroups;
+
+import org.immutables.value.Value;
+
+@Value.Immutable
+abstract class _BindRunningSecurityGroupRequest extends AbstractBindSecurityGroupRequest {
+
+}

--- a/cloudfoundry-client/src/main/java/org/cloudfoundry/client/v3/securitygroups/_BindRunningSecurityGroupRequest.java
+++ b/cloudfoundry-client/src/main/java/org/cloudfoundry/client/v3/securitygroups/_BindRunningSecurityGroupRequest.java
@@ -18,6 +18,9 @@ package org.cloudfoundry.client.v3.securitygroups;
 
 import org.immutables.value.Value;
 
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+
+@JsonSerialize
 @Value.Immutable
 abstract class _BindRunningSecurityGroupRequest extends AbstractBindSecurityGroupRequest {
 

--- a/cloudfoundry-client/src/main/java/org/cloudfoundry/client/v3/securitygroups/_BindRunningSecurityGroupResponse.java
+++ b/cloudfoundry-client/src/main/java/org/cloudfoundry/client/v3/securitygroups/_BindRunningSecurityGroupResponse.java
@@ -1,0 +1,24 @@
+/*
+ * Copyright 2013-2021 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.cloudfoundry.client.v3.securitygroups;
+
+import org.immutables.value.Value;
+
+@Value.Immutable
+public abstract class _BindRunningSecurityGroupResponse extends AbstractBindSecurityGroupResponse {
+
+}

--- a/cloudfoundry-client/src/main/java/org/cloudfoundry/client/v3/securitygroups/_BindRunningSecurityGroupResponse.java
+++ b/cloudfoundry-client/src/main/java/org/cloudfoundry/client/v3/securitygroups/_BindRunningSecurityGroupResponse.java
@@ -1,17 +1,15 @@
 /*
- * Copyright 2013-2021 the original author or authors.
+ * Copyright 2013-2023 the original author or authors.
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ * http://www.apache.org/licenses/LICENSE-2.0
  *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
  */
 
 package org.cloudfoundry.client.v3.securitygroups;

--- a/cloudfoundry-client/src/main/java/org/cloudfoundry/client/v3/securitygroups/_BindRunningSecurityGroupResponse.java
+++ b/cloudfoundry-client/src/main/java/org/cloudfoundry/client/v3/securitygroups/_BindRunningSecurityGroupResponse.java
@@ -18,6 +18,9 @@ package org.cloudfoundry.client.v3.securitygroups;
 
 import org.immutables.value.Value;
 
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+
+@JsonDeserialize
 @Value.Immutable
 public abstract class _BindRunningSecurityGroupResponse extends AbstractBindSecurityGroupResponse {
 

--- a/cloudfoundry-client/src/main/java/org/cloudfoundry/client/v3/securitygroups/_BindStagingSecurityGroupRequest.java
+++ b/cloudfoundry-client/src/main/java/org/cloudfoundry/client/v3/securitygroups/_BindStagingSecurityGroupRequest.java
@@ -1,17 +1,15 @@
 /*
- * Copyright 2013-2021 the original author or authors.
+ * Copyright 2013-2023 the original author or authors.
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ * http://www.apache.org/licenses/LICENSE-2.0
  *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
  */
 
 package org.cloudfoundry.client.v3.securitygroups;

--- a/cloudfoundry-client/src/main/java/org/cloudfoundry/client/v3/securitygroups/_BindStagingSecurityGroupRequest.java
+++ b/cloudfoundry-client/src/main/java/org/cloudfoundry/client/v3/securitygroups/_BindStagingSecurityGroupRequest.java
@@ -1,0 +1,24 @@
+/*
+ * Copyright 2013-2021 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.cloudfoundry.client.v3.securitygroups;
+
+import org.immutables.value.Value;
+
+@Value.Immutable
+abstract class _BindStagingSecurityGroupRequest extends AbstractBindSecurityGroupRequest {
+
+}

--- a/cloudfoundry-client/src/main/java/org/cloudfoundry/client/v3/securitygroups/_BindStagingSecurityGroupRequest.java
+++ b/cloudfoundry-client/src/main/java/org/cloudfoundry/client/v3/securitygroups/_BindStagingSecurityGroupRequest.java
@@ -17,7 +17,9 @@
 package org.cloudfoundry.client.v3.securitygroups;
 
 import org.immutables.value.Value;
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 
+@JsonSerialize
 @Value.Immutable
 abstract class _BindStagingSecurityGroupRequest extends AbstractBindSecurityGroupRequest {
 

--- a/cloudfoundry-client/src/main/java/org/cloudfoundry/client/v3/securitygroups/_BindStagingSecurityGroupResponse.java
+++ b/cloudfoundry-client/src/main/java/org/cloudfoundry/client/v3/securitygroups/_BindStagingSecurityGroupResponse.java
@@ -1,17 +1,15 @@
 /*
- * Copyright 2013-2021 the original author or authors.
+ * Copyright 2013-2023 the original author or authors.
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ * http://www.apache.org/licenses/LICENSE-2.0
  *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
  */
 
 package org.cloudfoundry.client.v3.securitygroups;

--- a/cloudfoundry-client/src/main/java/org/cloudfoundry/client/v3/securitygroups/_BindStagingSecurityGroupResponse.java
+++ b/cloudfoundry-client/src/main/java/org/cloudfoundry/client/v3/securitygroups/_BindStagingSecurityGroupResponse.java
@@ -1,0 +1,24 @@
+/*
+ * Copyright 2013-2021 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.cloudfoundry.client.v3.securitygroups;
+
+import org.immutables.value.Value;
+
+@Value.Immutable
+public abstract class _BindStagingSecurityGroupResponse extends AbstractBindSecurityGroupResponse {
+
+}

--- a/cloudfoundry-client/src/main/java/org/cloudfoundry/client/v3/securitygroups/_BindStagingSecurityGroupResponse.java
+++ b/cloudfoundry-client/src/main/java/org/cloudfoundry/client/v3/securitygroups/_BindStagingSecurityGroupResponse.java
@@ -17,7 +17,9 @@
 package org.cloudfoundry.client.v3.securitygroups;
 
 import org.immutables.value.Value;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 
+@JsonDeserialize
 @Value.Immutable
 public abstract class _BindStagingSecurityGroupResponse extends AbstractBindSecurityGroupResponse {
 

--- a/cloudfoundry-client/src/main/java/org/cloudfoundry/client/v3/securitygroups/_CreateSecurityGroupRequest.java
+++ b/cloudfoundry-client/src/main/java/org/cloudfoundry/client/v3/securitygroups/_CreateSecurityGroupRequest.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright 2013-2021 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.cloudfoundry.client.v3.securitygroups;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+import org.cloudfoundry.Nullable;
+import org.immutables.value.Value;
+
+import java.util.List;
+
+/**
+ * The request payload for the Create a Security Group operation
+ */
+@JsonSerialize
+@Value.Immutable
+abstract class _CreateSecurityGroupRequest {
+
+    /**
+     * The security group name
+     */
+    @JsonProperty("name")
+    abstract String getName();
+
+    /**
+     * the security group glbally enabled field
+     */
+    @JsonProperty("globally_enabled")
+    @Nullable
+    abstract GloballyEnabled getGloballyEnabled();
+
+    /**
+     * The security group rules
+     */
+    @JsonProperty("rules")
+    @Nullable
+    abstract List<Rule> getRules();
+
+    /**
+     * The security group relationships
+     */
+    @JsonProperty("relationships")
+    @Nullable
+    abstract Relationships getRelationships();
+
+}

--- a/cloudfoundry-client/src/main/java/org/cloudfoundry/client/v3/securitygroups/_CreateSecurityGroupResponse.java
+++ b/cloudfoundry-client/src/main/java/org/cloudfoundry/client/v3/securitygroups/_CreateSecurityGroupResponse.java
@@ -1,17 +1,15 @@
 /*
- * Copyright 2013-2021 the original author or authors.
+ * Copyright 2013-2023 the original author or authors.
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ * http://www.apache.org/licenses/LICENSE-2.0
  *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
  */
 
 package org.cloudfoundry.client.v3.securitygroups;

--- a/cloudfoundry-client/src/main/java/org/cloudfoundry/client/v3/securitygroups/_CreateSecurityGroupResponse.java
+++ b/cloudfoundry-client/src/main/java/org/cloudfoundry/client/v3/securitygroups/_CreateSecurityGroupResponse.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright 2013-2021 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.cloudfoundry.client.v3.securitygroups;
+
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import org.immutables.value.Value;
+
+/**
+ * The response payload for the Creating a Security Group operation
+ */
+@JsonDeserialize
+@Value.Immutable
+abstract class _CreateSecurityGroupResponse extends SecurityGroup {
+
+}

--- a/cloudfoundry-client/src/main/java/org/cloudfoundry/client/v3/securitygroups/_DeleteSecurityGroupRequest.java
+++ b/cloudfoundry-client/src/main/java/org/cloudfoundry/client/v3/securitygroups/_DeleteSecurityGroupRequest.java
@@ -23,7 +23,6 @@ import org.immutables.value.Value;
 /**
  * The request payload for the Delete Security Group operation
  */
-@JsonSerialize
 @Value.Immutable
 abstract class _DeleteSecurityGroupRequest {
 

--- a/cloudfoundry-client/src/main/java/org/cloudfoundry/client/v3/securitygroups/_DeleteSecurityGroupRequest.java
+++ b/cloudfoundry-client/src/main/java/org/cloudfoundry/client/v3/securitygroups/_DeleteSecurityGroupRequest.java
@@ -1,22 +1,19 @@
 /*
- * Copyright 2013-2021 the original author or authors.
+ * Copyright 2013-2023 the original author or authors.
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ * http://www.apache.org/licenses/LICENSE-2.0
  *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
  */
 
 package org.cloudfoundry.client.v3.securitygroups;
 
-import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import org.immutables.value.Value;
 

--- a/cloudfoundry-client/src/main/java/org/cloudfoundry/client/v3/securitygroups/_DeleteSecurityGroupRequest.java
+++ b/cloudfoundry-client/src/main/java/org/cloudfoundry/client/v3/securitygroups/_DeleteSecurityGroupRequest.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2013-2021 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.cloudfoundry.client.v3.securitygroups;
+
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import org.immutables.value.Value;
+
+/**
+ * The request payload for the Delete Security Group operation
+ */
+@JsonSerialize
+@Value.Immutable
+abstract class _DeleteSecurityGroupRequest {
+
+    /**
+     * The Security Group id
+     */
+    @JsonIgnore
+    abstract String getSecurityGroupId();
+
+}

--- a/cloudfoundry-client/src/main/java/org/cloudfoundry/client/v3/securitygroups/_GetSecurityGroupRequest.java
+++ b/cloudfoundry-client/src/main/java/org/cloudfoundry/client/v3/securitygroups/_GetSecurityGroupRequest.java
@@ -1,17 +1,15 @@
 /*
- * Copyright 2013-2021 the original author or authors.
+ * Copyright 2013-2023 the original author or authors.
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ * http://www.apache.org/licenses/LICENSE-2.0
  *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
  */
 
 package org.cloudfoundry.client.v3.securitygroups;

--- a/cloudfoundry-client/src/main/java/org/cloudfoundry/client/v3/securitygroups/_GetSecurityGroupRequest.java
+++ b/cloudfoundry-client/src/main/java/org/cloudfoundry/client/v3/securitygroups/_GetSecurityGroupRequest.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2013-2021 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.cloudfoundry.client.v3.securitygroups;
+
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import org.immutables.value.Value;
+
+/**
+ * The request payload for the Get Security Group operation
+ */
+@JsonDeserialize
+@Value.Immutable
+abstract class _GetSecurityGroupRequest {
+
+    /**
+     * The Security Group id
+     */
+    @JsonIgnore
+    abstract String getSecurityGroupId();
+
+}

--- a/cloudfoundry-client/src/main/java/org/cloudfoundry/client/v3/securitygroups/_GetSecurityGroupResponse.java
+++ b/cloudfoundry-client/src/main/java/org/cloudfoundry/client/v3/securitygroups/_GetSecurityGroupResponse.java
@@ -1,17 +1,15 @@
 /*
- * Copyright 2013-2021 the original author or authors.
+ * Copyright 2013-2023 the original author or authors.
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ * http://www.apache.org/licenses/LICENSE-2.0
  *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
  */
 
 package org.cloudfoundry.client.v3.securitygroups;

--- a/cloudfoundry-client/src/main/java/org/cloudfoundry/client/v3/securitygroups/_GetSecurityGroupResponse.java
+++ b/cloudfoundry-client/src/main/java/org/cloudfoundry/client/v3/securitygroups/_GetSecurityGroupResponse.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright 2013-2021 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.cloudfoundry.client.v3.securitygroups;
+
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import org.immutables.value.Value;
+
+/**
+ * The response payload for the get Security Group operation
+ */
+@JsonDeserialize
+@Value.Immutable
+abstract class _GetSecurityGroupResponse extends SecurityGroup {
+
+}

--- a/cloudfoundry-client/src/main/java/org/cloudfoundry/client/v3/securitygroups/_GloballyEnabled.java
+++ b/cloudfoundry-client/src/main/java/org/cloudfoundry/client/v3/securitygroups/_GloballyEnabled.java
@@ -2,6 +2,8 @@ package org.cloudfoundry.client.v3.securitygroups;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+
+import org.cloudfoundry.Nullable;
 import org.immutables.value.Value;
 
 /**
@@ -17,6 +19,7 @@ abstract class _GloballyEnabled {
      * applications
      */
     @JsonProperty("running")
+    @Nullable
     abstract Boolean getRunning();
 
     /**
@@ -24,6 +27,7 @@ abstract class _GloballyEnabled {
      * applications
      */
     @JsonProperty("staging")
+    @Nullable
     abstract Boolean getStaging();
 
 }

--- a/cloudfoundry-client/src/main/java/org/cloudfoundry/client/v3/securitygroups/_GloballyEnabled.java
+++ b/cloudfoundry-client/src/main/java/org/cloudfoundry/client/v3/securitygroups/_GloballyEnabled.java
@@ -1,3 +1,16 @@
+/*
+ * Copyright 2013-2023 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
 package org.cloudfoundry.client.v3.securitygroups;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
@@ -7,24 +20,21 @@ import org.cloudfoundry.Nullable;
 import org.immutables.value.Value;
 
 /**
- * Controls if the group is applied globally to the lifecycle of all
- * applications
+ * Controls if the group is applied globally to the lifecycle of all applications
  */
 @JsonDeserialize
 @Value.Immutable
 abstract class _GloballyEnabled {
 
     /**
-     * Specifies whether the group should be applied globally to all running
-     * applications
+     * Specifies whether the group should be applied globally to all running applications
      */
     @JsonProperty("running")
     @Nullable
     abstract Boolean getRunning();
 
     /**
-     * Specifies whether the group should be applied globally to all staging
-     * applications
+     * Specifies whether the group should be applied globally to all staging applications
      */
     @JsonProperty("staging")
     @Nullable

--- a/cloudfoundry-client/src/main/java/org/cloudfoundry/client/v3/securitygroups/_GloballyEnabled.java
+++ b/cloudfoundry-client/src/main/java/org/cloudfoundry/client/v3/securitygroups/_GloballyEnabled.java
@@ -1,0 +1,29 @@
+package org.cloudfoundry.client.v3.securitygroups;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import org.immutables.value.Value;
+
+/**
+ * Controls if the group is applied globally to the lifecycle of all
+ * applications
+ */
+@JsonDeserialize
+@Value.Immutable
+abstract class _GloballyEnabled {
+
+    /**
+     * Specifies whether the group should be applied globally to all running
+     * applications
+     */
+    @JsonProperty("running")
+    abstract Boolean getRunning();
+
+    /**
+     * Specifies whether the group should be applied globally to all staging
+     * applications
+     */
+    @JsonProperty("staging")
+    abstract Boolean getStaging();
+
+}

--- a/cloudfoundry-client/src/main/java/org/cloudfoundry/client/v3/securitygroups/_ListRunningSecurityGroupsRequest.java
+++ b/cloudfoundry-client/src/main/java/org/cloudfoundry/client/v3/securitygroups/_ListRunningSecurityGroupsRequest.java
@@ -1,23 +1,21 @@
 /*
  * Copyright 2013-2021 the original author or authors.
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ * http://www.apache.org/licenses/LICENSE-2.0
  *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
  */
 
 package org.cloudfoundry.client.v3.securitygroups;
 
 import org.immutables.value.Value;
-import com.fasterxml.jackson.databind.annotation.JsonSerialize;;
+
 
 /**
  * The request payload for the List running Security Group operation

--- a/cloudfoundry-client/src/main/java/org/cloudfoundry/client/v3/securitygroups/_ListRunningSecurityGroupsRequest.java
+++ b/cloudfoundry-client/src/main/java/org/cloudfoundry/client/v3/securitygroups/_ListRunningSecurityGroupsRequest.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright 2013-2021 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.cloudfoundry.client.v3.securitygroups;
+
+import org.immutables.value.Value;
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;;
+
+/**
+ * The request payload for the List running Security Group operation
+ */
+
+@Value.Immutable
+abstract class _ListRunningSecurityGroupsRequest extends AbstractListSecurityGroupRequest {
+
+}

--- a/cloudfoundry-client/src/main/java/org/cloudfoundry/client/v3/securitygroups/_ListRunningSecurityGroupsResponse.java
+++ b/cloudfoundry-client/src/main/java/org/cloudfoundry/client/v3/securitygroups/_ListRunningSecurityGroupsResponse.java
@@ -1,17 +1,15 @@
 /*
- * Copyright 2013-2021 the original author or authors.
+ * Copyright 2013-2023 the original author or authors.
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ * http://www.apache.org/licenses/LICENSE-2.0
  *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
  */
 
 package org.cloudfoundry.client.v3.securitygroups;

--- a/cloudfoundry-client/src/main/java/org/cloudfoundry/client/v3/securitygroups/_ListRunningSecurityGroupsResponse.java
+++ b/cloudfoundry-client/src/main/java/org/cloudfoundry/client/v3/securitygroups/_ListRunningSecurityGroupsResponse.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2013-2021 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.cloudfoundry.client.v3.securitygroups;
+
+import org.immutables.value.Value;
+
+import org.cloudfoundry.client.v3.PaginatedResponse;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+
+/**
+ * The response payload for the List Security Groups operation
+ */
+@JsonDeserialize
+@Value.Immutable
+abstract class _ListRunningSecurityGroupsResponse extends PaginatedResponse<SecurityGroupResource> {
+
+}

--- a/cloudfoundry-client/src/main/java/org/cloudfoundry/client/v3/securitygroups/_ListSecurityGroupsRequest.java
+++ b/cloudfoundry-client/src/main/java/org/cloudfoundry/client/v3/securitygroups/_ListSecurityGroupsRequest.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright 2013-2021 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.cloudfoundry.client.v3.securitygroups;
+
+import org.cloudfoundry.client.v2.PaginatedRequest;
+import org.immutables.value.Value;
+import org.cloudfoundry.client.v3.FilterParameter;
+import org.cloudfoundry.Nullable;
+import java.util.List;
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;;
+
+/**
+ * The request payload for the List Security Group operation
+ */
+@JsonSerialize
+@Value.Immutable
+abstract class _ListSecurityGroupsRequest extends PaginatedRequest {
+
+    /**
+     * The security group ids filter
+     */
+    @FilterParameter("guids")
+    abstract List<String> getSecurityGroupIds();
+
+    /**
+     * The security group names filter
+     */
+    @FilterParameter("names")
+    abstract List<String> getNames();
+
+    /**
+     * the security group globally enabled running filter
+     */
+    @FilterParameter("globally_enabled_running")
+    @Nullable
+    abstract Boolean getGloballyEnabledRunning();
+
+    /**
+     * the security group globally enabled staging filter
+     */
+    @FilterParameter("globally_enabled_staging")
+    @Nullable
+    abstract Boolean getGloballyEnabledStagingBoolean();
+
+    /**
+     * the security group running_space_guids filter
+     */
+    @FilterParameter("running_space_guids")
+    abstract List<String> getRunningSpaceIds();
+
+    /**
+     * the security group staging_space_guids filter
+     */
+    @FilterParameter("staging_space_guids")
+    abstract List<String> getStagingSpaceIds();
+}

--- a/cloudfoundry-client/src/main/java/org/cloudfoundry/client/v3/securitygroups/_ListSecurityGroupsRequest.java
+++ b/cloudfoundry-client/src/main/java/org/cloudfoundry/client/v3/securitygroups/_ListSecurityGroupsRequest.java
@@ -1,17 +1,15 @@
 /*
- * Copyright 2013-2021 the original author or authors.
+ * Copyright 2023 the original author or authors.
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ * http://www.apache.org/licenses/LICENSE-2.0
  *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
  */
 
 package org.cloudfoundry.client.v3.securitygroups;
@@ -21,7 +19,7 @@ import org.immutables.value.Value;
 import org.cloudfoundry.client.v3.FilterParameter;
 import org.cloudfoundry.Nullable;
 import java.util.List;
-import com.fasterxml.jackson.databind.annotation.JsonSerialize;;
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 
 /**
  * The request payload for the List Security Group operation

--- a/cloudfoundry-client/src/main/java/org/cloudfoundry/client/v3/securitygroups/_ListSecurityGroupsRequest.java
+++ b/cloudfoundry-client/src/main/java/org/cloudfoundry/client/v3/securitygroups/_ListSecurityGroupsRequest.java
@@ -60,11 +60,13 @@ abstract class _ListSecurityGroupsRequest extends PaginatedRequest {
      * the security group running_space_guids filter
      */
     @FilterParameter("running_space_guids")
+    @Nullable
     abstract List<String> getRunningSpaceIds();
 
     /**
      * the security group staging_space_guids filter
      */
     @FilterParameter("staging_space_guids")
+    @Nullable
     abstract List<String> getStagingSpaceIds();
 }

--- a/cloudfoundry-client/src/main/java/org/cloudfoundry/client/v3/securitygroups/_ListSecurityGroupsResponse.java
+++ b/cloudfoundry-client/src/main/java/org/cloudfoundry/client/v3/securitygroups/_ListSecurityGroupsResponse.java
@@ -26,6 +26,6 @@ import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
  */
 @JsonDeserialize
 @Value.Immutable
-abstract class _ListSecurityGroupsResponse extends PaginatedResponse<SecurityGroup> {
+abstract class _ListSecurityGroupsResponse extends PaginatedResponse<SecurityGroupResource> {
 
 }

--- a/cloudfoundry-client/src/main/java/org/cloudfoundry/client/v3/securitygroups/_ListSecurityGroupsResponse.java
+++ b/cloudfoundry-client/src/main/java/org/cloudfoundry/client/v3/securitygroups/_ListSecurityGroupsResponse.java
@@ -16,21 +16,16 @@
 
 package org.cloudfoundry.client.v3.securitygroups;
 
-import com.fasterxml.jackson.databind.annotation.JsonSerialize;
-import com.fasterxml.jackson.annotation.JsonIgnore;
 import org.immutables.value.Value;
 
-/**
- * The request payload for the Get Security Group operation
- */
-@JsonSerialize
-@Value.Immutable
-abstract class _GetSecurityGroupRequest {
+import org.cloudfoundry.client.v3.PaginatedResponse;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 
-    /**
-     * The Security Group id
-     */
-    @JsonIgnore
-    abstract String getSecurityGroupId();
+/**
+ * The response payload for the List Security Groups operation
+ */
+@JsonDeserialize
+@Value.Immutable
+abstract class _ListSecurityGroupsResponse extends PaginatedResponse<SecurityGroup> {
 
 }

--- a/cloudfoundry-client/src/main/java/org/cloudfoundry/client/v3/securitygroups/_ListStagingSecurityGroupsRequest.java
+++ b/cloudfoundry-client/src/main/java/org/cloudfoundry/client/v3/securitygroups/_ListStagingSecurityGroupsRequest.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2013-2021 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.cloudfoundry.client.v3.securitygroups;
+
+import org.immutables.value.Value;
+
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;;
+
+/**
+ * The request payload for the List staging Security Group operation
+ */
+@JsonDeserialize
+@Value.Immutable
+abstract class _ListStagingSecurityGroupsRequest extends AbstractListSecurityGroupRequest {
+
+}

--- a/cloudfoundry-client/src/main/java/org/cloudfoundry/client/v3/securitygroups/_ListStagingSecurityGroupsRequest.java
+++ b/cloudfoundry-client/src/main/java/org/cloudfoundry/client/v3/securitygroups/_ListStagingSecurityGroupsRequest.java
@@ -1,25 +1,22 @@
 /*
- * Copyright 2013-2021 the original author or authors.
+ * Copyright 2013-2023 the original author or authors.
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ * http://www.apache.org/licenses/LICENSE-2.0
  *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
  */
 
 package org.cloudfoundry.client.v3.securitygroups;
 
 import org.immutables.value.Value;
-
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
-import com.fasterxml.jackson.databind.annotation.JsonSerialize;;
+
 
 /**
  * The request payload for the List staging Security Group operation

--- a/cloudfoundry-client/src/main/java/org/cloudfoundry/client/v3/securitygroups/_ListStagingSecurityGroupsResponse.java
+++ b/cloudfoundry-client/src/main/java/org/cloudfoundry/client/v3/securitygroups/_ListStagingSecurityGroupsResponse.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2013-2021 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.cloudfoundry.client.v3.securitygroups;
+
+import org.immutables.value.Value;
+
+import org.cloudfoundry.client.v3.PaginatedResponse;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+
+/**
+ * The response payload for the List Security Groups operation
+ */
+@JsonDeserialize
+@Value.Immutable
+abstract class _ListStagingSecurityGroupsResponse extends PaginatedResponse<SecurityGroupResource> {
+
+}

--- a/cloudfoundry-client/src/main/java/org/cloudfoundry/client/v3/securitygroups/_ListStagingSecurityGroupsResponse.java
+++ b/cloudfoundry-client/src/main/java/org/cloudfoundry/client/v3/securitygroups/_ListStagingSecurityGroupsResponse.java
@@ -1,17 +1,15 @@
 /*
- * Copyright 2013-2021 the original author or authors.
+ * Copyright 2013-2023 the original author or authors.
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ * http://www.apache.org/licenses/LICENSE-2.0
  *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
  */
 
 package org.cloudfoundry.client.v3.securitygroups;

--- a/cloudfoundry-client/src/main/java/org/cloudfoundry/client/v3/securitygroups/_Relationships.java
+++ b/cloudfoundry-client/src/main/java/org/cloudfoundry/client/v3/securitygroups/_Relationships.java
@@ -1,3 +1,17 @@
+/*
+ * Copyright 2013-2023 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
 package org.cloudfoundry.client.v3.securitygroups;
 
 import com.fasterxml.jackson.annotation.JsonProperty;

--- a/cloudfoundry-client/src/main/java/org/cloudfoundry/client/v3/securitygroups/_Relationships.java
+++ b/cloudfoundry-client/src/main/java/org/cloudfoundry/client/v3/securitygroups/_Relationships.java
@@ -1,0 +1,30 @@
+package org.cloudfoundry.client.v3.securitygroups;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import org.cloudfoundry.client.v3.ToManyRelationship;
+import org.immutables.value.Value;
+
+/**
+ * Holds relationships to running/staging spaces where security groups is
+ * applied
+ */
+@JsonDeserialize
+@Value.Immutable
+abstract class _Relationships {
+
+    /**
+     * A relationship to the spaces where the security_group is applied to
+     * applications during runtime
+     */
+    @JsonProperty("running_spaces")
+    abstract ToManyRelationship getRunningSpaces();
+
+    /**
+     * A relationship to the spaces where the security_group is applied to
+     * applications during runtime
+     */
+    @JsonProperty("staging_spaces")
+    abstract ToManyRelationship getStagingSpaces();
+
+}

--- a/cloudfoundry-client/src/main/java/org/cloudfoundry/client/v3/securitygroups/_Rule.java
+++ b/cloudfoundry-client/src/main/java/org/cloudfoundry/client/v3/securitygroups/_Rule.java
@@ -1,17 +1,15 @@
 /*
- * Copyright 2013-2021 the original author or authors.
+ * Copyright 2013-2023 the original author or authors.
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ * http://www.apache.org/licenses/LICENSE-2.0
  *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
  */
 
 package org.cloudfoundry.client.v3.securitygroups;

--- a/cloudfoundry-client/src/main/java/org/cloudfoundry/client/v3/securitygroups/_Rule.java
+++ b/cloudfoundry-client/src/main/java/org/cloudfoundry/client/v3/securitygroups/_Rule.java
@@ -1,0 +1,80 @@
+/*
+ * Copyright 2013-2021 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.cloudfoundry.client.v3.securitygroups;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import org.cloudfoundry.Nullable;
+import org.immutables.value.Value;
+
+/**
+ * A security group rule
+ */
+@JsonDeserialize
+@Value.Immutable
+abstract class _Rule {
+
+    /**
+     * The code control signal for icmp
+     */
+    @JsonProperty("code")
+    @Nullable
+    abstract Integer getCode();
+
+    /**
+     * The description of the rule
+     */
+    @JsonProperty("description")
+    @Nullable
+    abstract String getDescription();
+
+    /**
+     * The destination
+     */
+    @JsonProperty("destination")
+    @Nullable
+    abstract String getDestination();
+
+    /**
+     * Enables logging for the egress rule
+     */
+    @JsonProperty("log")
+    @Nullable
+    abstract Boolean getLog();
+
+    /**
+     * The ports
+     */
+    @JsonProperty("ports")
+    @Nullable
+    abstract String getPorts();
+
+    /**
+     * The protocol
+     */
+    @JsonProperty("protocol")
+    @Nullable
+    abstract Protocol getProtocol();
+
+    /**
+     * The type control signal for icmp
+     */
+    @JsonProperty("type")
+    @Nullable
+    abstract Integer getType();
+
+}

--- a/cloudfoundry-client/src/main/java/org/cloudfoundry/client/v3/securitygroups/_SecurityGroupResource.java
+++ b/cloudfoundry-client/src/main/java/org/cloudfoundry/client/v3/securitygroups/_SecurityGroupResource.java
@@ -16,21 +16,18 @@
 
 package org.cloudfoundry.client.v3.securitygroups;
 
-import com.fasterxml.jackson.databind.annotation.JsonSerialize;
-import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import org.cloudfoundry.Nullable;
 import org.immutables.value.Value;
+import org.cloudfoundry.client.v3.Resource;
+import java.util.List;
 
 /**
- * The request payload for the Get Security Group operation
+ * The Resource response payload for the List SecurityGroups operation
  */
-@JsonSerialize
+@JsonDeserialize
 @Value.Immutable
-abstract class _GetSecurityGroupRequest {
-
-    /**
-     * The Security Group id
-     */
-    @JsonIgnore
-    abstract String getSecurityGroupId();
+abstract class _SecurityGroupResource extends SecurityGroup {
 
 }

--- a/cloudfoundry-client/src/main/java/org/cloudfoundry/client/v3/securitygroups/_SecurityGroupResource.java
+++ b/cloudfoundry-client/src/main/java/org/cloudfoundry/client/v3/securitygroups/_SecurityGroupResource.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2021 the original author or authors.
+ * Copyright 2013-2023 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,12 +16,9 @@
 
 package org.cloudfoundry.client.v3.securitygroups;
 
-import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
-import org.cloudfoundry.Nullable;
 import org.immutables.value.Value;
-import org.cloudfoundry.client.v3.Resource;
-import java.util.List;
+ 
 
 /**
  * The Resource response payload for the List SecurityGroups operation

--- a/cloudfoundry-client/src/main/java/org/cloudfoundry/client/v3/securitygroups/_UnbindRunningSecurityGroupRequest.java
+++ b/cloudfoundry-client/src/main/java/org/cloudfoundry/client/v3/securitygroups/_UnbindRunningSecurityGroupRequest.java
@@ -1,17 +1,15 @@
 /*
- * Copyright 2013-2021 the original author or authors.
+ * Copyright 2013-2023 the original author or authors.
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ * http://www.apache.org/licenses/LICENSE-2.0
  *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
  */
 
 package org.cloudfoundry.client.v3.securitygroups;

--- a/cloudfoundry-client/src/main/java/org/cloudfoundry/client/v3/securitygroups/_UnbindRunningSecurityGroupRequest.java
+++ b/cloudfoundry-client/src/main/java/org/cloudfoundry/client/v3/securitygroups/_UnbindRunningSecurityGroupRequest.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright 2013-2021 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.cloudfoundry.client.v3.securitygroups;
+
+import org.immutables.value.Value;
+
+/**
+ * The request payload for the Unbind Running Security Group operation
+ */
+@Value.Immutable
+abstract class _UnbindRunningSecurityGroupRequest extends AbstractUnbindSecurityGroupRequest {
+
+}

--- a/cloudfoundry-client/src/main/java/org/cloudfoundry/client/v3/securitygroups/_UnbindStagingSecurityGroupRequest.java
+++ b/cloudfoundry-client/src/main/java/org/cloudfoundry/client/v3/securitygroups/_UnbindStagingSecurityGroupRequest.java
@@ -1,17 +1,15 @@
 /*
- * Copyright 2013-2021 the original author or authors.
+ * Copyright 2013-2023 the original author or authors.
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ * http://www.apache.org/licenses/LICENSE-2.0
  *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
  */
 
 package org.cloudfoundry.client.v3.securitygroups;

--- a/cloudfoundry-client/src/main/java/org/cloudfoundry/client/v3/securitygroups/_UnbindStagingSecurityGroupRequest.java
+++ b/cloudfoundry-client/src/main/java/org/cloudfoundry/client/v3/securitygroups/_UnbindStagingSecurityGroupRequest.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright 2013-2021 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.cloudfoundry.client.v3.securitygroups;
+
+import org.immutables.value.Value;
+
+/**
+ * The request payload for the Unbind Staging Security Group operation
+ */
+@Value.Immutable
+abstract class _UnbindStagingSecurityGroupRequest extends AbstractUnbindSecurityGroupRequest {
+
+}

--- a/cloudfoundry-client/src/main/java/org/cloudfoundry/client/v3/securitygroups/_UpdateSecurityGroupRequest.java
+++ b/cloudfoundry-client/src/main/java/org/cloudfoundry/client/v3/securitygroups/_UpdateSecurityGroupRequest.java
@@ -1,17 +1,15 @@
 /*
- * Copyright 2013-2021 the original author or authors.
+ * Copyright 2013-2023 the original author or authors.
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ * http://www.apache.org/licenses/LICENSE-2.0
  *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
  */
 package org.cloudfoundry.client.v3.securitygroups;
 
@@ -42,8 +40,7 @@ abstract class _UpdateSecurityGroupRequest {
     abstract String getName();
 
     /**
-     * Object that controls if the group is applied globally to the lifecycle of all
-     * applications
+     * Object that controls if the group is applied globally to the lifecycle of all applications
      */
     @JsonProperty("globally_enabled")
     abstract GloballyEnabled getGloballyEnabled();

--- a/cloudfoundry-client/src/main/java/org/cloudfoundry/client/v3/securitygroups/_UpdateSecurityGroupRequest.java
+++ b/cloudfoundry-client/src/main/java/org/cloudfoundry/client/v3/securitygroups/_UpdateSecurityGroupRequest.java
@@ -20,6 +20,7 @@ import org.immutables.value.Value;
 import java.util.List;
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonIgnore;
 
 /**
  * The request payload for the Create a Security Group operation
@@ -27,6 +28,13 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 @JsonSerialize
 @Value.Immutable
 abstract class _UpdateSecurityGroupRequest {
+
+    /**
+     * Id of the security group
+     */
+    @JsonIgnore
+    abstract String getSecurityGroupId();
+
     /**
      * Name of the security group
      */

--- a/cloudfoundry-client/src/main/java/org/cloudfoundry/client/v3/securitygroups/_UpdateSecurityGroupRequest.java
+++ b/cloudfoundry-client/src/main/java/org/cloudfoundry/client/v3/securitygroups/_UpdateSecurityGroupRequest.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2013-2021 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.cloudfoundry.client.v3.securitygroups;
+
+import org.immutables.value.Value;
+
+import java.util.List;
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+/**
+ * The request payload for the Create a Security Group operation
+ */
+@JsonSerialize
+@Value.Immutable
+abstract class _UpdateSecurityGroupRequest {
+    /**
+     * Name of the security group
+     */
+    @JsonProperty("name")
+    abstract String getName();
+
+    /**
+     * Object that controls if the group is applied globally to the lifecycle of all
+     * applications
+     */
+    @JsonProperty("globally_enabled")
+    abstract GloballyEnabled getGloballyEnabled();
+
+    /**
+     * Rules that will be applied by this security group
+     */
+    @JsonProperty("rules")
+    abstract List<Rule> getRules();
+}

--- a/cloudfoundry-client/src/main/java/org/cloudfoundry/client/v3/securitygroups/_UpdateSecurityGroupResponse.java
+++ b/cloudfoundry-client/src/main/java/org/cloudfoundry/client/v3/securitygroups/_UpdateSecurityGroupResponse.java
@@ -1,19 +1,16 @@
 /*
- * Copyright 2013-2021 the original author or authors.
+ * Copyright 2013-2023 the original author or authors.
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ * http://www.apache.org/licenses/LICENSE-2.0
  *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
  */
-
 package org.cloudfoundry.client.v3.securitygroups;
 
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;

--- a/cloudfoundry-client/src/main/java/org/cloudfoundry/client/v3/securitygroups/_UpdateSecurityGroupResponse.java
+++ b/cloudfoundry-client/src/main/java/org/cloudfoundry/client/v3/securitygroups/_UpdateSecurityGroupResponse.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright 2013-2021 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.cloudfoundry.client.v3.securitygroups;
+
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import org.immutables.value.Value;
+
+/**
+ * The response payload for the Update a Security Group operation
+ */
+@JsonDeserialize
+@Value.Immutable
+abstract class _UpdateSecurityGroupResponse extends SecurityGroup {
+
+}

--- a/cloudfoundry-client/src/test/java/org/cloudfoundry/client/v3/securitygroups/BindRunningSecurityGroupRequestTest.java
+++ b/cloudfoundry-client/src/test/java/org/cloudfoundry/client/v3/securitygroups/BindRunningSecurityGroupRequestTest.java
@@ -1,6 +1,18 @@
+/*
+ * Copyright 2013-2023 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
 package org.cloudfoundry.client.v3.securitygroups;
 
-import org.cloudfoundry.client.v3.ToManyRelationship;
 import org.cloudfoundry.client.v3.Relationship;
 import org.junit.Test;
 
@@ -8,17 +20,14 @@ public class BindRunningSecurityGroupRequestTest {
 
         @Test(expected = IllegalStateException.class)
         public void noSecurityGroupId() {
-                BindRunningSecurityGroupRequest.builder()
-                                .build();
+                BindRunningSecurityGroupRequest.builder().build();
         }
 
         @Test
         public void valid() {
                 BindRunningSecurityGroupRequest.builder()
                                 .securityGroupId("b85a788e-671f-4549-814d-e34cdb2f539a")
-                                .boundSpaces(Relationship.builder()
-                                                .id("space-guid-1")
-                                                .build())
+                                .boundSpaces(Relationship.builder().id("space-guid-1").build())
                                 .build();
         }
 }

--- a/cloudfoundry-client/src/test/java/org/cloudfoundry/client/v3/securitygroups/BindRunningSecurityGroupRequestTest.java
+++ b/cloudfoundry-client/src/test/java/org/cloudfoundry/client/v3/securitygroups/BindRunningSecurityGroupRequestTest.java
@@ -1,0 +1,26 @@
+package org.cloudfoundry.client.v3.securitygroups;
+
+import org.cloudfoundry.client.v3.ToManyRelationship;
+import org.cloudfoundry.client.v3.Relationship;
+import org.junit.Test;
+
+public class BindRunningSecurityGroupRequestTest {
+
+        @Test(expected = IllegalStateException.class)
+        public void noSecurityGroupId() {
+                BindRunningSecurityGroupRequest.builder()
+                                .build();
+        }
+
+        @Test
+        public void valid() {
+                BindRunningSecurityGroupRequest.builder()
+                                .securityGroupId("b85a788e-671f-4549-814d-e34cdb2f539a")
+                                .boundSpaces(ToManyRelationship.builder()
+                                                .data(Relationship.builder()
+                                                                .id("space-guid-1")
+                                                                .build())
+                                                .build())
+                                .build();
+        }
+}

--- a/cloudfoundry-client/src/test/java/org/cloudfoundry/client/v3/securitygroups/BindRunningSecurityGroupRequestTest.java
+++ b/cloudfoundry-client/src/test/java/org/cloudfoundry/client/v3/securitygroups/BindRunningSecurityGroupRequestTest.java
@@ -16,10 +16,8 @@ public class BindRunningSecurityGroupRequestTest {
         public void valid() {
                 BindRunningSecurityGroupRequest.builder()
                                 .securityGroupId("b85a788e-671f-4549-814d-e34cdb2f539a")
-                                .boundSpaces(ToManyRelationship.builder()
-                                                .data(Relationship.builder()
-                                                                .id("space-guid-1")
-                                                                .build())
+                                .boundSpaces(Relationship.builder()
+                                                .id("space-guid-1")
                                                 .build())
                                 .build();
         }

--- a/cloudfoundry-client/src/test/java/org/cloudfoundry/client/v3/securitygroups/BindStagingSecurityGroupRequestTest.java
+++ b/cloudfoundry-client/src/test/java/org/cloudfoundry/client/v3/securitygroups/BindStagingSecurityGroupRequestTest.java
@@ -1,0 +1,26 @@
+package org.cloudfoundry.client.v3.securitygroups;
+
+import org.cloudfoundry.client.v3.ToManyRelationship;
+import org.cloudfoundry.client.v3.Relationship;
+import org.junit.Test;
+
+public class BindStagingSecurityGroupRequestTest {
+
+    @Test(expected = IllegalStateException.class)
+    public void noSecurityGroupId() {
+        BindStagingSecurityGroupRequest.builder()
+                .build();
+    }
+
+    @Test
+    public void valid() {
+        BindStagingSecurityGroupRequest.builder()
+                .securityGroupId("b85a788e-671f-4549-814d-e34cdb2f539a")
+                .boundSpaces(ToManyRelationship.builder()
+                        .data(Relationship.builder()
+                                .id("space-guid-1")
+                                .build())
+                        .build())
+                .build();
+    }
+}

--- a/cloudfoundry-client/src/test/java/org/cloudfoundry/client/v3/securitygroups/BindStagingSecurityGroupRequestTest.java
+++ b/cloudfoundry-client/src/test/java/org/cloudfoundry/client/v3/securitygroups/BindStagingSecurityGroupRequestTest.java
@@ -1,6 +1,18 @@
+/*
+ * Copyright 2013-2023 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
 package org.cloudfoundry.client.v3.securitygroups;
 
-import org.cloudfoundry.client.v3.ToManyRelationship;
 import org.cloudfoundry.client.v3.Relationship;
 import org.junit.Test;
 
@@ -8,17 +20,14 @@ public class BindStagingSecurityGroupRequestTest {
 
         @Test(expected = IllegalStateException.class)
         public void noSecurityGroupId() {
-                BindStagingSecurityGroupRequest.builder()
-                                .build();
+                BindStagingSecurityGroupRequest.builder().build();
         }
 
         @Test
         public void valid() {
                 BindStagingSecurityGroupRequest.builder()
                                 .securityGroupId("b85a788e-671f-4549-814d-e34cdb2f539a")
-                                .boundSpaces(Relationship.builder()
-                                                .id("space-guid-1")
-                                                .build())
+                                .boundSpaces(Relationship.builder().id("space-guid-1").build())
 
                                 .build();
         }

--- a/cloudfoundry-client/src/test/java/org/cloudfoundry/client/v3/securitygroups/BindStagingSecurityGroupRequestTest.java
+++ b/cloudfoundry-client/src/test/java/org/cloudfoundry/client/v3/securitygroups/BindStagingSecurityGroupRequestTest.java
@@ -6,21 +6,20 @@ import org.junit.Test;
 
 public class BindStagingSecurityGroupRequestTest {
 
-    @Test(expected = IllegalStateException.class)
-    public void noSecurityGroupId() {
-        BindStagingSecurityGroupRequest.builder()
-                .build();
-    }
+        @Test(expected = IllegalStateException.class)
+        public void noSecurityGroupId() {
+                BindStagingSecurityGroupRequest.builder()
+                                .build();
+        }
 
-    @Test
-    public void valid() {
-        BindStagingSecurityGroupRequest.builder()
-                .securityGroupId("b85a788e-671f-4549-814d-e34cdb2f539a")
-                .boundSpaces(ToManyRelationship.builder()
-                        .data(Relationship.builder()
-                                .id("space-guid-1")
-                                .build())
-                        .build())
-                .build();
-    }
+        @Test
+        public void valid() {
+                BindStagingSecurityGroupRequest.builder()
+                                .securityGroupId("b85a788e-671f-4549-814d-e34cdb2f539a")
+                                .boundSpaces(Relationship.builder()
+                                                .id("space-guid-1")
+                                                .build())
+
+                                .build();
+        }
 }

--- a/cloudfoundry-client/src/test/java/org/cloudfoundry/client/v3/securitygroups/CreateSecurityGroupRequestTest.java
+++ b/cloudfoundry-client/src/test/java/org/cloudfoundry/client/v3/securitygroups/CreateSecurityGroupRequestTest.java
@@ -1,17 +1,15 @@
 /*
- * Copyright 2013-2021 the original author or authors.
+ * Copyright 2013-2023 the original author or authors.
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ * http://www.apache.org/licenses/LICENSE-2.0
  *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
  */
 
 package org.cloudfoundry.client.v3.securitygroups;
@@ -22,9 +20,7 @@ public class CreateSecurityGroupRequestTest {
 
     @Test(expected = IllegalStateException.class)
     public void noName() {
-        CreateSecurityGroupRequest.builder()
-                .rule(Rule.builder().build())
-                .build();
+        CreateSecurityGroupRequest.builder().rule(Rule.builder().build()).build();
     }
 
 }

--- a/cloudfoundry-client/src/test/java/org/cloudfoundry/client/v3/securitygroups/CreateSecurityGroupRequestTest.java
+++ b/cloudfoundry-client/src/test/java/org/cloudfoundry/client/v3/securitygroups/CreateSecurityGroupRequestTest.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2013-2021 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.cloudfoundry.client.v3.securitygroups;
+
+import org.junit.Test;
+
+public class CreateSecurityGroupRequestTest {
+
+    @Test(expected = IllegalStateException.class)
+    public void noName() {
+        CreateSecurityGroupRequest.builder()
+                .rule(Rule.builder().build())
+                .build();
+    }
+
+}

--- a/cloudfoundry-client/src/test/java/org/cloudfoundry/client/v3/securitygroups/DeleteSecurityGroupRequestTest.java
+++ b/cloudfoundry-client/src/test/java/org/cloudfoundry/client/v3/securitygroups/DeleteSecurityGroupRequestTest.java
@@ -1,3 +1,16 @@
+/*
+ * Copyright 2013-2023 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
 package org.cloudfoundry.client.v3.securitygroups;
 
 import org.junit.Test;
@@ -6,14 +19,12 @@ public class DeleteSecurityGroupRequestTest {
 
     @Test(expected = IllegalStateException.class)
     public void noSecurityGroupId() {
-        DeleteSecurityGroupRequest.builder()
-                .build();
+        DeleteSecurityGroupRequest.builder().build();
     }
 
     @Test
     public void valid() {
-        DeleteSecurityGroupRequest.builder()
-                .securityGroupId("b85a788e-671f-4549-814d-e34cdb2f539a")
+        DeleteSecurityGroupRequest.builder().securityGroupId("b85a788e-671f-4549-814d-e34cdb2f539a")
                 .build();
     }
 }

--- a/cloudfoundry-client/src/test/java/org/cloudfoundry/client/v3/securitygroups/DeleteSecurityGroupRequestTest.java
+++ b/cloudfoundry-client/src/test/java/org/cloudfoundry/client/v3/securitygroups/DeleteSecurityGroupRequestTest.java
@@ -1,0 +1,19 @@
+package org.cloudfoundry.client.v3.securitygroups;
+
+import org.junit.Test;
+
+public class DeleteSecurityGroupRequestTest {
+
+    @Test(expected = IllegalStateException.class)
+    public void noSecurityGroupId() {
+        DeleteSecurityGroupRequest.builder()
+                .build();
+    }
+
+    @Test
+    public void valid() {
+        DeleteSecurityGroupRequest.builder()
+                .securityGroupId("b85a788e-671f-4549-814d-e34cdb2f539a")
+                .build();
+    }
+}

--- a/cloudfoundry-client/src/test/java/org/cloudfoundry/client/v3/securitygroups/GetSecurityGroupRequestTest.java
+++ b/cloudfoundry-client/src/test/java/org/cloudfoundry/client/v3/securitygroups/GetSecurityGroupRequestTest.java
@@ -1,0 +1,19 @@
+package org.cloudfoundry.client.v3.securitygroups;
+
+import org.junit.Test;
+
+public class GetSecurityGroupRequestTest {
+
+    @Test(expected = IllegalStateException.class)
+    public void noSecurityGroupId() {
+        GetSecurityGroupRequest.builder()
+                .build();
+    }
+
+    @Test
+    public void valid() {
+        GetSecurityGroupRequest.builder()
+                .securityGroupId("b85a788e-671f-4549-814d-e34cdb2f539a")
+                .build();
+    }
+}

--- a/cloudfoundry-client/src/test/java/org/cloudfoundry/client/v3/securitygroups/GetSecurityGroupRequestTest.java
+++ b/cloudfoundry-client/src/test/java/org/cloudfoundry/client/v3/securitygroups/GetSecurityGroupRequestTest.java
@@ -1,3 +1,17 @@
+/*
+ * Copyright 2013-2023 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
 package org.cloudfoundry.client.v3.securitygroups;
 
 import org.junit.Test;
@@ -6,14 +20,12 @@ public class GetSecurityGroupRequestTest {
 
     @Test(expected = IllegalStateException.class)
     public void noSecurityGroupId() {
-        GetSecurityGroupRequest.builder()
-                .build();
+        GetSecurityGroupRequest.builder().build();
     }
 
     @Test
     public void valid() {
-        GetSecurityGroupRequest.builder()
-                .securityGroupId("b85a788e-671f-4549-814d-e34cdb2f539a")
+        GetSecurityGroupRequest.builder().securityGroupId("b85a788e-671f-4549-814d-e34cdb2f539a")
                 .build();
     }
 }

--- a/cloudfoundry-client/src/test/java/org/cloudfoundry/client/v3/securitygroups/ListRunningSecurityGroupsRequestTest.java
+++ b/cloudfoundry-client/src/test/java/org/cloudfoundry/client/v3/securitygroups/ListRunningSecurityGroupsRequestTest.java
@@ -1,0 +1,20 @@
+package org.cloudfoundry.client.v3.securitygroups;
+
+import org.junit.Test;
+
+public class ListRunningSecurityGroupsRequestTest {
+
+    @Test(expected = IllegalStateException.class)
+    public void noSpaceID() {
+        ListRunningSecurityGroupsRequest.builder()
+                .build();
+    }
+
+    @Test
+    public void valid() {
+        ListRunningSecurityGroupsRequest.builder()
+                .spaceId("space-giud1")
+                .build();
+    }
+
+}

--- a/cloudfoundry-client/src/test/java/org/cloudfoundry/client/v3/securitygroups/ListRunningSecurityGroupsRequestTest.java
+++ b/cloudfoundry-client/src/test/java/org/cloudfoundry/client/v3/securitygroups/ListRunningSecurityGroupsRequestTest.java
@@ -1,3 +1,16 @@
+/*
+ * Copyright 2013-2023 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
 package org.cloudfoundry.client.v3.securitygroups;
 
 import org.junit.Test;
@@ -6,15 +19,12 @@ public class ListRunningSecurityGroupsRequestTest {
 
     @Test(expected = IllegalStateException.class)
     public void noSpaceID() {
-        ListRunningSecurityGroupsRequest.builder()
-                .build();
+        ListRunningSecurityGroupsRequest.builder().build();
     }
 
     @Test
     public void valid() {
-        ListRunningSecurityGroupsRequest.builder()
-                .spaceId("space-giud1")
-                .build();
+        ListRunningSecurityGroupsRequest.builder().spaceId("space-giud1").build();
     }
 
 }

--- a/cloudfoundry-client/src/test/java/org/cloudfoundry/client/v3/securitygroups/ListSecurityGroupsRequestTest.java
+++ b/cloudfoundry-client/src/test/java/org/cloudfoundry/client/v3/securitygroups/ListSecurityGroupsRequestTest.java
@@ -1,0 +1,13 @@
+package org.cloudfoundry.client.v3.securitygroups;
+
+import org.junit.Test;
+
+public class ListSecurityGroupsRequestTest {
+
+    @Test
+    public void valid() {
+        ListSecurityGroupsRequest.builder()
+                .build();
+    }
+
+}

--- a/cloudfoundry-client/src/test/java/org/cloudfoundry/client/v3/securitygroups/ListSecurityGroupsRequestTest.java
+++ b/cloudfoundry-client/src/test/java/org/cloudfoundry/client/v3/securitygroups/ListSecurityGroupsRequestTest.java
@@ -1,3 +1,16 @@
+/*
+ * Copyright 2013-2023 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
 package org.cloudfoundry.client.v3.securitygroups;
 
 import org.junit.Test;
@@ -6,8 +19,7 @@ public class ListSecurityGroupsRequestTest {
 
     @Test
     public void valid() {
-        ListSecurityGroupsRequest.builder()
-                .build();
+        ListSecurityGroupsRequest.builder().build();
     }
 
 }

--- a/cloudfoundry-client/src/test/java/org/cloudfoundry/client/v3/securitygroups/ListStagingSecurityGroupsRequestTest.java
+++ b/cloudfoundry-client/src/test/java/org/cloudfoundry/client/v3/securitygroups/ListStagingSecurityGroupsRequestTest.java
@@ -1,3 +1,16 @@
+/*
+ * Copyright 2013-2023 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
 package org.cloudfoundry.client.v3.securitygroups;
 
 import org.junit.Test;
@@ -6,15 +19,12 @@ public class ListStagingSecurityGroupsRequestTest {
 
     @Test(expected = IllegalStateException.class)
     public void noSpaceID() {
-        ListStagingSecurityGroupsRequest.builder()
-                .build();
+        ListStagingSecurityGroupsRequest.builder().build();
     }
 
     @Test
     public void valid() {
-        ListStagingSecurityGroupsRequest.builder()
-                .spaceId("space-giud1")
-                .build();
+        ListStagingSecurityGroupsRequest.builder().spaceId("space-giud1").build();
     }
 
 }

--- a/cloudfoundry-client/src/test/java/org/cloudfoundry/client/v3/securitygroups/ListStagingSecurityGroupsRequestTest.java
+++ b/cloudfoundry-client/src/test/java/org/cloudfoundry/client/v3/securitygroups/ListStagingSecurityGroupsRequestTest.java
@@ -1,0 +1,20 @@
+package org.cloudfoundry.client.v3.securitygroups;
+
+import org.junit.Test;
+
+public class ListStagingSecurityGroupsRequestTest {
+
+    @Test(expected = IllegalStateException.class)
+    public void noSpaceID() {
+        ListStagingSecurityGroupsRequest.builder()
+                .build();
+    }
+
+    @Test
+    public void valid() {
+        ListStagingSecurityGroupsRequest.builder()
+                .spaceId("space-giud1")
+                .build();
+    }
+
+}

--- a/cloudfoundry-client/src/test/java/org/cloudfoundry/client/v3/securitygroups/UnbindRunningSecurityGroupRequestTest.java
+++ b/cloudfoundry-client/src/test/java/org/cloudfoundry/client/v3/securitygroups/UnbindRunningSecurityGroupRequestTest.java
@@ -1,0 +1,28 @@
+package org.cloudfoundry.client.v3.securitygroups;
+
+import org.junit.Test;
+
+public class UnbindRunningSecurityGroupRequestTest {
+
+        @Test(expected = IllegalStateException.class)
+        public void noSecurityGroupId() {
+                UnbindRunningSecurityGroupRequest.builder()
+                                .build();
+        }
+
+        @Test(expected = IllegalStateException.class)
+        public void noSpaceId() {
+                UnbindRunningSecurityGroupRequest.builder()
+                                .securityGroupId("b85a788e-671f-4549-814d-e34cdb2f539a")
+                                .build();
+        }
+
+        @Test
+        public void valid() {
+                UnbindRunningSecurityGroupRequest.builder()
+                                .securityGroupId("b85a788e-671f-4549-814d-e34cdb2f539a")
+                                .spaceId("space-guid2")
+                                .build();
+        }
+
+}

--- a/cloudfoundry-client/src/test/java/org/cloudfoundry/client/v3/securitygroups/UnbindRunningSecurityGroupRequestTest.java
+++ b/cloudfoundry-client/src/test/java/org/cloudfoundry/client/v3/securitygroups/UnbindRunningSecurityGroupRequestTest.java
@@ -1,3 +1,16 @@
+/*
+ * Copyright 2013-2023 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
 package org.cloudfoundry.client.v3.securitygroups;
 
 import org.junit.Test;
@@ -6,23 +19,20 @@ public class UnbindRunningSecurityGroupRequestTest {
 
         @Test(expected = IllegalStateException.class)
         public void noSecurityGroupId() {
-                UnbindRunningSecurityGroupRequest.builder()
-                                .build();
+                UnbindRunningSecurityGroupRequest.builder().build();
         }
 
         @Test(expected = IllegalStateException.class)
         public void noSpaceId() {
                 UnbindRunningSecurityGroupRequest.builder()
-                                .securityGroupId("b85a788e-671f-4549-814d-e34cdb2f539a")
-                                .build();
+                                .securityGroupId("b85a788e-671f-4549-814d-e34cdb2f539a").build();
         }
 
         @Test
         public void valid() {
                 UnbindRunningSecurityGroupRequest.builder()
                                 .securityGroupId("b85a788e-671f-4549-814d-e34cdb2f539a")
-                                .spaceId("space-guid2")
-                                .build();
+                                .spaceId("space-guid2").build();
         }
 
 }

--- a/cloudfoundry-client/src/test/java/org/cloudfoundry/client/v3/securitygroups/UnbindStagingSecurityGroupRequestTest.java
+++ b/cloudfoundry-client/src/test/java/org/cloudfoundry/client/v3/securitygroups/UnbindStagingSecurityGroupRequestTest.java
@@ -1,3 +1,16 @@
+/*
+ * Copyright 2013-2023 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
 package org.cloudfoundry.client.v3.securitygroups;
 
 import org.junit.Test;
@@ -6,22 +19,19 @@ public class UnbindStagingSecurityGroupRequestTest {
 
         @Test(expected = IllegalStateException.class)
         public void noSecurityGroupId() {
-                UnbindStagingSecurityGroupRequest.builder()
-                                .build();
+                UnbindStagingSecurityGroupRequest.builder().build();
         }
 
         @Test(expected = IllegalStateException.class)
         public void noSpaceId() {
                 UnbindStagingSecurityGroupRequest.builder()
-                                .securityGroupId("b85a788e-671f-4549-814d-e34cdb2f539a")
-                                .build();
+                                .securityGroupId("b85a788e-671f-4549-814d-e34cdb2f539a").build();
         }
 
         @Test
         public void valid() {
                 UnbindStagingSecurityGroupRequest.builder()
                                 .securityGroupId("b85a788e-671f-4549-814d-e34cdb2f539a")
-                                .spaceId("space-guid2")
-                                .build();
+                                .spaceId("space-guid2").build();
         }
 }

--- a/cloudfoundry-client/src/test/java/org/cloudfoundry/client/v3/securitygroups/UnbindStagingSecurityGroupRequestTest.java
+++ b/cloudfoundry-client/src/test/java/org/cloudfoundry/client/v3/securitygroups/UnbindStagingSecurityGroupRequestTest.java
@@ -1,0 +1,27 @@
+package org.cloudfoundry.client.v3.securitygroups;
+
+import org.junit.Test;
+
+public class UnbindStagingSecurityGroupRequestTest {
+
+        @Test(expected = IllegalStateException.class)
+        public void noSecurityGroupId() {
+                UnbindStagingSecurityGroupRequest.builder()
+                                .build();
+        }
+
+        @Test(expected = IllegalStateException.class)
+        public void noSpaceId() {
+                UnbindStagingSecurityGroupRequest.builder()
+                                .securityGroupId("b85a788e-671f-4549-814d-e34cdb2f539a")
+                                .build();
+        }
+
+        @Test
+        public void valid() {
+                UnbindStagingSecurityGroupRequest.builder()
+                                .securityGroupId("b85a788e-671f-4549-814d-e34cdb2f539a")
+                                .spaceId("space-guid2")
+                                .build();
+        }
+}

--- a/cloudfoundry-client/src/test/java/org/cloudfoundry/client/v3/securitygroups/UpdateSecurityGroupRequestTest.java
+++ b/cloudfoundry-client/src/test/java/org/cloudfoundry/client/v3/securitygroups/UpdateSecurityGroupRequestTest.java
@@ -1,3 +1,16 @@
+/*
+ * Copyright 2013-2023 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
 package org.cloudfoundry.client.v3.securitygroups;
 
 import org.junit.Test;
@@ -6,31 +19,21 @@ public class UpdateSecurityGroupRequestTest {
 
         @Test(expected = IllegalStateException.class)
         public void noName() {
-                UpdateSecurityGroupRequest.builder()
-                                .build();
+                UpdateSecurityGroupRequest.builder().build();
         }
 
         @Test()
         public void valid() {
-                UpdateSecurityGroupRequest.builder()
-                                .name("my-group0")
+                UpdateSecurityGroupRequest.builder().name("my-group0")
                                 .securityGroupId("b85a788e-671f-4549-814d-e34cdb2f539a")
-                                .globallyEnabled(GloballyEnabled
-                                                .builder()
-                                                .running(true)
+                                .globallyEnabled(GloballyEnabled.builder().running(true).build())
+                                .rules(Rule.builder().protocol(Protocol.TCP)
+                                                .destination("10.10.10.0/24").ports("443,80,8080")
                                                 .build())
-                                .rules(Rule.builder()
-                                                .protocol(Protocol.TCP)
-                                                .destination("10.10.10.0/24")
-                                                .ports("443,80,8080")
-                                                .build())
-                                .rules(Rule.builder()
-                                                .protocol(Protocol.ICMP)
+                                .rules(Rule.builder().protocol(Protocol.ICMP)
                                                 .destination("10.10.10.0/24")
                                                 .description("Allow ping requests to private services")
-                                                .type(8)
-                                                .code(0)
-                                                .build())
+                                                .type(8).code(0).build())
                                 .build();
 
         }

--- a/cloudfoundry-client/src/test/java/org/cloudfoundry/client/v3/securitygroups/UpdateSecurityGroupRequestTest.java
+++ b/cloudfoundry-client/src/test/java/org/cloudfoundry/client/v3/securitygroups/UpdateSecurityGroupRequestTest.java
@@ -4,34 +4,35 @@ import org.junit.Test;
 
 public class UpdateSecurityGroupRequestTest {
 
-    @Test(expected = IllegalStateException.class)
-    public void noName() {
-        UpdateSecurityGroupRequest.builder()
-                .build();
-    }
+        @Test(expected = IllegalStateException.class)
+        public void noName() {
+                UpdateSecurityGroupRequest.builder()
+                                .build();
+        }
 
-    @Test()
-    public void valid() {
-        UpdateSecurityGroupRequest.builder()
-                .name("my-group0")
-                .globallyEnabled(GloballyEnabled
-                        .builder()
-                        .running(true)
-                        .build())
-                .rules(Rule.builder()
-                        .protocol(Protocol.TCP)
-                        .destination("10.10.10.0/24")
-                        .ports("443,80,8080")
-                        .build())
-                .rules(Rule.builder()
-                        .protocol(Protocol.ICMP)
-                        .destination("10.10.10.0/24")
-                        .description("Allow ping requests to private services")
-                        .type(8)
-                        .code(0)
-                        .build())
-                .build();
+        @Test()
+        public void valid() {
+                UpdateSecurityGroupRequest.builder()
+                                .name("my-group0")
+                                .securityGroupId("b85a788e-671f-4549-814d-e34cdb2f539a")
+                                .globallyEnabled(GloballyEnabled
+                                                .builder()
+                                                .running(true)
+                                                .build())
+                                .rules(Rule.builder()
+                                                .protocol(Protocol.TCP)
+                                                .destination("10.10.10.0/24")
+                                                .ports("443,80,8080")
+                                                .build())
+                                .rules(Rule.builder()
+                                                .protocol(Protocol.ICMP)
+                                                .destination("10.10.10.0/24")
+                                                .description("Allow ping requests to private services")
+                                                .type(8)
+                                                .code(0)
+                                                .build())
+                                .build();
 
-    }
+        }
 
 }

--- a/cloudfoundry-client/src/test/java/org/cloudfoundry/client/v3/securitygroups/UpdateSecurityGroupRequestTest.java
+++ b/cloudfoundry-client/src/test/java/org/cloudfoundry/client/v3/securitygroups/UpdateSecurityGroupRequestTest.java
@@ -1,0 +1,37 @@
+package org.cloudfoundry.client.v3.securitygroups;
+
+import org.junit.Test;
+
+public class UpdateSecurityGroupRequestTest {
+
+    @Test(expected = IllegalStateException.class)
+    public void noName() {
+        UpdateSecurityGroupRequest.builder()
+                .build();
+    }
+
+    @Test()
+    public void valid() {
+        UpdateSecurityGroupRequest.builder()
+                .name("my-group0")
+                .globallyEnabled(GloballyEnabled
+                        .builder()
+                        .running(true)
+                        .build())
+                .rules(Rule.builder()
+                        .protocol(Protocol.TCP)
+                        .destination("10.10.10.0/24")
+                        .ports("443,80,8080")
+                        .build())
+                .rules(Rule.builder()
+                        .protocol(Protocol.ICMP)
+                        .destination("10.10.10.0/24")
+                        .description("Allow ping requests to private services")
+                        .type(8)
+                        .code(0)
+                        .build())
+                .build();
+
+    }
+
+}

--- a/integration-test/src/test/java/org/cloudfoundry/client/v3/SecurityGroupsTest.java
+++ b/integration-test/src/test/java/org/cloudfoundry/client/v3/SecurityGroupsTest.java
@@ -47,9 +47,6 @@ public final class SecurityGroupsTest extends AbstractIntegrationTest {
         @Autowired
         private CloudFoundryClient cloudFoundryClient;
 
-        @Autowired
-        private Mono<String> organizationId;
-
         private String securityGroupName;
         private Mono<String> securityGroupId;
 

--- a/integration-test/src/test/java/org/cloudfoundry/client/v3/SecurityGroupsTest.java
+++ b/integration-test/src/test/java/org/cloudfoundry/client/v3/SecurityGroupsTest.java
@@ -31,8 +31,8 @@ import org.cloudfoundry.client.v3.securitygroups.ListSecurityGroupsRequest;
 import org.cloudfoundry.client.v3.securitygroups.ListRunningSecurityGroupsRequest;
 import org.cloudfoundry.client.v3.securitygroups.ListStagingSecurityGroupsRequest;
 import org.cloudfoundry.util.JobUtils;
-import org.junit.AfterClass;
-import org.junit.BeforeClass;
+import org.junit.After;
+import org.junit.Before;
 import org.junit.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import reactor.core.publisher.Mono;
@@ -53,8 +53,8 @@ public final class SecurityGroupsTest extends AbstractIntegrationTest {
         @Autowired
         private Mono<String> spaceId;
 
-        @BeforeClass
-        public void settup() {
+        @Before
+        void settup() {
                 this.securityGroupName = this.nameFactory.getSecurityGroupName();
 
                 this.cloudFoundryClient.securityGroupsV3()
@@ -75,8 +75,8 @@ public final class SecurityGroupsTest extends AbstractIntegrationTest {
                                 .verify(Duration.ofMinutes(5));
         }
 
-        @AfterClass
-        public void tearDown() {
+        @After
+        void tearDown() {
                 this.cloudFoundryClient.securityGroupsV3().delete(
                                 DeleteSecurityGroupRequest.builder()
                                                 .securityGroupId(this.securityGroupId.block())

--- a/integration-test/src/test/java/org/cloudfoundry/client/v3/SecurityGroupsTest.java
+++ b/integration-test/src/test/java/org/cloudfoundry/client/v3/SecurityGroupsTest.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright 2013-2021 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.cloudfoundry.client.v3;
+
+import org.cloudfoundry.CloudFoundryVersion;
+import org.cloudfoundry.IfCloudFoundryVersion;
+import org.cloudfoundry.AbstractIntegrationTest;
+import org.cloudfoundry.client.CloudFoundryClient;
+import org.cloudfoundry.client.v3.securitygroups.CreateSecurityGroupRequest;
+import org.cloudfoundry.client.v3.securitygroups.CreateSecurityGroupResponse;
+import org.cloudfoundry.client.v3.securitygroups.Rule;
+import org.cloudfoundry.util.JobUtils;
+import org.cloudfoundry.util.PaginationUtils;
+import org.cloudfoundry.util.ResourceUtils;
+import org.junit.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
+import reactor.test.StepVerifier;
+
+import java.time.Duration;
+
+import static org.cloudfoundry.client.v3.securitygroups.Protocol.TCP;
+import static org.cloudfoundry.util.tuple.TupleUtils.function;
+
+public final class SecurityGroupsTest extends AbstractIntegrationTest {
+
+        @Autowired
+        private CloudFoundryClient cloudFoundryClient;
+
+        @Test
+        public void create() {
+                String securityGroupName = this.nameFactory.getSecurityGroupName();
+
+                this.cloudFoundryClient.securityGroupsV3()
+                                .create(CreateSecurityGroupRequest.builder()
+                                                .name(securityGroupName)
+                                                .rule(Rule.builder()
+                                                                .destination("0.0.0.0/0")
+                                                                .log(false)
+                                                                .ports("2048-3000")
+                                                                .protocol(TCP)
+                                                                .build())
+                                                .build())
+                                .map(response -> response.getName())
+                                .as(StepVerifier::create)
+                                .expectNext(securityGroupName)
+                                .expectComplete()
+                                .verify(Duration.ofMinutes(5));
+        }
+
+}

--- a/integration-test/src/test/java/org/cloudfoundry/client/v3/SecurityGroupsTest.java
+++ b/integration-test/src/test/java/org/cloudfoundry/client/v3/SecurityGroupsTest.java
@@ -1,17 +1,15 @@
 /*
- * Copyright 2013-2021 the original author or authors.
+ * Copyright 2013-2023 the original author or authors.
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ * http://www.apache.org/licenses/LICENSE-2.0
  *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
  */
 
 package org.cloudfoundry.client.v3;
@@ -25,19 +23,16 @@ import org.cloudfoundry.client.v3.securitygroups.BindRunningSecurityGroupRequest
 import org.cloudfoundry.client.v3.securitygroups.CreateSecurityGroupRequest;
 import org.cloudfoundry.client.v3.securitygroups.CreateSecurityGroupResponse;
 import org.cloudfoundry.client.v3.securitygroups.Rule;
-import org.cloudfoundry.client.v3.securitygroups.SecurityGroup;
-import org.cloudfoundry.client.v3.ToManyRelationship;
-import org.cloudfoundry.client.v3.securitygroups.Relationships;
+
 import org.cloudfoundry.client.v3.securitygroups.GloballyEnabled;
-import org.cloudfoundry.client.v3.securitygroups.SecurityGroup;
+
 import org.cloudfoundry.client.v3.securitygroups.UpdateSecurityGroupRequest;
 import org.cloudfoundry.client.v3.securitygroups.DeleteSecurityGroupRequest;
 import org.cloudfoundry.client.v3.securitygroups.GetSecurityGroupRequest;
-import org.cloudfoundry.client.v3.securitygroups.GetSecurityGroupResponse;
+
 import org.cloudfoundry.client.v3.securitygroups.ListSecurityGroupsRequest;
 import org.cloudfoundry.client.v3.securitygroups.ListRunningSecurityGroupsRequest;
 import org.cloudfoundry.client.v3.securitygroups.ListStagingSecurityGroupsRequest;
-import org.cloudfoundry.util.JobUtils;
 
 import org.junit.Test;
 import org.junit.Before;
@@ -61,33 +56,26 @@ public final class SecurityGroupsTest extends AbstractIntegrationTest {
         private String securityGroupName;
 
         @Before
-        public void settup() {
+        public void setup() {
                 this.securityGroupName = this.nameFactory.getSecurityGroupName();
-                String spaceID = this.spaceId.block();
+
                 this.securityGroup = this.cloudFoundryClient.securityGroupsV3()
                                 .create(CreateSecurityGroupRequest.builder()
                                                 .name(this.securityGroupName)
                                                 .globallyEnabled(GloballyEnabled.builder()
-                                                                .staging(true)
-                                                                .running(true)
+                                                                .staging(true).running(true)
                                                                 .build())
-                                                .rule(Rule.builder()
-                                                                .destination("0.0.0.0/0")
-                                                                .log(false)
-                                                                .ports("2048-3000")
-                                                                .protocol(TCP)
-                                                                .build())
+                                                .rule(Rule.builder().destination("0.0.0.0/0")
+                                                                .log(false).ports("2048-3000")
+                                                                .protocol(TCP).build())
                                                 .build());
         }
 
         @Test
         public void create() {
-                this.securityGroup
-                                .map(securityGroup -> securityGroup.getName())
-                                .as(StepVerifier::create)
-                                .expectNext(this.securityGroupName)
-                                .expectComplete()
-                                .verify(Duration.ofMinutes(5));
+                this.securityGroup.map(securityGroup -> securityGroup.getName())
+                                .as(StepVerifier::create).expectNext(this.securityGroupName)
+                                .expectComplete().verify(Duration.ofMinutes(5));
         }
 
         @Test
@@ -95,159 +83,145 @@ public final class SecurityGroupsTest extends AbstractIntegrationTest {
                 this.securityGroup
                                 .flatMap(securityGroup -> this.cloudFoundryClient.securityGroupsV3()
                                                 .get(GetSecurityGroupRequest.builder()
-                                                                .securityGroupId(securityGroup.getId())
+                                                                .securityGroupId(securityGroup
+                                                                                .getId())
                                                                 .build())
                                                 .map(sg -> sg.getName()))
-                                .as(StepVerifier::create)
-                                .expectNext(this.securityGroupName)
-                                .expectComplete()
-                                .verify(Duration.ofMinutes(5));
+                                .as(StepVerifier::create).expectNext(this.securityGroupName)
+                                .expectComplete().verify(Duration.ofMinutes(5));
         }
 
         @Test
         public void update() {
                 String newSecurityGroupName = this.nameFactory.getSecurityGroupName();
                 this.securityGroup
-                                .flatMap(securityGroup -> this.cloudFoundryClient.securityGroupsV3().update(
-                                                UpdateSecurityGroupRequest.builder()
-                                                                .securityGroupId(securityGroup.getId())
+                                .flatMap(securityGroup -> this.cloudFoundryClient.securityGroupsV3()
+                                                .update(UpdateSecurityGroupRequest.builder()
+                                                                .securityGroupId(securityGroup
+                                                                                .getId())
                                                                 .name(newSecurityGroupName)
                                                                 .build()))
                                 .map(securityGroup -> securityGroup.getName())
-                                .as(StepVerifier::create)
-                                .expectNext(newSecurityGroupName)
-                                .expectComplete()
-                                .verify(Duration.ofMinutes(5));
+                                .as(StepVerifier::create).expectNext(newSecurityGroupName)
+                                .expectComplete().verify(Duration.ofMinutes(5));
         }
 
         @Test
         public void delete() {
                 this.securityGroup
-                                .flatMap(securityGroup -> this.cloudFoundryClient.securityGroupsV3().delete(
-                                                DeleteSecurityGroupRequest.builder()
-                                                                .securityGroupId(securityGroup.getId())
+                                .flatMap(securityGroup -> this.cloudFoundryClient.securityGroupsV3()
+                                                .delete(DeleteSecurityGroupRequest.builder()
+                                                                .securityGroupId(securityGroup
+                                                                                .getId())
                                                                 .build())
                                                 .map(id -> Arrays.asList(id)))
-                                .as(StepVerifier::create)
-                                .expectNextCount(1)
-                                .expectComplete()
+                                .as(StepVerifier::create).expectNextCount(1).expectComplete()
                                 .verify(Duration.ofMinutes(5));
         }
 
         @Test
         public void list() {
-                this.securityGroup.map(
-                                securityGroup -> this.cloudFoundryClient.securityGroupsV3()
+                this.securityGroup
+                                .map(securityGroup -> this.cloudFoundryClient.securityGroupsV3()
                                                 .list(ListSecurityGroupsRequest.builder()
-                                                                .names(Arrays.asList(securityGroup.getName()))
+                                                                .names(Arrays.asList(securityGroup
+                                                                                .getName()))
                                                                 .build()))
-                                .as(StepVerifier::create)
-                                .expectNextCount(1)
-                                .expectComplete()
+                                .as(StepVerifier::create).expectNextCount(1).expectComplete()
                                 .verify(Duration.ofMinutes(5));
         }
 
         @Test
         public void listRunning() {
-                Mono.zip(this.securityGroup, this.spaceId).flatMap(v -> this.cloudFoundryClient.securityGroupsV3()
+                Mono.zip(this.securityGroup, this.spaceId).flatMap(v -> this.cloudFoundryClient
+                                .securityGroupsV3()
                                 .listRunning(ListRunningSecurityGroupsRequest.builder()
                                                 .spaceId(v.getT2())
                                                 .names(Arrays.asList(v.getT1().getName())).build()))
-                                .as(StepVerifier::create)
-                                .expectNextCount(1)
-                                .expectComplete()
+                                .as(StepVerifier::create).expectNextCount(1).expectComplete()
                                 .verify(Duration.ofMinutes(5));
         }
 
         @Test
         public void listStaging() {
-                Mono.zip(this.securityGroup, this.spaceId).flatMap(v -> this.cloudFoundryClient.securityGroupsV3()
+                Mono.zip(this.securityGroup, this.spaceId).flatMap(v -> this.cloudFoundryClient
+                                .securityGroupsV3()
                                 .listStaging(ListStagingSecurityGroupsRequest.builder()
                                                 .spaceId(v.getT2())
                                                 .names(Arrays.asList(v.getT1().getName())).build()))
-                                .as(StepVerifier::create)
-                                .expectNextCount(1)
-                                .expectComplete()
+                                .as(StepVerifier::create).expectNextCount(1).expectComplete()
                                 .verify(Duration.ofMinutes(5));
         }
 
         @Test
         public void bindStagingSecurityGroup() {
-                Mono.zip(this.securityGroup, this.spaceId)
-                                .flatMap(v -> this.cloudFoundryClient.securityGroupsV3()
-                                                .bindStagingSecurityGroup(BindStagingSecurityGroupRequest.builder()
-                                                                .securityGroupId(v.getT1().getId())
-                                                                .boundSpaces(Relationship.builder()
-                                                                                .id(v.getT2()).build())
-                                                                .build()))
-                                .as(StepVerifier::create)
-                                .expectNextCount(1)
-                                .expectComplete()
+                Mono.zip(this.securityGroup, this.spaceId).flatMap(v -> this.cloudFoundryClient
+                                .securityGroupsV3()
+                                .bindStagingSecurityGroup(BindStagingSecurityGroupRequest.builder()
+                                                .securityGroupId(v.getT1().getId())
+                                                .boundSpaces(Relationship.builder().id(v.getT2())
+                                                                .build())
+                                                .build()))
+                                .as(StepVerifier::create).expectNextCount(1).expectComplete()
                                 .verify(Duration.ofMinutes(5));
         }
 
         @Test
         public void unbindStagingSecurityGroup() {
-                Mono.zip(this.securityGroup, this.spaceId)
-                                .flatMap(v -> this.cloudFoundryClient.securityGroupsV3()
-                                                .bindStagingSecurityGroup(BindStagingSecurityGroupRequest.builder()
-                                                                .securityGroupId(v.getT1().getId())
-                                                                .boundSpaces(Relationship.builder().id(v.getT2())
-                                                                                .build())
+                Mono.zip(this.securityGroup, this.spaceId).flatMap(v -> this.cloudFoundryClient
+                                .securityGroupsV3()
+                                .bindStagingSecurityGroup(BindStagingSecurityGroupRequest.builder()
+                                                .securityGroupId(v.getT1().getId())
+                                                .boundSpaces(Relationship.builder().id(v.getT2())
                                                                 .build())
-                                                .then(this.cloudFoundryClient.securityGroupsV3()
-                                                                .unbindStagingSecurityGroup(
-                                                                                UnbindStagingSecurityGroupRequest
-                                                                                                .builder()
-                                                                                                .securityGroupId(v
-                                                                                                                .getT1()
-                                                                                                                .getId())
-                                                                                                .spaceId(v.getT2())
-                                                                                                .build())))
+                                                .build())
+                                .then(this.cloudFoundryClient.securityGroupsV3()
+                                                .unbindStagingSecurityGroup(
+                                                                UnbindStagingSecurityGroupRequest
+                                                                                .builder()
+                                                                                .securityGroupId(v
+                                                                                                .getT1()
+                                                                                                .getId())
+                                                                                .spaceId(v.getT2())
+                                                                                .build())))
 
-                                .as(StepVerifier::create)
-                                .expectNextCount(0)
-                                .expectComplete()
+                                .as(StepVerifier::create).expectNextCount(0).expectComplete()
                                 .verify(Duration.ofMinutes(5));
         }
 
         @Test
         public void bindRunningSecurityGroup() {
-                Mono.zip(this.securityGroup, this.spaceId)
-                                .flatMap(v -> this.cloudFoundryClient.securityGroupsV3()
-                                                .bindRunningSecurityGroup(BindRunningSecurityGroupRequest.builder()
-                                                                .securityGroupId(v.getT1().getId())
-                                                                .boundSpaces(Relationship.builder().id(v.getT2())
-                                                                                .build())
-                                                                .build()))
-                                .as(StepVerifier::create)
-                                .expectNextCount(1)
-                                .expectComplete()
+                Mono.zip(this.securityGroup, this.spaceId).flatMap(v -> this.cloudFoundryClient
+                                .securityGroupsV3()
+                                .bindRunningSecurityGroup(BindRunningSecurityGroupRequest.builder()
+                                                .securityGroupId(v.getT1().getId())
+                                                .boundSpaces(Relationship.builder().id(v.getT2())
+                                                                .build())
+                                                .build()))
+                                .as(StepVerifier::create).expectNextCount(1).expectComplete()
                                 .verify(Duration.ofMinutes(5));
         }
 
         @Test
         public void unbindRunnungSecurityGroup() {
-                Mono.zip(this.securityGroup, this.spaceId)
-                                .flatMap(v -> this.cloudFoundryClient.securityGroupsV3()
-                                                .bindRunningSecurityGroup(BindRunningSecurityGroupRequest.builder()
-                                                                .securityGroupId(v.getT1().getId())
-                                                                .boundSpaces(Relationship.builder().id(v.getT2())
-                                                                                .build())
+                Mono.zip(this.securityGroup, this.spaceId).flatMap(v -> this.cloudFoundryClient
+                                .securityGroupsV3()
+                                .bindRunningSecurityGroup(BindRunningSecurityGroupRequest.builder()
+                                                .securityGroupId(v.getT1().getId())
+                                                .boundSpaces(Relationship.builder().id(v.getT2())
                                                                 .build())
-                                                .then(this.cloudFoundryClient.securityGroupsV3()
-                                                                .unbindRunningSecurityGroup(
-                                                                                UnbindRunningSecurityGroupRequest
-                                                                                                .builder()
-                                                                                                .securityGroupId(v
-                                                                                                                .getT1()
-                                                                                                                .getId())
-                                                                                                .spaceId(v.getT2())
-                                                                                                .build())))
+                                                .build())
+                                .then(this.cloudFoundryClient.securityGroupsV3()
+                                                .unbindRunningSecurityGroup(
+                                                                UnbindRunningSecurityGroupRequest
+                                                                                .builder()
+                                                                                .securityGroupId(v
+                                                                                                .getT1()
+                                                                                                .getId())
+                                                                                .spaceId(v.getT2())
+                                                                                .build())))
 
-                                .as(StepVerifier::create)
-                                .expectNextCount(0)
-                                .expectComplete()
+                                .as(StepVerifier::create).expectNextCount(0).expectComplete()
                                 .verify(Duration.ofMinutes(5));
         }
 }

--- a/integration-test/src/test/java/org/cloudfoundry/client/v3/SecurityGroupsTest.java
+++ b/integration-test/src/test/java/org/cloudfoundry/client/v3/SecurityGroupsTest.java
@@ -54,7 +54,7 @@ public final class SecurityGroupsTest extends AbstractIntegrationTest {
         private Mono<String> spaceId;
 
         @Before
-        void settup() {
+        prublic void settup() {
                 this.securityGroupName = this.nameFactory.getSecurityGroupName();
 
                 this.cloudFoundryClient.securityGroupsV3()
@@ -76,7 +76,7 @@ public final class SecurityGroupsTest extends AbstractIntegrationTest {
         }
 
         @After
-        void tearDown() {
+        public void tearDown() {
                 this.cloudFoundryClient.securityGroupsV3().delete(
                                 DeleteSecurityGroupRequest.builder()
                                                 .securityGroupId(this.securityGroupId.block())

--- a/integration-test/src/test/java/org/cloudfoundry/client/v3/SecurityGroupsTest.java
+++ b/integration-test/src/test/java/org/cloudfoundry/client/v3/SecurityGroupsTest.java
@@ -54,7 +54,7 @@ public final class SecurityGroupsTest extends AbstractIntegrationTest {
         private Mono<String> spaceId;
 
         @Before
-        prublic void settup() {
+        public void settup() {
                 this.securityGroupName = this.nameFactory.getSecurityGroupName();
 
                 this.cloudFoundryClient.securityGroupsV3()


### PR DESCRIPTION
Adopting Security Groups API V3 API. Change includes  implementation, unit and integration tests for the following operations:

- [ Create Security Group](https://v3-apidocs.cloudfoundry.org/version/3.140.0/index.html#create-a-security-group)
- [ Get Security Group](https://v3-apidocs.cloudfoundry.org/version/3.140.0/index.html#get-a-security-group)
- [ List Security Group](https://v3-apidocs.cloudfoundry.org/version/3.140.0/index.html#list-security-groups)
- [ Update Security Group](https://v3-apidocs.cloudfoundry.org/version/3.140.0/index.html#update-a-security-group)
- [Delete Security Group](https://v3-apidocs.cloudfoundry.org/version/3.140.0/index.html#delete-a-security-group)
- [Bind Running Security Group](https://v3-apidocs.cloudfoundry.org/version/3.140.0/index.html#bind-a-running-security-group-to-spaces)
- [Bind Staging Security group](https://v3-apidocs.cloudfoundry.org/version/3.140.0/index.html#bind-a-staging-security-group-to-spaces)
-  [Unbind Running Security Group](https://v3-apidocs.cloudfoundry.org/version/3.140.0/index.html#unbind-a-running-security-group-to-spaces)
- [Unind Staging Security group](https://v3-apidocs.cloudfoundry.org/version/3.140.0/index.html#unbind-a-staging-security-group-to-spaces)
-  [List Running Security Group](https://v3-apidocs.cloudfoundry.org/version/3.140.0/index.html#list-a-running-security-group-to-spaces)
- [List Staging Security group](https://v3-apidocs.cloudfoundry.org/version/3.140.0/index.html#list-a-staging-security-group-to-spaces)

PR ended up a bit on the large side, but it is mostly boilerplate, so I decided not to try to brake it further apart.