### PR TITLE
Updates Dockerfile with new script source

### DIFF
--- a/ci/Dockerfile
+++ b/ci/Dockerfile
@@ -1,7 +1,11 @@
 ARG base_image=openjdk:8-jre
+ARG script_image=springio/concourse-release-scripts:0.3.4
+
+FROM ${script_image}
+
 FROM ${base_image}
 
-ADD https://repo.spring.io/libs-release/io/spring/concourse/releasescripts/concourse-release-scripts/0.3.2/concourse-release-scripts-0.3.2.jar /opt/concourse-release-scripts.jar
+COPY --from=0 /concourse-release-scripts.jar /opt/
 
 RUN apt-get update && apt-get install --no-install-recommends -y \
     ca-certificates \


### PR DESCRIPTION
Since permissions for `repo.spring.io` have been changed, this PR updates the Dockerfile to use the [DockerHub image](https://hub.docker.com/r/springio/concourse-release-scripts/tags) as the source for `concourse-release-scripts`.

Uses version 0.3.4 for now as 0.4.0 is built with Java 17