### PR TITLE
Update CAPI v2 docs links to new subdomain

### DIFF
--- a/README.md
+++ b/README.md
@@ -312,7 +312,7 @@ Lastly before running the tests, it is strongly recommended that you take a snap
 ## License
 This project is released under version 2.0 of the [Apache License][l].
 
-[a]: https://apidocs.cloudfoundry.org/latest-release/
+[a]: https://apidocs.cloudfoundry.org/
 [c]: https://github.com/cloudfoundry/cli
 [e]: https://github.com/cloudfoundry/java-client/issues
 [g]: https://gradle.org

--- a/cloudfoundry-client/src/main/java/org/cloudfoundry/client/v2/applications/ApplicationsV2.java
+++ b/cloudfoundry-client/src/main/java/org/cloudfoundry/client/v2/applications/ApplicationsV2.java
@@ -25,7 +25,7 @@ import reactor.core.publisher.Mono;
 public interface ApplicationsV2 {
 
     /**
-     * Makes the <a href="https://apidocs.cloudfoundry.org/latest-release/apps/associate_route_with_the_app.html">Associate Route with the Application</a> request
+     * Makes the <a href="https://v2-apidocs.cloudfoundry.org/apps/associate_route_with_the_app.html">Associate Route with the Application</a> request
      *
      * @param request the Associate Route with the Application request
      * @return the response from the Associate Route with the Application request
@@ -34,7 +34,7 @@ public interface ApplicationsV2 {
             AssociateApplicationRouteRequest request);
 
     /**
-     * Makes the <a href="https://apidocs.cloudfoundry.org/latest-release/apps/copy_the_app_bits_for_an_app.html">Copy the app bits for an Application</a> request
+     * Makes the <a href="https://v2-apidocs.cloudfoundry.org/apps/copy_the_app_bits_for_an_app.html">Copy the app bits for an Application</a> request
      *
      * @param request the Copy Application request
      * @return the response from the Copy Application request
@@ -42,8 +42,8 @@ public interface ApplicationsV2 {
     Mono<CopyApplicationResponse> copy(CopyApplicationRequest request);
 
     /**
-     * Makes the <a href="https://apidocs.cloudfoundry.org/latest-release/apps/creating_an_app.html">Creating an App</a> request and the <a
-     * href="https://apidocs.cloudfoundry.org/latest-release/apps/creating_a_docker_app_%28experimental%29.html">Creating a Docker App</a> request.
+     * Makes the <a href="https://v2-apidocs.cloudfoundry.org/apps/creating_an_app.html">Creating an App</a> request and the <a
+     * href="https://v2-apidocs.cloudfoundry.org/apps/creating_a_docker_app_%28experimental%29.html">Creating a Docker App</a> request.
      *
      * @param request the Create Application request
      * @return the response from the Create Application request
@@ -51,7 +51,7 @@ public interface ApplicationsV2 {
     Mono<CreateApplicationResponse> create(CreateApplicationRequest request);
 
     /**
-     * Makes the <a href="https://apidocs.cloudfoundry.org/latest-release/apps/delete_a_particular_app.html">Delete the App</a> request
+     * Makes the <a href="https://v2-apidocs.cloudfoundry.org/apps/delete_a_particular_app.html">Delete the App</a> request
      *
      * @param request the Delete Application request
      * @return the response from the Delete Application request
@@ -59,7 +59,7 @@ public interface ApplicationsV2 {
     Mono<Void> delete(DeleteApplicationRequest request);
 
     /**
-     * Makes the <a href="https://apidocs.cloudfoundry.org/latest-release/apps/downloads_the_bits_for_an_app.html">Downloads the bits for an App</a> request
+     * Makes the <a href="https://v2-apidocs.cloudfoundry.org/apps/downloads_the_bits_for_an_app.html">Downloads the bits for an App</a> request
      *
      * @param request the Download Application request
      * @return the response from the Download Application request
@@ -67,7 +67,7 @@ public interface ApplicationsV2 {
     Flux<byte[]> download(DownloadApplicationRequest request);
 
     /**
-     * Makes the <a href="https://apidocs.cloudfoundry.org/latest-release/apps/downloads_the_staged_droplet_for_an_app.html">Downloads the staged droplet for an App</a> request
+     * Makes the <a href="https://v2-apidocs.cloudfoundry.org/apps/downloads_the_staged_droplet_for_an_app.html">Downloads the staged droplet for an App</a> request
      *
      * @param request the Download Droplet request
      * @return the response from the Download Droplet request
@@ -75,7 +75,7 @@ public interface ApplicationsV2 {
     Flux<byte[]> downloadDroplet(DownloadApplicationDropletRequest request);
 
     /**
-     * Makes the <a href="https://apidocs.cloudfoundry.org/latest-release/apps/get_the_env_for_an_app.html">Get the env for an App</a> request
+     * Makes the <a href="https://v2-apidocs.cloudfoundry.org/apps/get_the_env_for_an_app.html">Get the env for an App</a> request
      *
      * @param request the Get Application Environment request
      * @return the response from the Get Application Environment request
@@ -83,7 +83,7 @@ public interface ApplicationsV2 {
     Mono<ApplicationEnvironmentResponse> environment(ApplicationEnvironmentRequest request);
 
     /**
-     * Makes the <a href="https://apidocs.cloudfoundry.org/latest-release/apps/retrieve_a_particular_app.html">Retrieve a Particular App</a> request
+     * Makes the <a href="https://v2-apidocs.cloudfoundry.org/apps/retrieve_a_particular_app.html">Retrieve a Particular App</a> request
      *
      * @param request the Get Application request
      * @return the response from the Get Application request
@@ -91,7 +91,7 @@ public interface ApplicationsV2 {
     Mono<GetApplicationResponse> get(GetApplicationRequest request);
 
     /**
-     * Makes the <a href="https://apidocs.cloudfoundry.org/latest-release/apps/retrieving_permissions_on_a_app.html">Retrieve Permissions on a Particular App</a> request
+     * Makes the <a href="https://v2-apidocs.cloudfoundry.org/apps/retrieving_permissions_on_a_app.html">Retrieve Permissions on a Particular App</a> request
      *
      * @param request the Get Application Permissions request
      * @return the response from the Get Application Permissions request
@@ -100,7 +100,7 @@ public interface ApplicationsV2 {
             GetApplicationPermissionsRequest request);
 
     /**
-     * Makes the <a href="https://apidocs.cloudfoundry.org/latest-release/apps/get_the_instance_information_for_a_started_app.html">Get the instance information for a STARTED App</a> request
+     * Makes the <a href="https://v2-apidocs.cloudfoundry.org/apps/get_the_instance_information_for_a_started_app.html">Get the instance information for a STARTED App</a> request
      *
      * @param request the Get Instance Information request
      * @return the response from the Get Instance Information request
@@ -108,7 +108,7 @@ public interface ApplicationsV2 {
     Mono<ApplicationInstancesResponse> instances(ApplicationInstancesRequest request);
 
     /**
-     * Makes the <a href="https://apidocs.cloudfoundry.org/latest-release/apps/list_all_apps.html">List all Apps</a> request
+     * Makes the <a href="https://v2-apidocs.cloudfoundry.org/apps/list_all_apps.html">List all Apps</a> request
      *
      * @param request the List Applications request
      * @return the response from the List Applications request
@@ -116,7 +116,7 @@ public interface ApplicationsV2 {
     Mono<ListApplicationsResponse> list(ListApplicationsRequest request);
 
     /**
-     * Makes the <a href="https://apidocs.cloudfoundry.org/latest-release/apps/list_all_routes_for_the_app.html">List all Routes for the Application</a> request
+     * Makes the <a href="https://v2-apidocs.cloudfoundry.org/apps/list_all_routes_for_the_app.html">List all Routes for the Application</a> request
      *
      * @param request the List all Routes for the Application request
      * @return the response from the List all Routes for the Application request
@@ -124,7 +124,7 @@ public interface ApplicationsV2 {
     Mono<ListApplicationRoutesResponse> listRoutes(ListApplicationRoutesRequest request);
 
     /**
-     * Makes the <a href="https://apidocs.cloudfoundry.org/latest-release/apps/list_all_service_bindings_for_the_app.html">List all Service Bindings for the App</a> request
+     * Makes the <a href="https://v2-apidocs.cloudfoundry.org/apps/list_all_service_bindings_for_the_app.html">List all Service Bindings for the App</a> request
      *
      * @param request the List Service Bindings request
      * @return the response from the List Service Bindings request
@@ -133,7 +133,7 @@ public interface ApplicationsV2 {
             ListApplicationServiceBindingsRequest request);
 
     /**
-     * Makes the <a href="https://apidocs.cloudfoundry.org/latest-release/apps/remove_route_from_the_app.html">Remove Route from the Application</a> request
+     * Makes the <a href="https://v2-apidocs.cloudfoundry.org/apps/remove_route_from_the_app.html">Remove Route from the Application</a> request
      *
      * @param request the Remove Route from the Application request
      * @return the response from the Remove Route from the Application request
@@ -141,7 +141,7 @@ public interface ApplicationsV2 {
     Mono<Void> removeRoute(RemoveApplicationRouteRequest request);
 
     /**
-     * Makes the <a href="https://apidocs.cloudfoundry.org/latest-release/apps/remove_service_binding_from_the_app.html">Remove Service Binding from the Application</a> request
+     * Makes the <a href="https://v2-apidocs.cloudfoundry.org/apps/remove_service_binding_from_the_app.html">Remove Service Binding from the Application</a> request
      *
      * @param request the Remove a Service Binding from an Application request
      * @return the response from the Remove a Service Binding from an Application request
@@ -149,7 +149,7 @@ public interface ApplicationsV2 {
     Mono<Void> removeServiceBinding(RemoveApplicationServiceBindingRequest request);
 
     /**
-     * Makes the <a href="https://apidocs.cloudfoundry.org/latest-release/apps/restage_an_app.html">Restage an App</a> request
+     * Makes the <a href="https://v2-apidocs.cloudfoundry.org/apps/restage_an_app.html">Restage an App</a> request
      *
      * @param request the Restage an Application request
      * @return the response from the Restage an Application request
@@ -157,7 +157,7 @@ public interface ApplicationsV2 {
     Mono<RestageApplicationResponse> restage(RestageApplicationRequest request);
 
     /**
-     * Makes the <a href="https://apidocs.cloudfoundry.org/latest-release/apps/get_detailed_stats_for_a_started_app.html">Get detailed stats for a STARTED App</a> request
+     * Makes the <a href="https://v2-apidocs.cloudfoundry.org/apps/get_detailed_stats_for_a_started_app.html">Get detailed stats for a STARTED App</a> request
      *
      * @param request the Get Statistics request
      * @return the response from the Get Statistics request
@@ -165,7 +165,7 @@ public interface ApplicationsV2 {
     Mono<ApplicationStatisticsResponse> statistics(ApplicationStatisticsRequest request);
 
     /**
-     * Makes the <a href="https://apidocs.cloudfoundry.org/latest-release/apps/get_app_summary.html">Get Application Summary</a> request
+     * Makes the <a href="https://v2-apidocs.cloudfoundry.org/apps/get_app_summary.html">Get Application Summary</a> request
      *
      * @param request the Get Application Summary request
      * @return the response from the Get Application Summary request
@@ -173,7 +173,7 @@ public interface ApplicationsV2 {
     Mono<SummaryApplicationResponse> summary(SummaryApplicationRequest request);
 
     /**
-     * Makes the <a href="https://apidocs.cloudfoundry.org/latest-release/apps/terminate_the_running_app_instance_at_the_given_index.html">Terminate Application Instance</a> request
+     * Makes the <a href="https://v2-apidocs.cloudfoundry.org/apps/terminate_the_running_app_instance_at_the_given_index.html">Terminate Application Instance</a> request
      *
      * @param request the Terminate Application Instance request
      * @return the response form the Terminate Application Instance request
@@ -181,7 +181,7 @@ public interface ApplicationsV2 {
     Mono<Void> terminateInstance(TerminateApplicationInstanceRequest request);
 
     /**
-     * Makes the <a href="https://apidocs.cloudfoundry.org/latest-release/apps/updating_an_app.html">Updating an App</a> request
+     * Makes the <a href="https://v2-apidocs.cloudfoundry.org/apps/updating_an_app.html">Updating an App</a> request
      *
      * @param request the Update Application request
      * @return the response from the Update Application request
@@ -189,7 +189,7 @@ public interface ApplicationsV2 {
     Mono<UpdateApplicationResponse> update(UpdateApplicationRequest request);
 
     /**
-     * Makes the <a href="https://apidocs.cloudfoundry.org/latest-release/apps/uploads_the_bits_for_an_app.html">Upload the bits for an App</a> request
+     * Makes the <a href="https://v2-apidocs.cloudfoundry.org/apps/uploads_the_bits_for_an_app.html">Upload the bits for an App</a> request
      *
      * @param request the Upload Application request
      * @return the response from the Upload Application request
@@ -197,7 +197,7 @@ public interface ApplicationsV2 {
     Mono<UploadApplicationResponse> upload(UploadApplicationRequest request);
 
     /**
-     * Makes the <a href="https://apidocs.cloudfoundry.org/latest-release/apps/uploads_the_droplet_for_an_app.html">Upload the droplet for an App</a> request
+     * Makes the <a href="https://v2-apidocs.cloudfoundry.org/apps/uploads_the_droplet_for_an_app.html">Upload the droplet for an App</a> request
      *
      * @param request the Upload Droplet request
      * @return the response from the Upload Droplet request

--- a/cloudfoundry-client/src/main/java/org/cloudfoundry/client/v2/applicationusageevents/ApplicationUsageEvents.java
+++ b/cloudfoundry-client/src/main/java/org/cloudfoundry/client/v2/applicationusageevents/ApplicationUsageEvents.java
@@ -24,7 +24,7 @@ import reactor.core.publisher.Mono;
 public interface ApplicationUsageEvents {
 
     /**
-     * Makes the <a href="https://apidocs.cloudfoundry.org/latest-release/app_usage_events/retrieve_a_particular_app_usage_event.html">Get an Application Usage Event</a> request
+     * Makes the <a href="https://v2-apidocs.cloudfoundry.org/app_usage_events/retrieve_a_particular_app_usage_event.html">Get an Application Usage Event</a> request
      *
      * @param request the Get Application Usage Event request
      * @return the response from the Get all Application Usage Event request
@@ -32,7 +32,7 @@ public interface ApplicationUsageEvents {
     Mono<GetApplicationUsageEventResponse> get(GetApplicationUsageEventRequest request);
 
     /**
-     * Makes the <a href="https://apidocs.cloudfoundry.org/latest-release/app_usage_events/list_all_app_usage_events.html">List all Application Usage Events</a> request
+     * Makes the <a href="https://v2-apidocs.cloudfoundry.org/app_usage_events/list_all_app_usage_events.html">List all Application Usage Events</a> request
      *
      * @param request the List all Application Usage Events request
      * @return the response from the List all Application Usage Events request
@@ -40,7 +40,7 @@ public interface ApplicationUsageEvents {
     Mono<ListApplicationUsageEventsResponse> list(ListApplicationUsageEventsRequest request);
 
     /**
-     * Makes the <a href="https://apidocs.cloudfoundry.org/latest-release/app_usage_events/purge_and_reseed_app_usage_events.html">Purge and Reseed Application Usage Events</a> request
+     * Makes the <a href="https://v2-apidocs.cloudfoundry.org/app_usage_events/purge_and_reseed_app_usage_events.html">Purge and Reseed Application Usage Events</a> request
      *
      * @param request the Purge and Reseed Application Usage Events
      * @return the response from the Purge and Reseed Application Usage Events request

--- a/cloudfoundry-client/src/main/java/org/cloudfoundry/client/v2/blobstores/Blobstores.java
+++ b/cloudfoundry-client/src/main/java/org/cloudfoundry/client/v2/blobstores/Blobstores.java
@@ -24,7 +24,7 @@ import reactor.core.publisher.Mono;
 public interface Blobstores {
 
     /**
-     * Makes the <a href="https://apidocs.cloudfoundry.org/latest-release/blobstores/delete_all_blobs_in_the_buildpack_cache_blobstore.html">Delete Buildpack Caches</a> request
+     * Makes the <a href="https://v2-apidocs.cloudfoundry.org/blobstores/delete_all_blobs_in_the_buildpack_cache_blobstore.html">Delete Buildpack Caches</a> request
      *
      * @param request the Delete Buildpack Caches request
      * @return the response from the Delete Buildpack Caches request

--- a/cloudfoundry-client/src/main/java/org/cloudfoundry/client/v2/buildpacks/Buildpacks.java
+++ b/cloudfoundry-client/src/main/java/org/cloudfoundry/client/v2/buildpacks/Buildpacks.java
@@ -24,7 +24,7 @@ import reactor.core.publisher.Mono;
 public interface Buildpacks {
 
     /**
-     * Makes the <a href="https://apidocs.cloudfoundry.org/latest-release/buildpacks/creates_an_admin_buildpack.html">Create the Buildpack</a> request
+     * Makes the <a href="https://v2-apidocs.cloudfoundry.org/buildpacks/creates_an_admin_buildpack.html">Create the Buildpack</a> request
      *
      * @param request the Create Buildpack request
      * @return the response from the Create Buildpack request
@@ -32,7 +32,7 @@ public interface Buildpacks {
     Mono<CreateBuildpackResponse> create(CreateBuildpackRequest request);
 
     /**
-     * Makes the <a href="https://apidocs.cloudfoundry.org/latest-release/buildpacks/delete_a_particular_buildpack.html">Delete the Buildpack</a> request
+     * Makes the <a href="https://v2-apidocs.cloudfoundry.org/buildpacks/delete_a_particular_buildpack.html">Delete the Buildpack</a> request
      *
      * @param request the Delete Buildpack request
      * @return the response from the Delete Buildpack request
@@ -40,7 +40,7 @@ public interface Buildpacks {
     Mono<DeleteBuildpackResponse> delete(DeleteBuildpackRequest request);
 
     /**
-     * Makes the <a href="https://apidocs.cloudfoundry.org/latest-release/buildpacks/retrieve_a_particular_buildpack.html">Retrieve a particular Buildpack</a> request
+     * Makes the <a href="https://v2-apidocs.cloudfoundry.org/buildpacks/retrieve_a_particular_buildpack.html">Retrieve a particular Buildpack</a> request
      *
      * @param request the Get Buildpack request
      * @return the response from the Get Buildpack request
@@ -48,7 +48,7 @@ public interface Buildpacks {
     Mono<GetBuildpackResponse> get(GetBuildpackRequest request);
 
     /**
-     * Makes the <a href="https://apidocs.cloudfoundry.org/latest-release/buildpacks/list_all_buildpacks.html">List all Buildpacks</a> request
+     * Makes the <a href="https://v2-apidocs.cloudfoundry.org/buildpacks/list_all_buildpacks.html">List all Buildpacks</a> request
      *
      * @param request the List all Buildpacks request
      * @return the response from the List all Buildpacks request
@@ -56,9 +56,9 @@ public interface Buildpacks {
     Mono<ListBuildpacksResponse> list(ListBuildpacksRequest request);
 
     /**
-     * Makes the <a href="https://apidocs.cloudfoundry.org/latest-release/buildpacks/change_the_position_of_a_buildpack.html">Change the position of a Buildpack</a>,
-     * <a href="https://apidocs.cloudfoundry.org/latest-release/buildpacks/enable_or_disable_a_buildpack.html">Enable or disable a Buildpack</a>, and
-     * <a href="https://apidocs.cloudfoundry.org/latest-release/buildpacks/lock_or_unlock_a_buildpack.html">Lock or unlock a Buildpack</a> requests
+     * Makes the <a href="https://v2-apidocs.cloudfoundry.org/buildpacks/change_the_position_of_a_buildpack.html">Change the position of a Buildpack</a>,
+     * <a href="https://v2-apidocs.cloudfoundry.org/buildpacks/enable_or_disable_a_buildpack.html">Enable or disable a Buildpack</a>, and
+     * <a href="https://v2-apidocs.cloudfoundry.org/buildpacks/lock_or_unlock_a_buildpack.html">Lock or unlock a Buildpack</a> requests
      *
      * @param request the Update Buildpack request
      * @return the response from the Update Buildpack request
@@ -66,7 +66,7 @@ public interface Buildpacks {
     Mono<UpdateBuildpackResponse> update(UpdateBuildpackRequest request);
 
     /**
-     * Makes the <a href="https://apidocs.cloudfoundry.org/latest-release/buildpacks/upload_the_bits_for_an_admin_buildpack.html">Upload Buildpack</a> request
+     * Makes the <a href="https://v2-apidocs.cloudfoundry.org/buildpacks/upload_the_bits_for_an_admin_buildpack.html">Upload Buildpack</a> request
      *
      * @param request the Upload Buildpack request
      * @return the response from the Upload Buildpack request

--- a/cloudfoundry-client/src/main/java/org/cloudfoundry/client/v2/domains/Domains.java
+++ b/cloudfoundry-client/src/main/java/org/cloudfoundry/client/v2/domains/Domains.java
@@ -24,8 +24,8 @@ import reactor.core.publisher.Mono;
 public interface Domains {
 
     /**
-     * Makes the deprecated <a href="https://apidocs.cloudfoundry.org/latest-release/domains_%28deprecated%29/create_a_domain_owned_by_the_given_organization_%28deprecated%29.html">Create a Domain
-     * owned by the given Organization</a> request and the deprecated <a href="https://apidocs.cloudfoundry.org/latest-release/domains_%28deprecated%29/create_a_shared_domain_%28deprecated%29.html">
+     * Makes the deprecated <a href="https://v2-apidocs.cloudfoundry.org/domains_%28deprecated%29/create_a_domain_owned_by_the_given_organization_%28deprecated%29.html">Create a Domain
+     * owned by the given Organization</a> request and the deprecated <a href="https://v2-apidocs.cloudfoundry.org/domains_%28deprecated%29/create_a_shared_domain_%28deprecated%29.html">
      * Create a Shared Domain</a> request
      *
      * @param request the Create a Domain request
@@ -35,7 +35,7 @@ public interface Domains {
     Mono<CreateDomainResponse> create(CreateDomainRequest request);
 
     /**
-     * Makes the deprecated <a href="https://apidocs.cloudfoundry.org/latest-release/domains_%28deprecated%29/delete_a_particular_domain_%28deprecated%29.html">Delete a Particular Domain</a> request
+     * Makes the deprecated <a href="https://v2-apidocs.cloudfoundry.org/domains_%28deprecated%29/delete_a_particular_domain_%28deprecated%29.html">Delete a Particular Domain</a> request
      *
      * @param request the Delete a Particular Domain request
      * @return the response from the Delete a Particular Domain request
@@ -44,7 +44,7 @@ public interface Domains {
     Mono<DeleteDomainResponse> delete(DeleteDomainRequest request);
 
     /**
-     * Makes the deprecated <a href="https://apidocs.cloudfoundry.org/latest-release/domains_(deprecated)/retrieve_a_particular_domain_(deprecated).html">Get Domain</a> request
+     * Makes the deprecated <a href="https://v2-apidocs.cloudfoundry.org/domains_(deprecated)/retrieve_a_particular_domain_(deprecated).html">Get Domain</a> request
      *
      * @param request The Get Domain request
      * @return the response from the Get Domain request
@@ -53,7 +53,7 @@ public interface Domains {
     Mono<GetDomainResponse> get(GetDomainRequest request);
 
     /**
-     * Makes the deprecated <a href="https://apidocs.cloudfoundry.org/latest-release/domains_%28deprecated%29/list_all_domains_%28deprecated%29.html">List all Domains</a> request
+     * Makes the deprecated <a href="https://v2-apidocs.cloudfoundry.org/domains_%28deprecated%29/list_all_domains_%28deprecated%29.html">List all Domains</a> request
      *
      * @param request the List all Domains request
      * @return the response from the List all Domains request
@@ -62,7 +62,7 @@ public interface Domains {
     Mono<ListDomainsResponse> list(ListDomainsRequest request);
 
     /**
-     * Makes the deprecated <a href="https://apidocs.cloudfoundry.org/latest-release/domains_%28deprecated%29/list_all_spaces_for_the_domain_%28deprecated%29.html">List all Spaces for the Domain</a>
+     * Makes the deprecated <a href="https://v2-apidocs.cloudfoundry.org/domains_%28deprecated%29/list_all_spaces_for_the_domain_%28deprecated%29.html">List all Spaces for the Domain</a>
      * request
      *
      * @param request the List all Spaces for the Domain request

--- a/cloudfoundry-client/src/main/java/org/cloudfoundry/client/v2/environmentvariablegroups/EnvironmentVariableGroups.java
+++ b/cloudfoundry-client/src/main/java/org/cloudfoundry/client/v2/environmentvariablegroups/EnvironmentVariableGroups.java
@@ -24,7 +24,7 @@ import reactor.core.publisher.Mono;
 public interface EnvironmentVariableGroups {
 
     /**
-     * Makes the <a href="apidocs.cloudfoundry.org/latest-release/environment_variable_groups/getting_the_contents_of_the_running_environment_variable_group.html">Get the Running Environment
+     * Makes the <a href="v2-apidocs.cloudfoundry.org/environment_variable_groups/getting_the_contents_of_the_running_environment_variable_group.html">Get the Running Environment
      * Variables</a> request
      *
      * @param request the Get Running Environment Variables request
@@ -34,7 +34,7 @@ public interface EnvironmentVariableGroups {
             GetRunningEnvironmentVariablesRequest request);
 
     /**
-     * Makes the <a href="apidocs.cloudfoundry.org/latest-release/environment_variable_groups/getting_the_contents_of_the_staging_environment_variable_group.html">Get the Staging Environment
+     * Makes the <a href="v2-apidocs.cloudfoundry.org/environment_variable_groups/getting_the_contents_of_the_staging_environment_variable_group.html">Get the Staging Environment
      * Variables</a> request
      *
      * @param request the Get Staging Environment Variables request
@@ -44,7 +44,7 @@ public interface EnvironmentVariableGroups {
             GetStagingEnvironmentVariablesRequest request);
 
     /**
-     * Makes the <a href="apidocs.cloudfoundry.org/latest-release/environment_variable_groups/updating_the_contents_of_the_running_environment_variable_group.html">Update the Running Environment
+     * Makes the <a href="v2-apidocs.cloudfoundry.org/environment_variable_groups/updating_the_contents_of_the_running_environment_variable_group.html">Update the Running Environment
      * Variables</a> request
      *
      * @param request the Update Running Environment Variables request
@@ -54,7 +54,7 @@ public interface EnvironmentVariableGroups {
             UpdateRunningEnvironmentVariablesRequest request);
 
     /**
-     * Makes the <a href="apidocs.cloudfoundry.org/latest-releasehttps://apidocs.cloudfoundry.org/latest-release/environment_variable_groups/updating_the_contents_of_the_staging_environment_variable_group.html">Update
+     * Makes the <a href="v2-apidocs.cloudfoundry.orghttps://v2-apidocs.cloudfoundry.org/environment_variable_groups/updating_the_contents_of_the_staging_environment_variable_group.html">Update
      * the Staging Environment Variables</a> request
      *
      * @param request the Update Staging Environment Variables request

--- a/cloudfoundry-client/src/main/java/org/cloudfoundry/client/v2/events/Events.java
+++ b/cloudfoundry-client/src/main/java/org/cloudfoundry/client/v2/events/Events.java
@@ -24,7 +24,7 @@ import reactor.core.publisher.Mono;
 public interface Events {
 
     /**
-     * Makes the <a href="https://apidocs.cloudfoundry.org/latest-release/events/retrieve_a_particular_event.html">Get Event</a> request
+     * Makes the <a href="https://v2-apidocs.cloudfoundry.org/events/retrieve_a_particular_event.html">Get Event</a> request
      *
      * @param request the Get Event request
      * @return the response from the Get Event request
@@ -32,7 +32,7 @@ public interface Events {
     Mono<GetEventResponse> get(GetEventRequest request);
 
     /**
-     * Makes the <a href="https://apidocs.cloudfoundry.org/latest-release/events/list_all_events.html">List Events</a> request
+     * Makes the <a href="https://v2-apidocs.cloudfoundry.org/events/list_all_events.html">List Events</a> request
      *
      * @param request the List Events request
      * @return the response from the List Events request

--- a/cloudfoundry-client/src/main/java/org/cloudfoundry/client/v2/featureflags/FeatureFlags.java
+++ b/cloudfoundry-client/src/main/java/org/cloudfoundry/client/v2/featureflags/FeatureFlags.java
@@ -24,7 +24,7 @@ import reactor.core.publisher.Mono;
 public interface FeatureFlags {
 
     /**
-     * Makes one of the Get feature flags requests. See <a href="https://apidocs.cloudfoundry.org/latest-release">API</a> under Feature Flags.
+     * Makes one of the Get feature flags requests. See <a href="https://v2-apidocs.cloudfoundry.org">API</a> under Feature Flags.
      *
      * @param request the get feature flag request
      * @return the response from the get feature flag request
@@ -32,7 +32,7 @@ public interface FeatureFlags {
     Mono<GetFeatureFlagResponse> get(GetFeatureFlagRequest request);
 
     /**
-     * Makes the <a href="https://apidocs.cloudfoundry.org/latest-release/feature_flags/get_all_feature_flags.html">List Feature Flags</a> request
+     * Makes the <a href="https://v2-apidocs.cloudfoundry.org/feature_flags/get_all_feature_flags.html">List Feature Flags</a> request
      *
      * @param request the list feature flags request
      * @return the response from the list feature flags request
@@ -40,7 +40,7 @@ public interface FeatureFlags {
     Mono<ListFeatureFlagsResponse> list(ListFeatureFlagsRequest request);
 
     /**
-     * Makes the <a href="https://apidocs.cloudfoundry.org/latest-release/feature_flags/set_a_feature_flag.html">Set Feature Flag</a> request
+     * Makes the <a href="https://v2-apidocs.cloudfoundry.org/feature_flags/set_a_feature_flag.html">Set Feature Flag</a> request
      *
      * @param request the set feature flag request
      * @return the response from the set feature flag request

--- a/cloudfoundry-client/src/main/java/org/cloudfoundry/client/v2/info/Info.java
+++ b/cloudfoundry-client/src/main/java/org/cloudfoundry/client/v2/info/Info.java
@@ -24,7 +24,7 @@ import reactor.core.publisher.Mono;
 public interface Info {
 
     /**
-     * Makes the <a href="https://apidocs.cloudfoundry.org/latest-release/info/get_info.html">Get Info</a> request
+     * Makes the <a href="https://v2-apidocs.cloudfoundry.org/info/get_info.html">Get Info</a> request
      *
      * @param request the Get Info request
      * @return the response from the Get Info request

--- a/cloudfoundry-client/src/main/java/org/cloudfoundry/client/v2/jobs/Jobs.java
+++ b/cloudfoundry-client/src/main/java/org/cloudfoundry/client/v2/jobs/Jobs.java
@@ -24,7 +24,7 @@ import reactor.core.publisher.Mono;
 public interface Jobs {
 
     /**
-     * Makes the <a href="https://apidocs.cloudfoundry.org/latest-release/jobs/retrieve_job_that_is_queued.html">Get Job</a> request
+     * Makes the <a href="https://v2-apidocs.cloudfoundry.org/jobs/retrieve_job_that_is_queued.html">Get Job</a> request
      *
      * @param request the Get Job request
      * @return the response from the Get Job request

--- a/cloudfoundry-client/src/main/java/org/cloudfoundry/client/v2/organizationquotadefinitions/OrganizationQuotaDefinitions.java
+++ b/cloudfoundry-client/src/main/java/org/cloudfoundry/client/v2/organizationquotadefinitions/OrganizationQuotaDefinitions.java
@@ -24,7 +24,7 @@ import reactor.core.publisher.Mono;
 public interface OrganizationQuotaDefinitions {
 
     /**
-     * Makes the <a href="https://apidocs.cloudfoundry.org/latest-release/organization_quota_definitions/creating_a_organization_quota_definition.html">Creating an Organization Quota Definition</a>
+     * Makes the <a href="https://v2-apidocs.cloudfoundry.org/organization_quota_definitions/creating_a_organization_quota_definition.html">Creating an Organization Quota Definition</a>
      * request
      *
      * @param request the Create an Organization Quota Definition request
@@ -34,7 +34,7 @@ public interface OrganizationQuotaDefinitions {
             CreateOrganizationQuotaDefinitionRequest request);
 
     /**
-     * Makes the <a href="https://apidocs.cloudfoundry.org/latest-release/organization_quota_definitions/delete_a_particular_organization_quota_definition.html">Delete an Organization Quota
+     * Makes the <a href="https://v2-apidocs.cloudfoundry.org/organization_quota_definitions/delete_a_particular_organization_quota_definition.html">Delete an Organization Quota
      * Definition</a> request
      *
      * @param request the Delete an Organization Quota Definition request
@@ -44,7 +44,7 @@ public interface OrganizationQuotaDefinitions {
             DeleteOrganizationQuotaDefinitionRequest request);
 
     /**
-     * Makes the <a href="https://apidocs.cloudfoundry.org/latest-release/organization_quota_definitions/retrieve_a_particular_organization_quota_definition.html">Retrieve a Particular Organization
+     * Makes the <a href="https://v2-apidocs.cloudfoundry.org/organization_quota_definitions/retrieve_a_particular_organization_quota_definition.html">Retrieve a Particular Organization
      * Quota Definition</a> request
      *
      * @param request the Retrieve a Particular Organization Quota Definition request
@@ -53,7 +53,7 @@ public interface OrganizationQuotaDefinitions {
     Mono<GetOrganizationQuotaDefinitionResponse> get(GetOrganizationQuotaDefinitionRequest request);
 
     /**
-     * Makes the <a href="https://apidocs.cloudfoundry.org/latest-release/organization_quota_definitions/list_all_organization_quota_definitions.html">List all Organization Quota Definitions</a>
+     * Makes the <a href="https://v2-apidocs.cloudfoundry.org/organization_quota_definitions/list_all_organization_quota_definitions.html">List all Organization Quota Definitions</a>
      * request
      *
      * @param request the List all Organization Quota Definitions request
@@ -63,7 +63,7 @@ public interface OrganizationQuotaDefinitions {
             ListOrganizationQuotaDefinitionsRequest request);
 
     /**
-     * Makes the <a href="https://apidocs.cloudfoundry.org/latest-release/organization_quota_definitions/updating_a_organization_quota_definition.html">Update an Organization Quota Definition</a>
+     * Makes the <a href="https://v2-apidocs.cloudfoundry.org/organization_quota_definitions/updating_a_organization_quota_definition.html">Update an Organization Quota Definition</a>
      * request
      *
      * @param request the Update an Organization Quota Definition request

--- a/cloudfoundry-client/src/main/java/org/cloudfoundry/client/v2/organizations/Organizations.java
+++ b/cloudfoundry-client/src/main/java/org/cloudfoundry/client/v2/organizations/Organizations.java
@@ -24,7 +24,7 @@ import reactor.core.publisher.Mono;
 public interface Organizations {
 
     /**
-     * Makes the <a href="https://apidocs.cloudfoundry.org/latest-release/organizations/associate_auditor_with_the_organization.html">Associate Auditor with the Organization</a> request
+     * Makes the <a href="https://v2-apidocs.cloudfoundry.org/organizations/associate_auditor_with_the_organization.html">Associate Auditor with the Organization</a> request
      *
      * @param request the Associate Auditor request
      * @return the response from the Associate Auditor request
@@ -33,7 +33,7 @@ public interface Organizations {
             AssociateOrganizationAuditorRequest request);
 
     /**
-     * Makes the <a href="https://apidocs.cloudfoundry.org/latest-release/organizations/associate_auditor_with_the_organization_by_username.html">Associate Auditor with the Organization by Username</a>
+     * Makes the <a href="https://v2-apidocs.cloudfoundry.org/organizations/associate_auditor_with_the_organization_by_username.html">Associate Auditor with the Organization by Username</a>
      * request
      *
      * @param request the Associate Auditor with an Organization by Username request
@@ -43,7 +43,7 @@ public interface Organizations {
             AssociateOrganizationAuditorByUsernameRequest request);
 
     /**
-     * Makes the <a href="https://apidocs.cloudfoundry.org/latest-release/organizations/associate_billing_manager_with_the_organization.html">Associate Billing Manager with the Organization</a>
+     * Makes the <a href="https://v2-apidocs.cloudfoundry.org/organizations/associate_billing_manager_with_the_organization.html">Associate Billing Manager with the Organization</a>
      * request
      *
      * @param request the Associate Billing Manager with the Organization request
@@ -53,7 +53,7 @@ public interface Organizations {
             AssociateOrganizationBillingManagerRequest request);
 
     /**
-     * Makes the <a href="https://apidocs.cloudfoundry.org/latest-release/organizations/associate_billing_manager_with_the_organization_by_username.html">Associate Billing Manager with the Organization
+     * Makes the <a href="https://v2-apidocs.cloudfoundry.org/organizations/associate_billing_manager_with_the_organization_by_username.html">Associate Billing Manager with the Organization
      * by Username</a> request
      *
      * @param request the Associate Billing Manager with the Organization by Username request
@@ -63,7 +63,7 @@ public interface Organizations {
             AssociateOrganizationBillingManagerByUsernameRequest request);
 
     /**
-     * Makes the <a href="https://apidocs.cloudfoundry.org/latest-release/organizations/associate_manager_with_the_organization.html">Associate Manager with the Organization</a> request
+     * Makes the <a href="https://v2-apidocs.cloudfoundry.org/organizations/associate_manager_with_the_organization.html">Associate Manager with the Organization</a> request
      *
      * @param request the Associate Manager with the Organization request
      * @return the response from the Associate Manager with the Organization request
@@ -72,7 +72,7 @@ public interface Organizations {
             AssociateOrganizationManagerRequest request);
 
     /**
-     * Makes the <a href="https://apidocs.cloudfoundry.org/latest-release/organizations/associate_manager_with_the_organization_by_username.html">Associate Manager with the Organization by Username</a>
+     * Makes the <a href="https://v2-apidocs.cloudfoundry.org/organizations/associate_manager_with_the_organization_by_username.html">Associate Manager with the Organization by Username</a>
      * request
      *
      * @param request the Associate Manager with the Organization by Username request
@@ -82,7 +82,7 @@ public interface Organizations {
             AssociateOrganizationManagerByUsernameRequest request);
 
     /**
-     * Makes the <a href="https://apidocs.cloudfoundry.org/latest-release/organizations/associate_private_domain_with_the_organization.html">Associate Private Domain with the Organization</a> request
+     * Makes the <a href="https://v2-apidocs.cloudfoundry.org/organizations/associate_private_domain_with_the_organization.html">Associate Private Domain with the Organization</a> request
      *
      * @param request the Associate Private Domain with the Organization request
      * @return the response from the Associate Private Domain with the Organization request
@@ -91,7 +91,7 @@ public interface Organizations {
             AssociateOrganizationPrivateDomainRequest request);
 
     /**
-     * Makes the <a href="https://apidocs.cloudfoundry.org/latest-release/organizations/associate_user_with_the_organization.html">Associate User with the Organization</a> request
+     * Makes the <a href="https://v2-apidocs.cloudfoundry.org/organizations/associate_user_with_the_organization.html">Associate User with the Organization</a> request
      *
      * @param request the Associate User with the Organization request
      * @return the response from the Associate User with the Organization request
@@ -99,7 +99,7 @@ public interface Organizations {
     Mono<AssociateOrganizationUserResponse> associateUser(AssociateOrganizationUserRequest request);
 
     /**
-     * Makes the <a href="https://apidocs.cloudfoundry.org/latest-release/organizations/associate_user_with_the_organization_by_username.html">Associate User with the Organization by Username</a>
+     * Makes the <a href="https://v2-apidocs.cloudfoundry.org/organizations/associate_user_with_the_organization_by_username.html">Associate User with the Organization by Username</a>
      * request
      *
      * @param request the Associate User with the Organization by Username request
@@ -109,7 +109,7 @@ public interface Organizations {
             AssociateOrganizationUserByUsernameRequest request);
 
     /**
-     * Makes the <a href="https://apidocs.cloudfoundry.org/latest-release/organizations/creating_an_organization.html">Creating an Organization</a> request
+     * Makes the <a href="https://v2-apidocs.cloudfoundry.org/organizations/creating_an_organization.html">Creating an Organization</a> request
      *
      * @param request the Creating an Organization request
      * @return the response from the Creating an Organization request
@@ -117,7 +117,7 @@ public interface Organizations {
     Mono<CreateOrganizationResponse> create(CreateOrganizationRequest request);
 
     /**
-     * Makes the <a href="https://apidocs.cloudfoundry.org/latest-release/organizations/delete_a_particular_organization.html">Delete a Particular Organization</a> request
+     * Makes the <a href="https://v2-apidocs.cloudfoundry.org/organizations/delete_a_particular_organization.html">Delete a Particular Organization</a> request
      *
      * @param request the Delete a Particular Organization request
      * @return the response from the Delete a Particular Organization request
@@ -125,7 +125,7 @@ public interface Organizations {
     Mono<DeleteOrganizationResponse> delete(DeleteOrganizationRequest request);
 
     /**
-     * Makes the <a href="https://apidocs.cloudfoundry.org/latest-release/organizations/retrieve_a_particular_organization.html">Retrieve a Particular Organization</a> request
+     * Makes the <a href="https://v2-apidocs.cloudfoundry.org/organizations/retrieve_a_particular_organization.html">Retrieve a Particular Organization</a> request
      *
      * @param request the Retrieve a Particular Organization request
      * @return the response from the Retrieve a Particular Organization request
@@ -133,7 +133,7 @@ public interface Organizations {
     Mono<GetOrganizationResponse> get(GetOrganizationRequest request);
 
     /**
-     * Makes the <a href="https://apidocs.cloudfoundry.org/latest-release/organizations/retrieving_organization_instance_usage.html">Retrieving organization instance usage</a> request
+     * Makes the <a href="https://v2-apidocs.cloudfoundry.org/organizations/retrieving_organization_instance_usage.html">Retrieving organization instance usage</a> request
      *
      * @param request the Retrieving organization instance usage request
      * @return the response from the Retrieving organization instance usage request
@@ -142,7 +142,7 @@ public interface Organizations {
             GetOrganizationInstanceUsageRequest request);
 
     /**
-     * Makes the <a href="https://apidocs.cloudfoundry.org/latest-release/organizations/retrieving_organization_memory_usage.html">Retrieving organization memory usage</a> request
+     * Makes the <a href="https://v2-apidocs.cloudfoundry.org/organizations/retrieving_organization_memory_usage.html">Retrieving organization memory usage</a> request
      *
      * @param request the Retrieving organization memory usage request
      * @return the response from the Retrieving organization memory usage request
@@ -151,7 +151,7 @@ public interface Organizations {
             GetOrganizationMemoryUsageRequest request);
 
     /**
-     * Makes the <a href="https://apidocs.cloudfoundry.org/latest-release/organizations/retrieving_the_roles_of_all_users_in_the_organization.html">Retrieving the roles of all Users in the
+     * Makes the <a href="https://v2-apidocs.cloudfoundry.org/organizations/retrieving_the_roles_of_all_users_in_the_organization.html">Retrieving the roles of all Users in the
      * Organization</a> request
      *
      * @param request the Retrieving the roles of all Users in the Organization request
@@ -160,7 +160,7 @@ public interface Organizations {
     Mono<GetOrganizationUserRolesResponse> getUserRoles(GetOrganizationUserRolesRequest request);
 
     /**
-     * Makes the <a href="https://apidocs.cloudfoundry.org/latest-release/organizations/list_all_organizations.html">List Organizations</a> request
+     * Makes the <a href="https://v2-apidocs.cloudfoundry.org/organizations/list_all_organizations.html">List Organizations</a> request
      *
      * @param request the List Organizations request
      * @return the response from the List Organizations request
@@ -168,7 +168,7 @@ public interface Organizations {
     Mono<ListOrganizationsResponse> list(ListOrganizationsRequest request);
 
     /**
-     * Makes the <a href="https://apidocs.cloudfoundry.org/latest-release/organizations/list_all_auditors_for_the_organization.html">List all Auditors for the Organization</a> request
+     * Makes the <a href="https://v2-apidocs.cloudfoundry.org/organizations/list_all_auditors_for_the_organization.html">List all Auditors for the Organization</a> request
      *
      * @param request the List all Auditors for the Organization request
      * @return the response from the List all Auditors for the Organization request
@@ -176,7 +176,7 @@ public interface Organizations {
     Mono<ListOrganizationAuditorsResponse> listAuditors(ListOrganizationAuditorsRequest request);
 
     /**
-     * Makes the <a href="https://apidocs.cloudfoundry.org/latest-release/organizations/list_all_billing_managers_for_the_organization.html">List all Billing Managers for the Organization</a> request
+     * Makes the <a href="https://v2-apidocs.cloudfoundry.org/organizations/list_all_billing_managers_for_the_organization.html">List all Billing Managers for the Organization</a> request
      *
      * @param request the List all Billing Managers for the Organization request
      * @return the response from the List all Billing Managers for the Organization request
@@ -185,7 +185,7 @@ public interface Organizations {
             ListOrganizationBillingManagersRequest request);
 
     /**
-     * <a href="https://apidocs.cloudfoundry.org/latest-release/organizations/list_all_domains_for_the_organization_%28deprecated%29.html">List all Domains for the Organization</a> request
+     * <a href="https://v2-apidocs.cloudfoundry.org/organizations/list_all_domains_for_the_organization_%28deprecated%29.html">List all Domains for the Organization</a> request
      *
      * @param request the List all Domains for the Organization request
      * @return the response from the List all Domains for the Organization request
@@ -194,7 +194,7 @@ public interface Organizations {
     Mono<ListOrganizationDomainsResponse> listDomains(ListOrganizationDomainsRequest request);
 
     /**
-     * Makes the <a href="https://apidocs.cloudfoundry.org/latest-release/organizations/list_all_managers_for_the_organization.html">List all Managers for the Organization</a> request
+     * Makes the <a href="https://v2-apidocs.cloudfoundry.org/organizations/list_all_managers_for_the_organization.html">List all Managers for the Organization</a> request
      *
      * @param request the List all Managers for the Organization request
      * @return the response from the List all Managers for the Organization request
@@ -202,7 +202,7 @@ public interface Organizations {
     Mono<ListOrganizationManagersResponse> listManagers(ListOrganizationManagersRequest request);
 
     /**
-     * <a href="https://apidocs.cloudfoundry.org/latest-release/organizations/list_all_private_domains_for_the_organization.html">List all Private Domains for the Organization</a> request
+     * <a href="https://v2-apidocs.cloudfoundry.org/organizations/list_all_private_domains_for_the_organization.html">List all Private Domains for the Organization</a> request
      *
      * @param request the List all Private Domains for the Organization request
      * @return the response from the List all Private Domains for the Organization request
@@ -211,7 +211,7 @@ public interface Organizations {
             ListOrganizationPrivateDomainsRequest request);
 
     /**
-     * Makes the <a href="https://apidocs.cloudfoundry.org/latest-release/organizations/list_all_services_for_the_organization.html">List all Services for the Organization</a> request
+     * Makes the <a href="https://v2-apidocs.cloudfoundry.org/organizations/list_all_services_for_the_organization.html">List all Services for the Organization</a> request
      *
      * @param request the List all Services for the Organization request
      * @return the response from the List all Services for the Organization request
@@ -219,7 +219,7 @@ public interface Organizations {
     Mono<ListOrganizationServicesResponse> listServices(ListOrganizationServicesRequest request);
 
     /**
-     * Makes the <a href="https://apidocs.cloudfoundry.org/latest-release/organizations/list_all_space_quota_definitions_for_the_organization.html">List all Space Quota Definitions for the
+     * Makes the <a href="https://v2-apidocs.cloudfoundry.org/organizations/list_all_space_quota_definitions_for_the_organization.html">List all Space Quota Definitions for the
      * Organization</a> request
      *
      * @param request the List all Space Quota Definitions for the Organization request
@@ -229,7 +229,7 @@ public interface Organizations {
             ListOrganizationSpaceQuotaDefinitionsRequest request);
 
     /**
-     * Makes the <a href="https://apidocs.cloudfoundry.org/latest-release/organizations/list_all_spaces_for_the_organization.html">List all Spaces for the Organization</a> request
+     * Makes the <a href="https://v2-apidocs.cloudfoundry.org/organizations/list_all_spaces_for_the_organization.html">List all Spaces for the Organization</a> request
      *
      * @param request the List all Spaces for the Organization request
      * @return the response from the List all Spaces for the Organization request
@@ -237,7 +237,7 @@ public interface Organizations {
     Mono<ListOrganizationSpacesResponse> listSpaces(ListOrganizationSpacesRequest request);
 
     /**
-     * Makes the <a href="https://apidocs.cloudfoundry.org/latest-release/organizations/list_all_users_for_the_organization.html">List all Users for the Organization</a> request
+     * Makes the <a href="https://v2-apidocs.cloudfoundry.org/organizations/list_all_users_for_the_organization.html">List all Users for the Organization</a> request
      *
      * @param request the List all Users for the Organization request
      * @return the response from the List all Users for the Organization request
@@ -245,7 +245,7 @@ public interface Organizations {
     Mono<ListOrganizationUsersResponse> listUsers(ListOrganizationUsersRequest request);
 
     /**
-     * Makes the <a href="https://apidocs.cloudfoundry.org/latest-release/organizations/remove_auditor_from_the_organization.html">Remove Auditor from the Organization</a> request
+     * Makes the <a href="https://v2-apidocs.cloudfoundry.org/organizations/remove_auditor_from_the_organization.html">Remove Auditor from the Organization</a> request
      *
      * @param request the Remove Auditor from the Organization request
      * @return the response from the Remove Auditor from the Organization request
@@ -253,7 +253,7 @@ public interface Organizations {
     Mono<Void> removeAuditor(RemoveOrganizationAuditorRequest request);
 
     /**
-     * Makes the <a href="https://apidocs.cloudfoundry.org/latest-release/organizations/disassociate_auditor_with_the_organization_by_username.html">Disassociate Auditor with the Organization by
+     * Makes the <a href="https://v2-apidocs.cloudfoundry.org/organizations/disassociate_auditor_with_the_organization_by_username.html">Disassociate Auditor with the Organization by
      * Username</a> request
      *
      * @param request the Remove Auditor with the Organization By Username request
@@ -262,7 +262,7 @@ public interface Organizations {
     Mono<Void> removeAuditorByUsername(RemoveOrganizationAuditorByUsernameRequest request);
 
     /**
-     * Makes the <a href="https://apidocs.cloudfoundry.org/latest-release/organizations/remove_billing_manager_from_the_organization.html">Remove Billing Manager from the Organization</a> request
+     * Makes the <a href="https://v2-apidocs.cloudfoundry.org/organizations/remove_billing_manager_from_the_organization.html">Remove Billing Manager from the Organization</a> request
      *
      * @param request the Remove Billing Manager from the Organization request
      * @return the response from the Remove Billing Manager from the Organization request
@@ -270,7 +270,7 @@ public interface Organizations {
     Mono<Void> removeBillingManager(RemoveOrganizationBillingManagerRequest request);
 
     /**
-     * Makes the <a href="https://apidocs.cloudfoundry.org/latest-release/organizations/disassociate_billing_manager_with_the_organization_by_username.html">Disassociate Billing Manager with the
+     * Makes the <a href="https://v2-apidocs.cloudfoundry.org/organizations/disassociate_billing_manager_with_the_organization_by_username.html">Disassociate Billing Manager with the
      * Organization by Username</a> request
      *
      * @param request the Disassociate Billing Manager with the Organization by Username request
@@ -280,7 +280,7 @@ public interface Organizations {
             RemoveOrganizationBillingManagerByUsernameRequest request);
 
     /**
-     * Makes the <a href="https://apidocs.cloudfoundry.org/latest-release/organizations/remove_manager_from_the_organization.html">Remove Manager from the Organization</a> request
+     * Makes the <a href="https://v2-apidocs.cloudfoundry.org/organizations/remove_manager_from_the_organization.html">Remove Manager from the Organization</a> request
      *
      * @param request the Remove Manager from the Organization request
      * @return the response from the Remove Manager from the Organization request
@@ -288,7 +288,7 @@ public interface Organizations {
     Mono<Void> removeManager(RemoveOrganizationManagerRequest request);
 
     /**
-     * Makes the <a href="https://apidocs.cloudfoundry.org/latest-release/organizations/disassociate_manager_with_the_organization_by_username.html">Disassociate Manager with the Organization by
+     * Makes the <a href="https://v2-apidocs.cloudfoundry.org/organizations/disassociate_manager_with_the_organization_by_username.html">Disassociate Manager with the Organization by
      * Username</a> request
      *
      * @param request the Disassociate Manager with the Organization by Username request
@@ -297,7 +297,7 @@ public interface Organizations {
     Mono<Void> removeManagerByUsername(RemoveOrganizationManagerByUsernameRequest request);
 
     /**
-     * Makes the <a href="https://apidocs.cloudfoundry.org/latest-release/organizations/remove_private_domain_from_the_organization.html">Remove Private Domain from the Organization</a> request
+     * Makes the <a href="https://v2-apidocs.cloudfoundry.org/organizations/remove_private_domain_from_the_organization.html">Remove Private Domain from the Organization</a> request
      *
      * @param request the Remove Private Domain from the Organization request
      * @return the response from the Remove Private Domain from the Organization request
@@ -305,7 +305,7 @@ public interface Organizations {
     Mono<Void> removePrivateDomain(RemoveOrganizationPrivateDomainRequest request);
 
     /**
-     * Makes the <a href="https://apidocs.cloudfoundry.org/latest-release/organizations/remove_user_from_the_organization.html">Remove User from the Organization</a> request
+     * Makes the <a href="https://v2-apidocs.cloudfoundry.org/organizations/remove_user_from_the_organization.html">Remove User from the Organization</a> request
      *
      * @param request the Remove User from the Organization request
      * @return the response from the Remove User from the Organization request
@@ -313,7 +313,7 @@ public interface Organizations {
     Mono<Void> removeUser(RemoveOrganizationUserRequest request);
 
     /**
-     * Makes the <a href="https://apidocs.cloudfoundry.org/latest-release/organizations/disassociate_user_with_the_organization_by_username.html">Disassociate User with the Organization by Username</a>
+     * Makes the <a href="https://v2-apidocs.cloudfoundry.org/organizations/disassociate_user_with_the_organization_by_username.html">Disassociate User with the Organization by Username</a>
      * request
      *
      * @param request the Disassociate User with the Organization by Username request
@@ -322,7 +322,7 @@ public interface Organizations {
     Mono<Void> removeUserByUsername(RemoveOrganizationUserByUsernameRequest request);
 
     /**
-     * Makes the <a href="https://apidocs.cloudfoundry.org/latest-release/organizations/get_organization_summary.html">Get Organization summary</a> request
+     * Makes the <a href="https://v2-apidocs.cloudfoundry.org/organizations/get_organization_summary.html">Get Organization summary</a> request
      *
      * @param request the Organization summary request
      * @return the response from the Organization summary request
@@ -330,7 +330,7 @@ public interface Organizations {
     Mono<SummaryOrganizationResponse> summary(SummaryOrganizationRequest request);
 
     /**
-     * Makes the <a href="https://apidocs.cloudfoundry.org/latest-release/organizations/update_an_organization.html">Update an Organization</a> request
+     * Makes the <a href="https://v2-apidocs.cloudfoundry.org/organizations/update_an_organization.html">Update an Organization</a> request
      *
      * @param request the Update an Organization request
      * @return the response from the Update an Organization request

--- a/cloudfoundry-client/src/main/java/org/cloudfoundry/client/v2/privatedomains/PrivateDomains.java
+++ b/cloudfoundry-client/src/main/java/org/cloudfoundry/client/v2/privatedomains/PrivateDomains.java
@@ -24,7 +24,7 @@ import reactor.core.publisher.Mono;
 public interface PrivateDomains {
 
     /**
-     * Makes the <a href="https://apidocs.cloudfoundry.org/latest-release/private_domains/create_a_private_domain_owned_by_the_given_organization.html">Create a Private Domain owned by the given
+     * Makes the <a href="https://v2-apidocs.cloudfoundry.org/private_domains/create_a_private_domain_owned_by_the_given_organization.html">Create a Private Domain owned by the given
      * Organization</a> request
      *
      * @param request the Create a Private Domain request
@@ -33,7 +33,7 @@ public interface PrivateDomains {
     Mono<CreatePrivateDomainResponse> create(CreatePrivateDomainRequest request);
 
     /**
-     * Makes the <a href="https://apidocs.cloudfoundry.org/latest-release/private_domains/delete_a_particular_private_domain.html">Delete a Particular Private Domain</a> request
+     * Makes the <a href="https://v2-apidocs.cloudfoundry.org/private_domains/delete_a_particular_private_domain.html">Delete a Particular Private Domain</a> request
      *
      * @param request the Delete Private Domain request
      * @return the response from the Delete Private Domain request
@@ -41,7 +41,7 @@ public interface PrivateDomains {
     Mono<DeletePrivateDomainResponse> delete(DeletePrivateDomainRequest request);
 
     /**
-     * Makes the <a href="https://apidocs.cloudfoundry.org/latest-release/private_domains/retrieve_a_particular_private_domain.html">Retrieve a Particular Private Domain</a> request
+     * Makes the <a href="https://v2-apidocs.cloudfoundry.org/private_domains/retrieve_a_particular_private_domain.html">Retrieve a Particular Private Domain</a> request
      *
      * @param request the Get Private Domain request
      * @return the response from the Get Private Domain request
@@ -49,7 +49,7 @@ public interface PrivateDomains {
     Mono<GetPrivateDomainResponse> get(GetPrivateDomainRequest request);
 
     /**
-     * Makes the <a href="https://apidocs.cloudfoundry.org/latest-release/private_domains/filtering_private_domains_by_name.html">List Private Domains</a> request
+     * Makes the <a href="https://v2-apidocs.cloudfoundry.org/private_domains/filtering_private_domains_by_name.html">List Private Domains</a> request
      *
      * @param request the List Private Domains request
      * @return the response from the List Private Domains request
@@ -57,7 +57,7 @@ public interface PrivateDomains {
     Mono<ListPrivateDomainsResponse> list(ListPrivateDomainsRequest request);
 
     /**
-     * Makes the <a href="https://apidocs.cloudfoundry.org/latest-release/private_domains/list_all_shared_organizations_for_the_private_domain.html">List all Shared Organizations for the Private
+     * Makes the <a href="https://v2-apidocs.cloudfoundry.org/private_domains/list_all_shared_organizations_for_the_private_domain.html">List all Shared Organizations for the Private
      * Domain</a> request
      *
      * @param request the List Private Domain Shared Organizations request

--- a/cloudfoundry-client/src/main/java/org/cloudfoundry/client/v2/resourcematch/ResourceMatch.java
+++ b/cloudfoundry-client/src/main/java/org/cloudfoundry/client/v2/resourcematch/ResourceMatch.java
@@ -24,7 +24,7 @@ import reactor.core.publisher.Mono;
 public interface ResourceMatch {
 
     /**
-     * Makes the <a href="https://apidocs.cloudfoundry.org/latest-release/resource_match/list_all_matching_resources.html">List Matching Resources</a> request
+     * Makes the <a href="https://v2-apidocs.cloudfoundry.org/resource_match/list_all_matching_resources.html">List Matching Resources</a> request
      *
      * @param request the List Matching Resources request
      * @return the response from the List Matching Resources request

--- a/cloudfoundry-client/src/main/java/org/cloudfoundry/client/v2/routemappings/RouteMappings.java
+++ b/cloudfoundry-client/src/main/java/org/cloudfoundry/client/v2/routemappings/RouteMappings.java
@@ -24,7 +24,7 @@ import reactor.core.publisher.Mono;
 public interface RouteMappings {
 
     /**
-     * Makes the <a href="https://apidocs.cloudfoundry.org/latest-release/routes_mapping/mapping_an_app_and_a_route.html">Creating a Route Mapping</a> request
+     * Makes the <a href="https://v2-apidocs.cloudfoundry.org/routes_mapping/mapping_an_app_and_a_route.html">Creating a Route Mapping</a> request
      *
      * @param request the Creating a Route Mapping request
      * @return the response from the Creating a Route Mapping request
@@ -32,7 +32,7 @@ public interface RouteMappings {
     Mono<CreateRouteMappingResponse> create(CreateRouteMappingRequest request);
 
     /**
-     * Makes the <a href="https://apidocs.cloudfoundry.org/latest-release/routes_mapping/delete_a_particular_route_mapping.html">Deleting a Route Mapping</a> request
+     * Makes the <a href="https://v2-apidocs.cloudfoundry.org/routes_mapping/delete_a_particular_route_mapping.html">Deleting a Route Mapping</a> request
      *
      * @param request the Delete a Route Mapping request
      * @return the response from deleting a Route Mapping request
@@ -40,7 +40,7 @@ public interface RouteMappings {
     Mono<DeleteRouteMappingResponse> delete(DeleteRouteMappingRequest request);
 
     /**
-     * Makes the <a href="https://apidocs.cloudfoundry.org/latest-release/routes_mapping/retrieve_a_particular_route_mapping.html">Retrieve a Particular Route Mapping</a> request
+     * Makes the <a href="https://v2-apidocs.cloudfoundry.org/routes_mapping/retrieve_a_particular_route_mapping.html">Retrieve a Particular Route Mapping</a> request
      *
      * @param request the Get a Particular Route Mapping request
      * @return the response from the Get a Particular Route Mapping request
@@ -48,7 +48,7 @@ public interface RouteMappings {
     Mono<GetRouteMappingResponse> get(GetRouteMappingRequest request);
 
     /**
-     * Makes the <a href="https://apidocs.cloudfoundry.org/latest-release/routes_mapping/list_all_route_mappings.html">List Route Mappings</a> request
+     * Makes the <a href="https://v2-apidocs.cloudfoundry.org/routes_mapping/list_all_route_mappings.html">List Route Mappings</a> request
      *
      * @param request the List Route Mappings request
      * @return the response from the List Route Mappings request

--- a/cloudfoundry-client/src/main/java/org/cloudfoundry/client/v2/routes/Routes.java
+++ b/cloudfoundry-client/src/main/java/org/cloudfoundry/client/v2/routes/Routes.java
@@ -24,7 +24,7 @@ import reactor.core.publisher.Mono;
 public interface Routes {
 
     /**
-     * Makes the <a href="https://apidocs.cloudfoundry.org/latest-release/routes/associate_app_with_the_route.html">Associate Application with the Route</a> request
+     * Makes the <a href="https://v2-apidocs.cloudfoundry.org/routes/associate_app_with_the_route.html">Associate Application with the Route</a> request
      *
      * @param request the Associate an Application with the Route request
      * @return the response from the Associate an Application with the Route request
@@ -33,7 +33,7 @@ public interface Routes {
             AssociateRouteApplicationRequest request);
 
     /**
-     * Makes the <a href="https://apidocs.cloudfoundry.org/latest-release/routes/creating_a_route.html">Creating a Route</a> request
+     * Makes the <a href="https://v2-apidocs.cloudfoundry.org/routes/creating_a_route.html">Creating a Route</a> request
      *
      * @param request the Creating a Route request
      * @return the response from the Creating a Route request
@@ -41,7 +41,7 @@ public interface Routes {
     Mono<CreateRouteResponse> create(CreateRouteRequest request);
 
     /**
-     * Makes the <a href="https://apidocs.cloudfoundry.org/latest-release/routes/delete_a_particular_route.html">Delete a Particular Route</a> request
+     * Makes the <a href="https://v2-apidocs.cloudfoundry.org/routes/delete_a_particular_route.html">Delete a Particular Route</a> request
      *
      * @param request the Delete a Particular Route request
      * @return the response from the Delete a Particular Route request
@@ -49,7 +49,7 @@ public interface Routes {
     Mono<DeleteRouteResponse> delete(DeleteRouteRequest request);
 
     /**
-     * Makes the <a href="https://apidocs.cloudfoundry.org/latest-release/routes/check_a_route_exists.html">Check a Route exists</a> request
+     * Makes the <a href="https://v2-apidocs.cloudfoundry.org/routes/check_a_route_exists.html">Check a Route exists</a> request
      *
      * @param request the Check a Route exists request
      * @return the response from the Check a Route exists request
@@ -57,7 +57,7 @@ public interface Routes {
     Mono<Boolean> exists(RouteExistsRequest request);
 
     /**
-     * Makes the <a href="https://apidocs.cloudfoundry.org/latest-release/routes/retrieve_a_particular_route.html">Retrieve a Particular Route</a> request
+     * Makes the <a href="https://v2-apidocs.cloudfoundry.org/routes/retrieve_a_particular_route.html">Retrieve a Particular Route</a> request
      *
      * @param request the Retrieve a Particular Route request
      * @return the response from the Retrieve a Particular Route request
@@ -65,7 +65,7 @@ public interface Routes {
     Mono<GetRouteResponse> get(GetRouteRequest request);
 
     /**
-     * Makes the <a href="https://apidocs.cloudfoundry.org/latest-release/routes/list_all_routes.html">List all Routes</a> request
+     * Makes the <a href="https://v2-apidocs.cloudfoundry.org/routes/list_all_routes.html">List all Routes</a> request
      *
      * @param request the List all Applications for the Route request
      * @return the response from the List all Applications for the Route request
@@ -73,7 +73,7 @@ public interface Routes {
     Mono<ListRoutesResponse> list(ListRoutesRequest request);
 
     /**
-     * Makes the <a href="https://apidocs.cloudfoundry.org/latest-release/routes/list_all_apps_for_the_route.html">List all Applications for the Route</a> request
+     * Makes the <a href="https://v2-apidocs.cloudfoundry.org/routes/list_all_apps_for_the_route.html">List all Applications for the Route</a> request
      *
      * @param request the List all Applications for the Route request
      * @return the response from the List all Applications for the Route request
@@ -81,7 +81,7 @@ public interface Routes {
     Mono<ListRouteApplicationsResponse> listApplications(ListRouteApplicationsRequest request);
 
     /**
-     * Makes the <a href="https://apidocs.cloudfoundry.org/latest-release/routes/list_all_route_mappings_for_the_route.html">List all Route Mappings for the Route</a> request
+     * Makes the <a href="https://v2-apidocs.cloudfoundry.org/routes/list_all_route_mappings_for_the_route.html">List all Route Mappings for the Route</a> request
      *
      * @param request the List all Route Mappings for the Route request
      * @return the response from the List all Route Mappings for the Route request
@@ -89,7 +89,7 @@ public interface Routes {
     Mono<ListRouteMappingsResponse> listMappings(ListRouteMappingsRequest request);
 
     /**
-     * Makes the <a href="https://apidocs.cloudfoundry.org/latest-release/routes/remove_app_from_the_route.html">Remove Application from the Route</a> request
+     * Makes the <a href="https://v2-apidocs.cloudfoundry.org/routes/remove_app_from_the_route.html">Remove Application from the Route</a> request
      *
      * @param request the Remove Application from the Route request
      * @return the response from the Remove Application from the Route request
@@ -97,7 +97,7 @@ public interface Routes {
     Mono<Void> removeApplication(RemoveRouteApplicationRequest request);
 
     /**
-     * Makes the <a href="https://apidocs.cloudfoundry.org/latest-release/routes/update_a_route.html">Update a Route</a> request
+     * Makes the <a href="https://v2-apidocs.cloudfoundry.org/routes/update_a_route.html">Update a Route</a> request
      *
      * @param request the Update a Route request
      * @return the response from the Update a Route request

--- a/cloudfoundry-client/src/main/java/org/cloudfoundry/client/v2/securitygroups/SecurityGroups.java
+++ b/cloudfoundry-client/src/main/java/org/cloudfoundry/client/v2/securitygroups/SecurityGroups.java
@@ -21,7 +21,7 @@ import reactor.core.publisher.Mono;
 public interface SecurityGroups {
 
     /**
-     * Makes the <a href="https://apidocs.cloudfoundry.org/latest-release/security_groups/associate_space_with_the_security_group.html">Associate Space with the Security Group</a> request.
+     * Makes the <a href="https://v2-apidocs.cloudfoundry.org/security_groups/associate_space_with_the_security_group.html">Associate Space with the Security Group</a> request.
      *
      * @param request the associate security group space request
      * @return the response from the associate security group space request
@@ -30,7 +30,7 @@ public interface SecurityGroups {
             AssociateSecurityGroupSpaceRequest request);
 
     /**
-     * Makes the <a href="https://apidocs.cloudfoundry.org/latest-release/security_groups/creating_a_security_group.html">Creating a Security Group</a> request.
+     * Makes the <a href="https://v2-apidocs.cloudfoundry.org/security_groups/creating_a_security_group.html">Creating a Security Group</a> request.
      *
      * @param request the create security group request
      * @return the response from the create security group request
@@ -38,7 +38,7 @@ public interface SecurityGroups {
     Mono<CreateSecurityGroupResponse> create(CreateSecurityGroupRequest request);
 
     /**
-     * Makes the <a href="https://apidocs.cloudfoundry.org/latest-release/security_groups/delete_a_particular_security_group.html">Delete a Particular Security Group</a> request.
+     * Makes the <a href="https://v2-apidocs.cloudfoundry.org/security_groups/delete_a_particular_security_group.html">Delete a Particular Security Group</a> request.
      *
      * @param request the delete security group request
      * @return the response from the delete security group request
@@ -46,7 +46,7 @@ public interface SecurityGroups {
     Mono<DeleteSecurityGroupResponse> delete(DeleteSecurityGroupRequest request);
 
     /**
-     * Makes the <a href="https://apidocs.cloudfoundry.org/latest-release/security_groups/retrieve_a_particular_security_group.html">Retrieve a Particular Security Group</a> request.
+     * Makes the <a href="https://v2-apidocs.cloudfoundry.org/security_groups/retrieve_a_particular_security_group.html">Retrieve a Particular Security Group</a> request.
      *
      * @param request the get security groups request
      * @return the response from the get security groups request
@@ -54,7 +54,7 @@ public interface SecurityGroups {
     Mono<GetSecurityGroupResponse> get(GetSecurityGroupRequest request);
 
     /**
-     * Makes the <a href="https://apidocs.cloudfoundry.org/latest-release/security_groups/list_all_security_groups.html">List all Security Groups</a> request.
+     * Makes the <a href="https://v2-apidocs.cloudfoundry.org/security_groups/list_all_security_groups.html">List all Security Groups</a> request.
      *
      * @param request the list all security groups request
      * @return the response from the list all security groups request
@@ -62,7 +62,7 @@ public interface SecurityGroups {
     Mono<ListSecurityGroupsResponse> list(ListSecurityGroupsRequest request);
 
     /**
-     * Makes the <a href="https://apidocs.cloudfoundry.org/latest-release/security_group_running_defaults/return_the_security_groups_used_for_running_apps.html">List Running Security Groups</a>
+     * Makes the <a href="https://v2-apidocs.cloudfoundry.org/security_group_running_defaults/return_the_security_groups_used_for_running_apps.html">List Running Security Groups</a>
      * request.
      *
      * @param request the list running security groups request
@@ -72,7 +72,7 @@ public interface SecurityGroups {
             ListSecurityGroupRunningDefaultsRequest request);
 
     /**
-     * Makes the <a href="https://apidocs.cloudfoundry.org/latest-release/security_groups/list_all_spaces_for_the_security_group.html">List all Spaces for the Security Group</a> request.
+     * Makes the <a href="https://v2-apidocs.cloudfoundry.org/security_groups/list_all_spaces_for_the_security_group.html">List all Spaces for the Security Group</a> request.
      *
      * @param request the list all spaces for the security group request
      * @return the response from the list all spaces for the security group request
@@ -80,7 +80,7 @@ public interface SecurityGroups {
     Mono<ListSecurityGroupSpacesResponse> listSpaces(ListSecurityGroupSpacesRequest request);
 
     /**
-     * Makes the <a href="https://apidocs.cloudfoundry.org/latest-release/security_group_staging_defaults/return_the_security_groups_used_for_staging.html">List Staging Security Groups</a> request.
+     * Makes the <a href="https://v2-apidocs.cloudfoundry.org/security_group_staging_defaults/return_the_security_groups_used_for_staging.html">List Staging Security Groups</a> request.
      *
      * @param request the list staging security groups request
      * @return the response from the list staging security groups request
@@ -89,7 +89,7 @@ public interface SecurityGroups {
             ListSecurityGroupStagingDefaultsRequest request);
 
     /**
-     * Makes the <a href="https://apidocs.cloudfoundry.org/latest-release/security_group_running_defaults/removing_a_security_group_as_a_default_for_running_apps.html">
+     * Makes the <a href="https://v2-apidocs.cloudfoundry.org/security_group_running_defaults/removing_a_security_group_as_a_default_for_running_apps.html">
      * Removing a Security Group as a default for running Apps</a> request.
      *
      * @param request the remove running security group request
@@ -98,7 +98,7 @@ public interface SecurityGroups {
     Mono<Void> removeRunningDefault(RemoveSecurityGroupRunningDefaultRequest request);
 
     /**
-     * Makes the <a href="https://apidocs.cloudfoundry.org/latest-release/security_groups/remove_space_from_the_security_group.html">Remove Space from the Security Group</a> request.
+     * Makes the <a href="https://v2-apidocs.cloudfoundry.org/security_groups/remove_space_from_the_security_group.html">Remove Space from the Security Group</a> request.
      *
      * @param request the remove security group space request
      * @return the response from the remove security group space request
@@ -106,7 +106,7 @@ public interface SecurityGroups {
     Mono<Void> removeSpace(RemoveSecurityGroupSpaceRequest request);
 
     /**
-     * Makes the <a href="https://apidocs.cloudfoundry.org/latest-release/security_group_staging_defaults/removing_a_security_group_as_a_default_for_staging.html">
+     * Makes the <a href="https://v2-apidocs.cloudfoundry.org/security_group_staging_defaults/removing_a_security_group_as_a_default_for_staging.html">
      * Removing a Security Group as a default for staging</a> request.
      *
      * @param request the remove staging security group request
@@ -115,7 +115,7 @@ public interface SecurityGroups {
     Mono<Void> removeStagingDefault(RemoveSecurityGroupStagingDefaultRequest request);
 
     /**
-     * Makes the <a href="https://apidocs.cloudfoundry.org/latest-release/security_group_running_defaults/set_a_security_group_as_a_default_for_running_apps.html">Set a Security Group as a default for
+     * Makes the <a href="https://v2-apidocs.cloudfoundry.org/security_group_running_defaults/set_a_security_group_as_a_default_for_running_apps.html">Set a Security Group as a default for
      * running Apps</a> request.
      *
      * @param request the list running security groups request
@@ -125,7 +125,7 @@ public interface SecurityGroups {
             SetSecurityGroupRunningDefaultRequest request);
 
     /**
-     * Makes the <a href="https://apidocs.cloudfoundry.org/latest-release/security_group_staging_defaults/set_a_security_group_as_a_default_for_staging.html">Set a Security Group as a default for
+     * Makes the <a href="https://v2-apidocs.cloudfoundry.org/security_group_staging_defaults/set_a_security_group_as_a_default_for_staging.html">Set a Security Group as a default for
      * staging Apps</a> request.
      *
      * @param request the list staging security groups request
@@ -135,7 +135,7 @@ public interface SecurityGroups {
             SetSecurityGroupStagingDefaultRequest request);
 
     /**
-     * Makes the <a href="https://apidocs.cloudfoundry.org/latest-release/security_groups/updating_a_security_group.html">Updating a Security Group</a> request.
+     * Makes the <a href="https://v2-apidocs.cloudfoundry.org/security_groups/updating_a_security_group.html">Updating a Security Group</a> request.
      *
      * @param request the update security group request
      * @return the response from the update security group request

--- a/cloudfoundry-client/src/main/java/org/cloudfoundry/client/v2/servicebindings/ServiceBindingsV2.java
+++ b/cloudfoundry-client/src/main/java/org/cloudfoundry/client/v2/servicebindings/ServiceBindingsV2.java
@@ -24,7 +24,7 @@ import reactor.core.publisher.Mono;
 public interface ServiceBindingsV2 {
 
     /**
-     * Makes the <a href="https://apidocs.cloudfoundry.org/latest-release/service_bindings/create_a_service_binding.html">Create Service Binding</a> request
+     * Makes the <a href="https://v2-apidocs.cloudfoundry.org/service_bindings/create_a_service_binding.html">Create Service Binding</a> request
      *
      * @param request the Create Service Binding request
      * @return the response from the Create Service Binding request
@@ -32,7 +32,7 @@ public interface ServiceBindingsV2 {
     Mono<CreateServiceBindingResponse> create(CreateServiceBindingRequest request);
 
     /**
-     * Makes the <a href="https://apidocs.cloudfoundry.org/latest-release/service_bindings/delete_a_particular_service_binding.html">Delete the Service Binding</a> request
+     * Makes the <a href="https://v2-apidocs.cloudfoundry.org/service_bindings/delete_a_particular_service_binding.html">Delete the Service Binding</a> request
      *
      * @param request the Delete Service Binding request
      * @return the response from the Delete Service Binding request
@@ -40,7 +40,7 @@ public interface ServiceBindingsV2 {
     Mono<DeleteServiceBindingResponse> delete(DeleteServiceBindingRequest request);
 
     /**
-     * Makes the <a href="https://apidocs.cloudfoundry.org/latest-release/service_bindings/retrieve_a_particular_service_binding.html">Retrieve a Particular Service Binding</a> request
+     * Makes the <a href="https://v2-apidocs.cloudfoundry.org/service_bindings/retrieve_a_particular_service_binding.html">Retrieve a Particular Service Binding</a> request
      *
      * @param request the Get Service Binding request
      * @return the response from the Get Service Binding request
@@ -48,7 +48,7 @@ public interface ServiceBindingsV2 {
     Mono<GetServiceBindingResponse> get(GetServiceBindingRequest request);
 
     /**
-     * Makes the <a href="https://apidocs.cloudfoundry.org/latest-release/service_bindings/retrieve_a_particular_service_binding_parameters.html">Retrieve a Particular Service Binding's Parameters</a>
+     * Makes the <a href="https://v2-apidocs.cloudfoundry.org/service_bindings/retrieve_a_particular_service_binding_parameters.html">Retrieve a Particular Service Binding's Parameters</a>
      * request
      *
      * @param request the Get Parameters request
@@ -58,7 +58,7 @@ public interface ServiceBindingsV2 {
             GetServiceBindingParametersRequest request);
 
     /**
-     * Makes the <a href="https://apidocs.cloudfoundry.org/latest-release/service_bindings/list_all_service_bindings.html">List all Service Bindings</a> request
+     * Makes the <a href="https://v2-apidocs.cloudfoundry.org/service_bindings/list_all_service_bindings.html">List all Service Bindings</a> request
      *
      * @param request the List Service Bindings request
      * @return the response from the List Service Bindings request

--- a/cloudfoundry-client/src/main/java/org/cloudfoundry/client/v2/servicebrokers/ServiceBrokers.java
+++ b/cloudfoundry-client/src/main/java/org/cloudfoundry/client/v2/servicebrokers/ServiceBrokers.java
@@ -24,7 +24,7 @@ import reactor.core.publisher.Mono;
 public interface ServiceBrokers {
 
     /**
-     * Makes the <a href="https://apidocs.cloudfoundry.org/latest-release/service_brokers/create_a_service_broker.html">Create Service Broker</a> request
+     * Makes the <a href="https://v2-apidocs.cloudfoundry.org/service_brokers/create_a_service_broker.html">Create Service Broker</a> request
      *
      * @param request the Create Service Broker request
      * @return the response from the Create Service Broker request
@@ -32,7 +32,7 @@ public interface ServiceBrokers {
     Mono<CreateServiceBrokerResponse> create(CreateServiceBrokerRequest request);
 
     /**
-     * Makes the <a href="https://apidocs.cloudfoundry.org/latest-release/service_brokers/delete_a_particular_service_broker.html">Delete the Service Broker</a> request
+     * Makes the <a href="https://v2-apidocs.cloudfoundry.org/service_brokers/delete_a_particular_service_broker.html">Delete the Service Broker</a> request
      *
      * @param request the Delete Service Broker request
      * @return the response from the Delete Service Broker request
@@ -40,7 +40,7 @@ public interface ServiceBrokers {
     Mono<Void> delete(DeleteServiceBrokerRequest request);
 
     /**
-     * Makes the <a href="https://apidocs.cloudfoundry.org/latest-release/service_brokers/retrieve_a_particular_service_broker.html">Retrieve a Particular Service Broker</a> request
+     * Makes the <a href="https://v2-apidocs.cloudfoundry.org/service_brokers/retrieve_a_particular_service_broker.html">Retrieve a Particular Service Broker</a> request
      *
      * @param request the Get Service Broker request
      * @return the response from the Get Service Broker request
@@ -48,7 +48,7 @@ public interface ServiceBrokers {
     Mono<GetServiceBrokerResponse> get(GetServiceBrokerRequest request);
 
     /**
-     * Makes the <a href="https://apidocs.cloudfoundry.org/latest-release/service_brokers/list_all_service_brokers.html">List all Service Brokers</a> request
+     * Makes the <a href="https://v2-apidocs.cloudfoundry.org/service_brokers/list_all_service_brokers.html">List all Service Brokers</a> request
      *
      * @param request the List Service Brokers request
      * @return the response from the List Service Brokers request
@@ -56,7 +56,7 @@ public interface ServiceBrokers {
     Mono<ListServiceBrokersResponse> list(ListServiceBrokersRequest request);
 
     /**
-     * Makes the <a href="https://apidocs.cloudfoundry.org/latest-release/service_brokers/update_a_service_broker.html">Update Service Broker</a> request
+     * Makes the <a href="https://v2-apidocs.cloudfoundry.org/service_brokers/update_a_service_broker.html">Update Service Broker</a> request
      *
      * @param request the Update Service Broker request
      * @return the response from the Update Service Broker request

--- a/cloudfoundry-client/src/main/java/org/cloudfoundry/client/v2/serviceinstances/ServiceInstances.java
+++ b/cloudfoundry-client/src/main/java/org/cloudfoundry/client/v2/serviceinstances/ServiceInstances.java
@@ -24,7 +24,7 @@ import reactor.core.publisher.Mono;
 public interface ServiceInstances {
 
     /**
-     * Makes the <a href="https://apidocs.cloudfoundry.org/latest-release/service_instances/binding_a_service_instance_to_a_route.html">Bind Service Instance To a Route</a> request
+     * Makes the <a href="https://v2-apidocs.cloudfoundry.org/service_instances/binding_a_service_instance_to_a_route.html">Bind Service Instance To a Route</a> request
      *
      * @param request the Bind Service Instance To Route request
      * @return the response from the Bind Service Instance To Route request
@@ -32,7 +32,7 @@ public interface ServiceInstances {
     Mono<BindServiceInstanceRouteResponse> bindRoute(BindServiceInstanceRouteRequest request);
 
     /**
-     * Makes the <a href="https://apidocs.cloudfoundry.org/latest-release/service_instances/creating_a_service_instance.html">Create Service Instance</a> request
+     * Makes the <a href="https://v2-apidocs.cloudfoundry.org/service_instances/creating_a_service_instance.html">Create Service Instance</a> request
      *
      * @param request the Create Service Instance request
      * @return the response from the Create Service Instance request
@@ -40,7 +40,7 @@ public interface ServiceInstances {
     Mono<CreateServiceInstanceResponse> create(CreateServiceInstanceRequest request);
 
     /**
-     * Makes the <a href="https://apidocs.cloudfoundry.org/latest-release/service_instances/delete_a_service_instance.html">Delete the Service Instance</a> request
+     * Makes the <a href="https://v2-apidocs.cloudfoundry.org/service_instances/delete_a_service_instance.html">Delete the Service Instance</a> request
      *
      * @param request the Delete Service Instance request
      * @return the response from the Delete Service Instance request
@@ -48,7 +48,7 @@ public interface ServiceInstances {
     Mono<DeleteServiceInstanceResponse> delete(DeleteServiceInstanceRequest request);
 
     /**
-     * Makes the <a href="https://apidocs.cloudfoundry.org/latest-release/service_instances/retrieve_a_particular_service_instance.html">Retrieve a Particular Service Instance</a> request
+     * Makes the <a href="https://v2-apidocs.cloudfoundry.org/service_instances/retrieve_a_particular_service_instance.html">Retrieve a Particular Service Instance</a> request
      *
      * @param request the Get Service Instance request
      * @return the response from the Get Service Instance request
@@ -57,7 +57,7 @@ public interface ServiceInstances {
 
     /**
      * Makes the
-     * <a href="https://apidocs.cloudfoundry.org/latest-release/service_instances/retrieve_a_particular_service_instance_parameters.html">Retrieve a Particular Service Instance's Parameters</a>
+     * <a href="https://v2-apidocs.cloudfoundry.org/service_instances/retrieve_a_particular_service_instance_parameters.html">Retrieve a Particular Service Instance's Parameters</a>
      * request
      *
      * @param request the Get Parameters request
@@ -67,7 +67,7 @@ public interface ServiceInstances {
             GetServiceInstanceParametersRequest request);
 
     /**
-     * Makes the <a href="https://apidocs.cloudfoundry.org/latest-release/service_instances/retrieving_permissions_on_a_service_instance.html">Retrieving permissions on a Service Instance</a> request
+     * Makes the <a href="https://v2-apidocs.cloudfoundry.org/service_instances/retrieving_permissions_on_a_service_instance.html">Retrieving permissions on a Service Instance</a> request
      *
      * @param request the Get Permissions request
      * @return the response from the Get Permissions request
@@ -76,7 +76,7 @@ public interface ServiceInstances {
             GetServiceInstancePermissionsRequest request);
 
     /**
-     * Makes the <a href="https://apidocs.cloudfoundry.org/latest-release/service_instances/list_all_service_instances.html">List Service Instances</a> request
+     * Makes the <a href="https://v2-apidocs.cloudfoundry.org/service_instances/list_all_service_instances.html">List Service Instances</a> request
      *
      * @param request the List Service Instances request
      * @return the response from the List Service Instances request
@@ -84,7 +84,7 @@ public interface ServiceInstances {
     Mono<ListServiceInstancesResponse> list(ListServiceInstancesRequest request);
 
     /**
-     * Makes the <a href="https://apidocs.cloudfoundry.org/latest-release/service_instances/list_all_routes_for_the_service_instance.html">List all Routes for the Service Instance</a> request
+     * Makes the <a href="https://v2-apidocs.cloudfoundry.org/service_instances/list_all_routes_for_the_service_instance.html">List all Routes for the Service Instance</a> request
      *
      * @param request the List Routes request
      * @return the response from the List Routes request
@@ -92,7 +92,7 @@ public interface ServiceInstances {
     Mono<ListServiceInstanceRoutesResponse> listRoutes(ListServiceInstanceRoutesRequest request);
 
     /**
-     * Makes the <a href="https://apidocs.cloudfoundry.org/latest-release/service_instances/list_all_service_bindings_for_the_service_instance.html">List all Service Bindings for the Service
+     * Makes the <a href="https://v2-apidocs.cloudfoundry.org/service_instances/list_all_service_bindings_for_the_service_instance.html">List all Service Bindings for the Service
      * Instance</a> request
      *
      * @param request the List Service Bindings request
@@ -102,7 +102,7 @@ public interface ServiceInstances {
             ListServiceInstanceServiceBindingsRequest request);
 
     /**
-     * Makes the <a href="https://apidocs.cloudfoundry.org/latest-release/service_instances/retrieving_service_keys_associated_with_a_service_instance.html">List all Service keys for the Service
+     * Makes the <a href="https://v2-apidocs.cloudfoundry.org/service_instances/retrieving_service_keys_associated_with_a_service_instance.html">List all Service keys for the Service
      * Instance</a> request
      *
      * @param request the List Service Keys request
@@ -112,7 +112,7 @@ public interface ServiceInstances {
             ListServiceInstanceServiceKeysRequest request);
 
     /**
-     * Makes the <a href="https://apidocs.cloudfoundry.org/latest-release/service_instances/unbinding_a_service_instance_from_a_route.html">Unbinding a Service Instance from a Route</a> request
+     * Makes the <a href="https://v2-apidocs.cloudfoundry.org/service_instances/unbinding_a_service_instance_from_a_route.html">Unbinding a Service Instance from a Route</a> request
      *
      * @param request the Unbind Service Instance from a Route request
      * @return the response from the Unbind Service Instance from a Route request
@@ -120,7 +120,7 @@ public interface ServiceInstances {
     Mono<Void> unbindRoute(UnbindServiceInstanceRouteRequest request);
 
     /**
-     * Makes the <a href="https://apidocs.cloudfoundry.org/latest-release/service_instances/update_a_service_instance.html">Update Service Instance</a> request
+     * Makes the <a href="https://v2-apidocs.cloudfoundry.org/service_instances/update_a_service_instance.html">Update Service Instance</a> request
      *
      * @param request the Update Service Instance request
      * @return the response from the Update Service Instance request

--- a/cloudfoundry-client/src/main/java/org/cloudfoundry/client/v2/servicekeys/ServiceKeys.java
+++ b/cloudfoundry-client/src/main/java/org/cloudfoundry/client/v2/servicekeys/ServiceKeys.java
@@ -24,7 +24,7 @@ import reactor.core.publisher.Mono;
 public interface ServiceKeys {
 
     /**
-     * Makes the <a href="https://apidocs.cloudfoundry.org/latest-release/service_keys/create_a_service_key.html">Create Service Key</a> request
+     * Makes the <a href="https://v2-apidocs.cloudfoundry.org/service_keys/create_a_service_key.html">Create Service Key</a> request
      *
      * @param request the Create Service Key request
      * @return the response from the Create Service Key request
@@ -32,7 +32,7 @@ public interface ServiceKeys {
     Mono<CreateServiceKeyResponse> create(CreateServiceKeyRequest request);
 
     /**
-     * Makes the <a href="https://apidocs.cloudfoundry.org/latest-release/service_keys/delete_a_particular_service_key.html">Delete the Service Key</a> request
+     * Makes the <a href="https://v2-apidocs.cloudfoundry.org/service_keys/delete_a_particular_service_key.html">Delete the Service Key</a> request
      *
      * @param request the Delete Service Key request
      * @return the response from the Delete Service Key request
@@ -40,7 +40,7 @@ public interface ServiceKeys {
     Mono<Void> delete(DeleteServiceKeyRequest request);
 
     /**
-     * Makes the <a href="https://apidocs.cloudfoundry.org/latest-release/service_keys/retrieve_a_particular_service_key.html">Retrieve a Particular Service Key</a> request
+     * Makes the <a href="https://v2-apidocs.cloudfoundry.org/service_keys/retrieve_a_particular_service_key.html">Retrieve a Particular Service Key</a> request
      *
      * @param request the Get Service Key request
      * @return the response from the Get Service Key request
@@ -48,7 +48,7 @@ public interface ServiceKeys {
     Mono<GetServiceKeyResponse> get(GetServiceKeyRequest request);
 
     /**
-     * Makes the <a href="https://apidocs.cloudfoundry.org/latest-release/service_keys/list_all_service_keys.html">List Service Keys</a> request
+     * Makes the <a href="https://v2-apidocs.cloudfoundry.org/service_keys/list_all_service_keys.html">List Service Keys</a> request
      *
      * @param request the List Service Keys request
      * @return the response from the List Service Keys request

--- a/cloudfoundry-client/src/main/java/org/cloudfoundry/client/v2/serviceplans/ServicePlans.java
+++ b/cloudfoundry-client/src/main/java/org/cloudfoundry/client/v2/serviceplans/ServicePlans.java
@@ -21,7 +21,7 @@ import reactor.core.publisher.Mono;
 public interface ServicePlans {
 
     /**
-     * Makes the <a href="https://apidocs.cloudfoundry.org/latest-release/service_plans/delete_a_particular_service_plans.html">Delete the Service Plan</a> request
+     * Makes the <a href="https://v2-apidocs.cloudfoundry.org/service_plans/delete_a_particular_service_plans.html">Delete the Service Plan</a> request
      *
      * @param request the Delete Service Plan request
      * @return the response from the Delete Service Plan request
@@ -29,7 +29,7 @@ public interface ServicePlans {
     Mono<DeleteServicePlanResponse> delete(DeleteServicePlanRequest request);
 
     /**
-     * Makes the <a href="https://apidocs.cloudfoundry.org/latest-release/service_plans/retrieve_a_particular_service_plan.html">Retrieve a Particular Service Plan</a> request
+     * Makes the <a href="https://v2-apidocs.cloudfoundry.org/service_plans/retrieve_a_particular_service_plan.html">Retrieve a Particular Service Plan</a> request
      *
      * @param request the Get Service Plan request
      * @return the response from the Get Service Plan request
@@ -37,7 +37,7 @@ public interface ServicePlans {
     Mono<GetServicePlanResponse> get(GetServicePlanRequest request);
 
     /**
-     * Makes the <a href="https://apidocs.cloudfoundry.org/latest-release/service_plans/list_all_service_plans.html">List Service Plans</a> request
+     * Makes the <a href="https://v2-apidocs.cloudfoundry.org/service_plans/list_all_service_plans.html">List Service Plans</a> request
      *
      * @param request the List Service Plans request
      * @return the response from the List Service Plans request
@@ -45,7 +45,7 @@ public interface ServicePlans {
     Mono<ListServicePlansResponse> list(ListServicePlansRequest request);
 
     /**
-     * Makes the <a href="https://apidocs.cloudfoundry.org/latest-release/service_plans/list_all_service_instances_for_the_service_plan.html">List all Service Instances for the Service Plan</a>
+     * Makes the <a href="https://v2-apidocs.cloudfoundry.org/service_plans/list_all_service_instances_for_the_service_plan.html">List all Service Instances for the Service Plan</a>
      * request
      *
      * @param request the List Service Instances request
@@ -55,7 +55,7 @@ public interface ServicePlans {
             ListServicePlanServiceInstancesRequest request);
 
     /**
-     * Makes the <a href="https://apidocs.cloudfoundry.org/latest-release/service_plans/updating_a_service_plan.html">Updating a Service Plan</a> request
+     * Makes the <a href="https://v2-apidocs.cloudfoundry.org/service_plans/updating_a_service_plan.html">Updating a Service Plan</a> request
      *
      * @param request the Update Service Plan request
      * @return the response from the Update Service Plan request

--- a/cloudfoundry-client/src/main/java/org/cloudfoundry/client/v2/serviceplanvisibilities/ServicePlanVisibilities.java
+++ b/cloudfoundry-client/src/main/java/org/cloudfoundry/client/v2/serviceplanvisibilities/ServicePlanVisibilities.java
@@ -24,7 +24,7 @@ import reactor.core.publisher.Mono;
 public interface ServicePlanVisibilities {
 
     /**
-     * Makes the <a href="https://apidocs.cloudfoundry.org/latest-release/service_plan_visibilities/creating_a_service_plan_visibility.html">Create Service Plan Visibility</a> request
+     * Makes the <a href="https://v2-apidocs.cloudfoundry.org/service_plan_visibilities/creating_a_service_plan_visibility.html">Create Service Plan Visibility</a> request
      *
      * @param request the Create Service Plan Visibility request
      * @return the response from the Create Service Plan Visibility request
@@ -32,7 +32,7 @@ public interface ServicePlanVisibilities {
     Mono<CreateServicePlanVisibilityResponse> create(CreateServicePlanVisibilityRequest request);
 
     /**
-     * Makes the <a href="https://apidocs.cloudfoundry.org/latest-release/service_plan_visibilities/delete_a_particular_service_plan_visibilities.html">Delete the Service Plan Visibility</a> request
+     * Makes the <a href="https://v2-apidocs.cloudfoundry.org/service_plan_visibilities/delete_a_particular_service_plan_visibilities.html">Delete the Service Plan Visibility</a> request
      *
      * @param request the Delete Service Plan Visibility request
      * @return the response from the Delete Service Plan Visibility request
@@ -40,7 +40,7 @@ public interface ServicePlanVisibilities {
     Mono<DeleteServicePlanVisibilityResponse> delete(DeleteServicePlanVisibilityRequest request);
 
     /**
-     * Makes the <a href="https://apidocs.cloudfoundry.org/latest-release/service_plan_visibilities/retrieve_a_particular_service_plan_visibility.html">Retrieve a Particular Service Plan Visibility</a>
+     * Makes the <a href="https://v2-apidocs.cloudfoundry.org/service_plan_visibilities/retrieve_a_particular_service_plan_visibility.html">Retrieve a Particular Service Plan Visibility</a>
      * request
      *
      * @param request the Get Service Plan Visibility request
@@ -49,7 +49,7 @@ public interface ServicePlanVisibilities {
     Mono<GetServicePlanVisibilityResponse> get(GetServicePlanVisibilityRequest request);
 
     /**
-     * Makes the <a href="https://apidocs.cloudfoundry.org/latest-release/service_bindings/list_all_service_bindings.html">List all Service Plan Visibilities</a> request
+     * Makes the <a href="https://v2-apidocs.cloudfoundry.org/service_bindings/list_all_service_bindings.html">List all Service Plan Visibilities</a> request
      *
      * @param request the List Service Plan Visibilities request
      * @return the response from the List Service Plan Visibilities request
@@ -57,7 +57,7 @@ public interface ServicePlanVisibilities {
     Mono<ListServicePlanVisibilitiesResponse> list(ListServicePlanVisibilitiesRequest request);
 
     /**
-     * Makes the <a href="https://apidocs.cloudfoundry.org/latest-release/service_plan_visibilities/updating_a_service_plan_visibility.html">Update Service Plan Visibility</a> request
+     * Makes the <a href="https://v2-apidocs.cloudfoundry.org/service_plan_visibilities/updating_a_service_plan_visibility.html">Update Service Plan Visibility</a> request
      *
      * @param request the Update Service Plan Visibility request
      * @return the response from the Update Service Plan Visibility request

--- a/cloudfoundry-client/src/main/java/org/cloudfoundry/client/v2/services/Services.java
+++ b/cloudfoundry-client/src/main/java/org/cloudfoundry/client/v2/services/Services.java
@@ -24,7 +24,7 @@ import reactor.core.publisher.Mono;
 public interface Services {
 
     /**
-     * Makes the <a href="https://apidocs.cloudfoundry.org/latest-release/services/delete_a_particular_service.html">Delete the Service</a> request
+     * Makes the <a href="https://v2-apidocs.cloudfoundry.org/services/delete_a_particular_service.html">Delete the Service</a> request
      *
      * @param request the Delete Service request
      * @return the response from the Delete Service request
@@ -32,7 +32,7 @@ public interface Services {
     Mono<DeleteServiceResponse> delete(DeleteServiceRequest request);
 
     /**
-     * Makes the <a href="https://apidocs.cloudfoundry.org/latest-release/services/retrieve_a_particular_service.html">Retrieve a Particular Service</a> request
+     * Makes the <a href="https://v2-apidocs.cloudfoundry.org/services/retrieve_a_particular_service.html">Retrieve a Particular Service</a> request
      *
      * @param request the Get Service request
      * @return the response from the Get Service request
@@ -40,7 +40,7 @@ public interface Services {
     Mono<GetServiceResponse> get(GetServiceRequest request);
 
     /**
-     * Makes the <a href="https://apidocs.cloudfoundry.org/latest-release/services/list_all_services.html">List Services</a> request
+     * Makes the <a href="https://v2-apidocs.cloudfoundry.org/services/list_all_services.html">List Services</a> request
      *
      * @param request the List Services request
      * @return the response from the List Services request
@@ -48,7 +48,7 @@ public interface Services {
     Mono<ListServicesResponse> list(ListServicesRequest request);
 
     /**
-     * Makes the <a href="https://apidocs.cloudfoundry.org/latest-release/services/list_all_service_plans_for_the_service.html">List all Service Plans for the Service</a> request
+     * Makes the <a href="https://v2-apidocs.cloudfoundry.org/services/list_all_service_plans_for_the_service.html">List all Service Plans for the Service</a> request
      *
      * @param request the List Service Plans request
      * @return the response from the List Service Plans request

--- a/cloudfoundry-client/src/main/java/org/cloudfoundry/client/v2/serviceusageevents/ServiceUsageEvents.java
+++ b/cloudfoundry-client/src/main/java/org/cloudfoundry/client/v2/serviceusageevents/ServiceUsageEvents.java
@@ -24,7 +24,7 @@ import reactor.core.publisher.Mono;
 public interface ServiceUsageEvents {
 
     /**
-     * Makes the <a href="https://apidocs.cloudfoundry.org/latest-release/service_usage_events/retrieve_a_particular_service_usage_event.html">Retrieve a Particular Service Usage Events</a> request
+     * Makes the <a href="https://v2-apidocs.cloudfoundry.org/service_usage_events/retrieve_a_particular_service_usage_event.html">Retrieve a Particular Service Usage Events</a> request
      *
      * @param request the Get Service Usage Events
      * @return the response from the Get Service Usage Events request
@@ -32,7 +32,7 @@ public interface ServiceUsageEvents {
     Mono<GetServiceUsageEventResponse> get(GetServiceUsageEventRequest request);
 
     /**
-     * Makes the <a href="https://apidocs.cloudfoundry.org/latest-release/service_usage_events/list_service_usage_events.html">List Service Usage Events</a> request
+     * Makes the <a href="https://v2-apidocs.cloudfoundry.org/service_usage_events/list_service_usage_events.html">List Service Usage Events</a> request
      *
      * @param request the List Service Usage Events request
      * @return the response from the List Service Usage Events request
@@ -40,7 +40,7 @@ public interface ServiceUsageEvents {
     Mono<ListServiceUsageEventsResponse> list(ListServiceUsageEventsRequest request);
 
     /**
-     * Makes the <a href="https://apidocs.cloudfoundry.org/latest-release/service_usage_events/purge_and_reseed_service_usage_events.html">Purge and Reseed Service Usage Events</a> request
+     * Makes the <a href="https://v2-apidocs.cloudfoundry.org/service_usage_events/purge_and_reseed_service_usage_events.html">Purge and Reseed Service Usage Events</a> request
      *
      * @param request the Purge and Reseed Service Usage Events
      * @return the response from the Purge and Reseed Service Usage Events request

--- a/cloudfoundry-client/src/main/java/org/cloudfoundry/client/v2/shareddomains/SharedDomains.java
+++ b/cloudfoundry-client/src/main/java/org/cloudfoundry/client/v2/shareddomains/SharedDomains.java
@@ -24,7 +24,7 @@ import reactor.core.publisher.Mono;
 public interface SharedDomains {
 
     /**
-     * Makes the <a href="https://apidocs.cloudfoundry.org/latest-release/shared_domains/create_a_shared_domain.html">Create a Shared Domain</a> request
+     * Makes the <a href="https://v2-apidocs.cloudfoundry.org/shared_domains/create_a_shared_domain.html">Create a Shared Domain</a> request
      *
      * @param request the Create a Shared Domain request
      * @return the response from the Create a Shared Domain request
@@ -32,7 +32,7 @@ public interface SharedDomains {
     Mono<CreateSharedDomainResponse> create(CreateSharedDomainRequest request);
 
     /**
-     * Makes the <a href="https://apidocs.cloudfoundry.org/latest-release/shared_domains/delete_a_particular_shared_domain.html">Delete a Shared Domain</a> request
+     * Makes the <a href="https://v2-apidocs.cloudfoundry.org/shared_domains/delete_a_particular_shared_domain.html">Delete a Shared Domain</a> request
      *
      * @param request the Delete a Shared Domain request
      * @return the response from the Delete a Shared Domain request
@@ -40,7 +40,7 @@ public interface SharedDomains {
     Mono<DeleteSharedDomainResponse> delete(DeleteSharedDomainRequest request);
 
     /**
-     * Makes the <a href="https://apidocs.cloudfoundry.org/latest-release/shared_domains/retrieve_a_particular_shared_domain.html">Get a Shared Domain</a> request
+     * Makes the <a href="https://v2-apidocs.cloudfoundry.org/shared_domains/retrieve_a_particular_shared_domain.html">Get a Shared Domain</a> request
      *
      * @param request the Get a Shared Domain request
      * @return the response from the Get a Shared Domain request
@@ -48,7 +48,7 @@ public interface SharedDomains {
     Mono<GetSharedDomainResponse> get(GetSharedDomainRequest request);
 
     /**
-     * Makes the <a href="https://apidocs.cloudfoundry.org/latest-release/shared_domains/list_all_shared_domains.html">List all Shared Domains</a> request
+     * Makes the <a href="https://v2-apidocs.cloudfoundry.org/shared_domains/list_all_shared_domains.html">List all Shared Domains</a> request
      *
      * @param request the List all Shared Domains request
      * @return the response from the List all Shared Domains request

--- a/cloudfoundry-client/src/main/java/org/cloudfoundry/client/v2/spacequotadefinitions/SpaceQuotaDefinitions.java
+++ b/cloudfoundry-client/src/main/java/org/cloudfoundry/client/v2/spacequotadefinitions/SpaceQuotaDefinitions.java
@@ -24,7 +24,7 @@ import reactor.core.publisher.Mono;
 public interface SpaceQuotaDefinitions {
 
     /**
-     * Makes the <a href="https://apidocs.cloudfoundry.org/latest-release/space_quota_definitions/associate_space_with_the_space_quota_definition.html">Associate a Space with a Space Quota
+     * Makes the <a href="https://v2-apidocs.cloudfoundry.org/space_quota_definitions/associate_space_with_the_space_quota_definition.html">Associate a Space with a Space Quota
      * Definition</a> request
      *
      * @param request the Associate a Space with a Space Quota Definition request
@@ -34,7 +34,7 @@ public interface SpaceQuotaDefinitions {
             AssociateSpaceQuotaDefinitionRequest request);
 
     /**
-     * Makes the <a href="https://apidocs.cloudfoundry.org/latest-release/space_quota_definitions/creating_a_space_quota_definition.html">Creating a Space Quota Definition</a> request
+     * Makes the <a href="https://v2-apidocs.cloudfoundry.org/space_quota_definitions/creating_a_space_quota_definition.html">Creating a Space Quota Definition</a> request
      *
      * @param request the Create a Space Quota Definition request
      * @return the response from the Create a Space Quota Definition request
@@ -42,7 +42,7 @@ public interface SpaceQuotaDefinitions {
     Mono<CreateSpaceQuotaDefinitionResponse> create(CreateSpaceQuotaDefinitionRequest request);
 
     /**
-     * Makes the <a href="https://apidocs.cloudfoundry.org/latest-release/space_quota_definitions/delete_a_particular_space_quota_definition.html">Delete a Particular Space Quota Definition</a> request
+     * Makes the <a href="https://v2-apidocs.cloudfoundry.org/space_quota_definitions/delete_a_particular_space_quota_definition.html">Delete a Particular Space Quota Definition</a> request
      *
      * @param request the Delete a Particular Space Quota Definition request
      * @return the response from the Delete a Particular Space Quota Definition request
@@ -50,7 +50,7 @@ public interface SpaceQuotaDefinitions {
     Mono<DeleteSpaceQuotaDefinitionResponse> delete(DeleteSpaceQuotaDefinitionRequest request);
 
     /**
-     * Makes the <a href="https://apidocs.cloudfoundry.org/latest-release/space_quota_definitions/retrieve_a_particular_space_quota_definition.html">Retrieve a Particular Space Quota Definition</a>
+     * Makes the <a href="https://v2-apidocs.cloudfoundry.org/space_quota_definitions/retrieve_a_particular_space_quota_definition.html">Retrieve a Particular Space Quota Definition</a>
      * request
      *
      * @param request the Retrieve a Particular Space Quota Definition request
@@ -59,7 +59,7 @@ public interface SpaceQuotaDefinitions {
     Mono<GetSpaceQuotaDefinitionResponse> get(GetSpaceQuotaDefinitionRequest request);
 
     /**
-     * Makes the <a href="https://apidocs.cloudfoundry.org/latest-release/space_quota_definitions/list_all_space_quota_definitions.html">List all Space Quota Definitions</a> request
+     * Makes the <a href="https://v2-apidocs.cloudfoundry.org/space_quota_definitions/list_all_space_quota_definitions.html">List all Space Quota Definitions</a> request
      *
      * @param request the List Space Quota Definitions request
      * @return the response from the List Space Quota Definitions request
@@ -67,7 +67,7 @@ public interface SpaceQuotaDefinitions {
     Mono<ListSpaceQuotaDefinitionsResponse> list(ListSpaceQuotaDefinitionsRequest request);
 
     /**
-     * Makes the <a href="https://apidocs.cloudfoundry.org/latest-release/space_quota_definitions/list_all_spaces_for_the_space_quota_definition.html">List all Spaces for the Space Quota Definition</a>
+     * Makes the <a href="https://v2-apidocs.cloudfoundry.org/space_quota_definitions/list_all_spaces_for_the_space_quota_definition.html">List all Spaces for the Space Quota Definition</a>
      * request
      *
      * @param request the List all Spaces for the Space Quota Definition request
@@ -77,7 +77,7 @@ public interface SpaceQuotaDefinitions {
             ListSpaceQuotaDefinitionSpacesRequest request);
 
     /**
-     * Makes the <a href="https://apidocs.cloudfoundry.org/latest-release/space_quota_definitions/remove_space_from_the_space_quota_definition.html">Remove a Space from a Space Quota Definition</a>
+     * Makes the <a href="https://v2-apidocs.cloudfoundry.org/space_quota_definitions/remove_space_from_the_space_quota_definition.html">Remove a Space from a Space Quota Definition</a>
      * request
      *
      * @param request the Remove a Space from a Space Quota Definition request
@@ -86,7 +86,7 @@ public interface SpaceQuotaDefinitions {
     Mono<Void> removeSpace(RemoveSpaceQuotaDefinitionRequest request);
 
     /**
-     * Makes the <a href="https://apidocs.cloudfoundry.org/latest-release/space_quota_definitions/updating_a_space_quota_definition.html">Updating a Space Quota Definition</a> request
+     * Makes the <a href="https://v2-apidocs.cloudfoundry.org/space_quota_definitions/updating_a_space_quota_definition.html">Updating a Space Quota Definition</a> request
      *
      * @param request the Update Space Quota Definitions request
      * @return the response from the Update Space Quota Definitions request

--- a/cloudfoundry-client/src/main/java/org/cloudfoundry/client/v2/spaces/Spaces.java
+++ b/cloudfoundry-client/src/main/java/org/cloudfoundry/client/v2/spaces/Spaces.java
@@ -24,7 +24,7 @@ import reactor.core.publisher.Mono;
 public interface Spaces {
 
     /**
-     * Makes the <a href="https://apidocs.cloudfoundry.org/latest-release/spaces/associate_auditor_with_the_space.html">Associate Auditor with the Space</a> request
+     * Makes the <a href="https://v2-apidocs.cloudfoundry.org/spaces/associate_auditor_with_the_space.html">Associate Auditor with the Space</a> request
      *
      * @param request the Associate Auditor request
      * @return the response from the Associate Auditor request
@@ -32,7 +32,7 @@ public interface Spaces {
     Mono<AssociateSpaceAuditorResponse> associateAuditor(AssociateSpaceAuditorRequest request);
 
     /**
-     * Makes the <a href="https://apidocs.cloudfoundry.org/latest-release/spaces/associate_auditor_with_the_space_by_username.html">Associate Auditor with the Space by Username</a> request
+     * Makes the <a href="https://v2-apidocs.cloudfoundry.org/spaces/associate_auditor_with_the_space_by_username.html">Associate Auditor with the Space by Username</a> request
      *
      * @param request the Associate Auditor with the Space by Username request
      * @return the response from the Associate Auditor with the Space by Username request
@@ -41,7 +41,7 @@ public interface Spaces {
             AssociateSpaceAuditorByUsernameRequest request);
 
     /**
-     * Makes the <a href="https://apidocs.cloudfoundry.org/latest-release/spaces/associate_developer_with_the_space.html">Associate Developer with the Space</a> request
+     * Makes the <a href="https://v2-apidocs.cloudfoundry.org/spaces/associate_developer_with_the_space.html">Associate Developer with the Space</a> request
      *
      * @param request the Associate Developer request
      * @return the response from the Associate Developer request
@@ -50,7 +50,7 @@ public interface Spaces {
             AssociateSpaceDeveloperRequest request);
 
     /**
-     * Makes the <a href="https://apidocs.cloudfoundry.org/latest-release/spaces/associate_developer_with_the_space_by_username.html">Associate Developer with the Space by Username</a> request
+     * Makes the <a href="https://v2-apidocs.cloudfoundry.org/spaces/associate_developer_with_the_space_by_username.html">Associate Developer with the Space by Username</a> request
      *
      * @param request the Associate Developer with the Space by Username request
      * @return the response from the Associate Developer with the Space by Username request
@@ -59,7 +59,7 @@ public interface Spaces {
             AssociateSpaceDeveloperByUsernameRequest request);
 
     /**
-     * Makes the <a href="https://apidocs.cloudfoundry.org/latest-release/spaces/associate_manager_with_the_space.html">Associate Manager with the Space</a> request
+     * Makes the <a href="https://v2-apidocs.cloudfoundry.org/spaces/associate_manager_with_the_space.html">Associate Manager with the Space</a> request
      *
      * @param request the Associate Manager request
      * @return the response from the Associate Manager request
@@ -67,7 +67,7 @@ public interface Spaces {
     Mono<AssociateSpaceManagerResponse> associateManager(AssociateSpaceManagerRequest request);
 
     /**
-     * Makes the <a href="https://apidocs.cloudfoundry.org/latest-release/spaces/associate_manager_with_the_space_by_username.html">Associate Manager with the Space by Username</a> request
+     * Makes the <a href="https://v2-apidocs.cloudfoundry.org/spaces/associate_manager_with_the_space_by_username.html">Associate Manager with the Space by Username</a> request
      *
      * @param request the Associate Manager with the Space by Username request
      * @return the response from the Associate Manager with the Space by Username request
@@ -76,7 +76,7 @@ public interface Spaces {
             AssociateSpaceManagerByUsernameRequest request);
 
     /**
-     * Makes the <a href="https://apidocs.cloudfoundry.org/latest-release/spaces/associate_security_group_with_the_space.html">Associate Security Group with the Space</a> request
+     * Makes the <a href="https://v2-apidocs.cloudfoundry.org/spaces/associate_security_group_with_the_space.html">Associate Security Group with the Space</a> request
      *
      * @param request the Associate Security Group request
      * @return the response from the Associate Security Group request
@@ -85,7 +85,7 @@ public interface Spaces {
             AssociateSpaceSecurityGroupRequest request);
 
     /**
-     * Makes the <a href="https://apidocs.cloudfoundry.org/latest-release/spaces/creating_a_space.html">Create Space</a> request
+     * Makes the <a href="https://v2-apidocs.cloudfoundry.org/spaces/creating_a_space.html">Create Space</a> request
      *
      * @param request the Create Space request
      * @return the response from the Create Space request
@@ -93,7 +93,7 @@ public interface Spaces {
     Mono<CreateSpaceResponse> create(CreateSpaceRequest request);
 
     /**
-     * Makes the <a href="https://apidocs.cloudfoundry.org/latest-release/spaces/delete_a_particular_space.html">Delete a Particular Space</a> request
+     * Makes the <a href="https://v2-apidocs.cloudfoundry.org/spaces/delete_a_particular_space.html">Delete a Particular Space</a> request
      *
      * @param request the Delete a Space request
      * @return the response from the Delete a Space request
@@ -101,7 +101,7 @@ public interface Spaces {
     Mono<DeleteSpaceResponse> delete(DeleteSpaceRequest request);
 
     /**
-     * Makes the <a href="https://apidocs.cloudfoundry.org/latest-release/spaces/retrieve_a_particular_space.html">Get Space</a> request
+     * Makes the <a href="https://v2-apidocs.cloudfoundry.org/spaces/retrieve_a_particular_space.html">Get Space</a> request
      *
      * @param request the Get Space request
      * @return the response from the Get Space request
@@ -109,7 +109,7 @@ public interface Spaces {
     Mono<GetSpaceResponse> get(GetSpaceRequest request);
 
     /**
-     * Makes the <a href="https://apidocs.cloudfoundry.org/latest-release/spaces/get_space_summary.html">Get Space Summary</a> request
+     * Makes the <a href="https://v2-apidocs.cloudfoundry.org/spaces/get_space_summary.html">Get Space Summary</a> request
      *
      * @param request the Get Space Summary request
      * @return the response from the Get Space Summary request
@@ -117,7 +117,7 @@ public interface Spaces {
     Mono<GetSpaceSummaryResponse> getSummary(GetSpaceSummaryRequest request);
 
     /**
-     * Makes the <a href="https://apidocs.cloudfoundry.org/latest-release/spaces/list_all_spaces.html">List Spaces</a> request
+     * Makes the <a href="https://v2-apidocs.cloudfoundry.org/spaces/list_all_spaces.html">List Spaces</a> request
      *
      * @param request the List Spaces request
      * @return the response from the List Spaces request
@@ -125,7 +125,7 @@ public interface Spaces {
     Mono<ListSpacesResponse> list(ListSpacesRequest request);
 
     /**
-     * Makes the <a href="https://apidocs.cloudfoundry.org/latest-release/spaces/list_all_apps_for_the_space.html">List all Apps for the Space</a> request
+     * Makes the <a href="https://v2-apidocs.cloudfoundry.org/spaces/list_all_apps_for_the_space.html">List all Apps for the Space</a> request
      *
      * @param request the List all Apps for the Space request
      * @return the response from the List all Apps for the Space request
@@ -133,7 +133,7 @@ public interface Spaces {
     Mono<ListSpaceApplicationsResponse> listApplications(ListSpaceApplicationsRequest request);
 
     /**
-     * Makes the <a href="https://apidocs.cloudfoundry.org/latest-release/spaces/list_all_auditors_for_the_space.html">List all Auditors for the Space</a> request
+     * Makes the <a href="https://v2-apidocs.cloudfoundry.org/spaces/list_all_auditors_for_the_space.html">List all Auditors for the Space</a> request
      *
      * @param request the List all Auditors for the Space request
      * @return the response from the List all Auditors for the Space request
@@ -141,7 +141,7 @@ public interface Spaces {
     Mono<ListSpaceAuditorsResponse> listAuditors(ListSpaceAuditorsRequest request);
 
     /**
-     * Makes the <a href="https://apidocs.cloudfoundry.org/latest-release/spaces/list_all_developers_for_the_space.html">List all Developers for the Space</a> request
+     * Makes the <a href="https://v2-apidocs.cloudfoundry.org/spaces/list_all_developers_for_the_space.html">List all Developers for the Space</a> request
      *
      * @param request the List all Developers for the Space request
      * @return the response from the List all Developers for the Space request
@@ -149,7 +149,7 @@ public interface Spaces {
     Mono<ListSpaceDevelopersResponse> listDevelopers(ListSpaceDevelopersRequest request);
 
     /**
-     * Makes the deprecated <a href="https://apidocs.cloudfoundry.org/latest-release/spaces/list_all_domains_for_the_space_%28deprecated%29.html">List all Domains for the Space</a> request
+     * Makes the deprecated <a href="https://v2-apidocs.cloudfoundry.org/spaces/list_all_domains_for_the_space_%28deprecated%29.html">List all Domains for the Space</a> request
      *
      * @param request the List all Domains for the Space request
      * @return the response from the List all Domains for the Space request
@@ -158,7 +158,7 @@ public interface Spaces {
     Mono<ListSpaceDomainsResponse> listDomains(ListSpaceDomainsRequest request);
 
     /**
-     * Makes the <a href="https://apidocs.cloudfoundry.org/latest-release/spaces/list_all_events_for_the_space.html">List all Events for the Space</a> request
+     * Makes the <a href="https://v2-apidocs.cloudfoundry.org/spaces/list_all_events_for_the_space.html">List all Events for the Space</a> request
      *
      * @param request the List all Events for the Space request
      * @return the response from the List all Events for the Space request
@@ -166,7 +166,7 @@ public interface Spaces {
     Mono<ListSpaceEventsResponse> listEvents(ListSpaceEventsRequest request);
 
     /**
-     * Makes the <a href="https://apidocs.cloudfoundry.org/latest-release/spaces/list_all_managers_for_the_space.html">List all Managers for the Space</a> request
+     * Makes the <a href="https://v2-apidocs.cloudfoundry.org/spaces/list_all_managers_for_the_space.html">List all Managers for the Space</a> request
      *
      * @param request the List all Managers for the Space request
      * @return the response from the List all Managers for the Space request
@@ -174,7 +174,7 @@ public interface Spaces {
     Mono<ListSpaceManagersResponse> listManagers(ListSpaceManagersRequest request);
 
     /**
-     * Makes the <a href="https://apidocs.cloudfoundry.org/latest-release/spaces/list_all_routes_for_the_space.html">List all Routes for the Space</a> request
+     * Makes the <a href="https://v2-apidocs.cloudfoundry.org/spaces/list_all_routes_for_the_space.html">List all Routes for the Space</a> request
      *
      * @param request the List all Routes for the Space request
      * @return the response from the List all Routes for the Space request
@@ -182,7 +182,7 @@ public interface Spaces {
     Mono<ListSpaceRoutesResponse> listRoutes(ListSpaceRoutesRequest request);
 
     /**
-     * Makes the <a href="https://apidocs.cloudfoundry.org/latest-release/spaces/list_all_security_groups_for_the_space.html">List all Security Groups for the Space</a> request
+     * Makes the <a href="https://v2-apidocs.cloudfoundry.org/spaces/list_all_security_groups_for_the_space.html">List all Security Groups for the Space</a> request
      *
      * @param request the List all Security Groups for the Space request
      * @return the response from the List all Security Groups for the Space request
@@ -191,7 +191,7 @@ public interface Spaces {
             ListSpaceSecurityGroupsRequest request);
 
     /**
-     * Makes the <a href="https://apidocs.cloudfoundry.org/latest-release/spaces/list_all_service_instances_for_the_space.html">List all Service Instances for the Space</a> request
+     * Makes the <a href="https://v2-apidocs.cloudfoundry.org/spaces/list_all_service_instances_for_the_space.html">List all Service Instances for the Space</a> request
      *
      * @param request the List all Service Instances for the Space request
      * @return the response from the List all Service Instances for the Space request
@@ -200,7 +200,7 @@ public interface Spaces {
             ListSpaceServiceInstancesRequest request);
 
     /**
-     * Makes the <a href="https://apidocs.cloudfoundry.org/latest-release/spaces/list_all_services_for_the_space.html">List all Services for the Space</a> request
+     * Makes the <a href="https://v2-apidocs.cloudfoundry.org/spaces/list_all_services_for_the_space.html">List all Services for the Space</a> request
      *
      * @param request the List all Services for the Space request
      * @return the response from the List all Services for the Space request
@@ -208,7 +208,7 @@ public interface Spaces {
     Mono<ListSpaceServicesResponse> listServices(ListSpaceServicesRequest request);
 
     /**
-     * Makes the <a href="https://apidocs.cloudfoundry.org/latest-release/spaces/retrieving_the_roles_of_all_users_in_the_space.html">Retrieving the roles of all Users in the Space</a> request
+     * Makes the <a href="https://v2-apidocs.cloudfoundry.org/spaces/retrieving_the_roles_of_all_users_in_the_space.html">Retrieving the roles of all Users in the Space</a> request
      *
      * @param request the Retrieving the roles of all Users in the Space request
      * @return the response from the Retrieving the roles of all Users in the Space request
@@ -216,7 +216,7 @@ public interface Spaces {
     Mono<ListSpaceUserRolesResponse> listUserRoles(ListSpaceUserRolesRequest request);
 
     /**
-     * Makes the <a href="https://apidocs.cloudfoundry.org/latest-release/spaces/remove_auditor_from_the_space.html">Remove Auditor from the Space</a> request
+     * Makes the <a href="https://v2-apidocs.cloudfoundry.org/spaces/remove_auditor_from_the_space.html">Remove Auditor from the Space</a> request
      *
      * @param request the Remove Auditor from the Space request
      * @return the response from the Remove Auditor from the Space request
@@ -224,7 +224,7 @@ public interface Spaces {
     Mono<Void> removeAuditor(RemoveSpaceAuditorRequest request);
 
     /**
-     * Makes the <a href="https://apidocs.cloudfoundry.org/latest-release/spaces/disassociate_auditor_with_the_space_by_username.html">Disassociate Auditor with the Space by Username</a> request
+     * Makes the <a href="https://v2-apidocs.cloudfoundry.org/spaces/disassociate_auditor_with_the_space_by_username.html">Disassociate Auditor with the Space by Username</a> request
      *
      * @param request the Disassociate Auditor with the Space by Username request
      * @return the response from the Disassociate Auditor with the Space by Username request
@@ -233,7 +233,7 @@ public interface Spaces {
             RemoveSpaceAuditorByUsernameRequest request);
 
     /**
-     * Makes the <a href="https://apidocs.cloudfoundry.org/latest-release/spaces/remove_developer_from_the_space.html">Remove Developer from the Space</a> request
+     * Makes the <a href="https://v2-apidocs.cloudfoundry.org/spaces/remove_developer_from_the_space.html">Remove Developer from the Space</a> request
      *
      * @param request the Remove Developer from the Space request
      * @return the response from the Remove Developer from the Space request
@@ -241,7 +241,7 @@ public interface Spaces {
     Mono<Void> removeDeveloper(RemoveSpaceDeveloperRequest request);
 
     /**
-     * Makes the <a href="https://apidocs.cloudfoundry.org/latest-release/spaces/disassociate_developer_with_the_space_by_username.html">Disassociate Developer with the Space by Username</a> request
+     * Makes the <a href="https://v2-apidocs.cloudfoundry.org/spaces/disassociate_developer_with_the_space_by_username.html">Disassociate Developer with the Space by Username</a> request
      *
      * @param request the Disassociate Developer with the Space by Username request
      * @return the response from the Disassociate Developer with the Space by Username request
@@ -250,7 +250,7 @@ public interface Spaces {
             RemoveSpaceDeveloperByUsernameRequest request);
 
     /**
-     * Makes the <a href="https://apidocs.cloudfoundry.org/latest-release/spaces/remove_manager_from_the_space.html">Remove Manager from the Space</a> request
+     * Makes the <a href="https://v2-apidocs.cloudfoundry.org/spaces/remove_manager_from_the_space.html">Remove Manager from the Space</a> request
      *
      * @param request the Remove Manager from the Space request
      * @return the response from the Remove Manager from the Space request
@@ -258,7 +258,7 @@ public interface Spaces {
     Mono<Void> removeManager(RemoveSpaceManagerRequest request);
 
     /**
-     * Makes the <a href="https://apidocs.cloudfoundry.org/latest-release/spaces/disassociate_manager_with_the_space_by_username.html">Disassociate Manager with the Space by Username</a> request
+     * Makes the <a href="https://v2-apidocs.cloudfoundry.org/spaces/disassociate_manager_with_the_space_by_username.html">Disassociate Manager with the Space by Username</a> request
      *
      * @param request the Disassociate Manager with the Space by Username request
      * @return the response from the Disassociate Manager with the Space by Username request
@@ -267,7 +267,7 @@ public interface Spaces {
             RemoveSpaceManagerByUsernameRequest request);
 
     /**
-     * Makes the <a href="https://apidocs.cloudfoundry.org/latest-release/spaces/remove_security_group_from_the_space.html">Remove Security Group from the Space</a> request
+     * Makes the <a href="https://v2-apidocs.cloudfoundry.org/spaces/remove_security_group_from_the_space.html">Remove Security Group from the Space</a> request
      *
      * @param request the Remove Security Group from the Space request
      * @return the response from the Remove Security Group from the Space request
@@ -275,7 +275,7 @@ public interface Spaces {
     Mono<Void> removeSecurityGroup(RemoveSpaceSecurityGroupRequest request);
 
     /**
-     * Makes the <a href="https://apidocs.cloudfoundry.org/latest-release/spaces/update_a_space.html">Update a Space</a> request
+     * Makes the <a href="https://v2-apidocs.cloudfoundry.org/spaces/update_a_space.html">Update a Space</a> request
      *
      * @param request the Update a Space request
      * @return the response from the Update a Space request

--- a/cloudfoundry-client/src/main/java/org/cloudfoundry/client/v2/stacks/Stacks.java
+++ b/cloudfoundry-client/src/main/java/org/cloudfoundry/client/v2/stacks/Stacks.java
@@ -21,7 +21,7 @@ import reactor.core.publisher.Mono;
 public interface Stacks {
 
     /**
-     * Makes the <a href="https://apidocs.cloudfoundry.org/latest-release/stacks/create_a_stack.html">Create a Stack</a> request
+     * Makes the <a href="https://v2-apidocs.cloudfoundry.org/stacks/create_a_stack.html">Create a Stack</a> request
      *
      * @param request the Create a Stack request
      * @return the response from the Create a Stack Request
@@ -29,7 +29,7 @@ public interface Stacks {
     Mono<CreateStackResponse> create(CreateStackRequest request);
 
     /**
-     * Makes the <a href="https://apidocs.cloudfoundry.org/latest-release/stacks/delete_a_particular_stack.html">Delete a Stack</a> request
+     * Makes the <a href="https://v2-apidocs.cloudfoundry.org/stacks/delete_a_particular_stack.html">Delete a Stack</a> request
      *
      * @param request the Delete a Stack request
      * @return the response from the Delete a Stack Request
@@ -37,7 +37,7 @@ public interface Stacks {
     Mono<DeleteStackResponse> delete(DeleteStackRequest request);
 
     /**
-     * Makes the <a href="https://apidocs.cloudfoundry.org/latest-release/stacks/retrieve_a_particular_stack.html">Get Stack</a> request
+     * Makes the <a href="https://v2-apidocs.cloudfoundry.org/stacks/retrieve_a_particular_stack.html">Get Stack</a> request
      *
      * @param request the Get Stack request
      * @return the response from the Get Stack Request
@@ -45,7 +45,7 @@ public interface Stacks {
     Mono<GetStackResponse> get(GetStackRequest request);
 
     /**
-     * Makes the <a href="https://apidocs.cloudfoundry.org/latest-release/stacks/list_all_stacks.html">List Stacks</a> request
+     * Makes the <a href="https://v2-apidocs.cloudfoundry.org/stacks/list_all_stacks.html">List Stacks</a> request
      *
      * @param request the List Stacks request
      * @return the response from the List Stacks request

--- a/cloudfoundry-client/src/main/java/org/cloudfoundry/client/v2/userprovidedserviceinstances/UserProvidedServiceInstances.java
+++ b/cloudfoundry-client/src/main/java/org/cloudfoundry/client/v2/userprovidedserviceinstances/UserProvidedServiceInstances.java
@@ -24,7 +24,7 @@ import reactor.core.publisher.Mono;
 public interface UserProvidedServiceInstances {
 
     /**
-     * Makes the <a href="https://apidocs.cloudfoundry.org/latest-release/user_provided_service_instances/associate_route_with_the_user_provided_service_instance.html">Associate Route with the User
+     * Makes the <a href="https://v2-apidocs.cloudfoundry.org/user_provided_service_instances/associate_route_with_the_user_provided_service_instance.html">Associate Route with the User
      * Provided Service Instance</a> request
      *
      * @param request the Associate Route With User Provided Service Instance request
@@ -34,7 +34,7 @@ public interface UserProvidedServiceInstances {
             AssociateUserProvidedServiceInstanceRouteRequest request);
 
     /**
-     * Makes the <a href="https://apidocs.cloudfoundry.org/latest-release/user_provided_service_instances/creating_a_user_provided_service_instance.html">Create User Provided Service Instance</a>
+     * Makes the <a href="https://v2-apidocs.cloudfoundry.org/user_provided_service_instances/creating_a_user_provided_service_instance.html">Create User Provided Service Instance</a>
      * request
      *
      * @param request the Create User Provided Service Instance request
@@ -44,7 +44,7 @@ public interface UserProvidedServiceInstances {
             CreateUserProvidedServiceInstanceRequest request);
 
     /**
-     * Makes the <a href="https://apidocs.cloudfoundry.org/latest-release/user_provided_service_instances/delete_a_particular_user_provided_service_instance.html">Delete the User Provided Service
+     * Makes the <a href="https://v2-apidocs.cloudfoundry.org/user_provided_service_instances/delete_a_particular_user_provided_service_instance.html">Delete the User Provided Service
      * Instance</a> request
      *
      * @param request the Delete User Provided Service Instance request
@@ -53,7 +53,7 @@ public interface UserProvidedServiceInstances {
     Mono<Void> delete(DeleteUserProvidedServiceInstanceRequest request);
 
     /**
-     * Makes the <a href="https://apidocs.cloudfoundry.org/latest-release/user_provided_service_instances/retrieve_a_particular_user_provided_service_instance.html">Retrieve a Particular User Provided
+     * Makes the <a href="https://v2-apidocs.cloudfoundry.org/user_provided_service_instances/retrieve_a_particular_user_provided_service_instance.html">Retrieve a Particular User Provided
      * Service Instance</a> request
      *
      * @param request the Get User Provided Service Instance request
@@ -62,7 +62,7 @@ public interface UserProvidedServiceInstances {
     Mono<GetUserProvidedServiceInstanceResponse> get(GetUserProvidedServiceInstanceRequest request);
 
     /**
-     * Makes the <a href="https://apidocs.cloudfoundry.org/latest-release/user_provided_service_instances/list_all_user_provided_service_instances.html">List User Provided Service Instances</a>
+     * Makes the <a href="https://v2-apidocs.cloudfoundry.org/user_provided_service_instances/list_all_user_provided_service_instances.html">List User Provided Service Instances</a>
      * request
      *
      * @param request the List User Provided Service Instances request
@@ -72,7 +72,7 @@ public interface UserProvidedServiceInstances {
             ListUserProvidedServiceInstancesRequest request);
 
     /**
-     * Makes the <a href="https://apidocs.cloudfoundry.org/latest-release/user_provided_service_instances/list_all_routes_for_the_user_provided_service_instance.html">List all Routes for the User
+     * Makes the <a href="https://v2-apidocs.cloudfoundry.org/user_provided_service_instances/list_all_routes_for_the_user_provided_service_instance.html">List all Routes for the User
      * Provided Service Instance</a> request
      *
      * @param request the List User Provided Service Instance Routes request
@@ -82,7 +82,7 @@ public interface UserProvidedServiceInstances {
             ListUserProvidedServiceInstanceRoutesRequest request);
 
     /**
-     * Makes the <a href="https://apidocs.cloudfoundry.org/latest-release/user_provided_service_instances/list_all_service_bindings_for_the_user_provided_service_instance.html">List all Service
+     * Makes the <a href="https://v2-apidocs.cloudfoundry.org/user_provided_service_instances/list_all_service_bindings_for_the_user_provided_service_instance.html">List all Service
      * Bindings for the User Provided Service Instance</a> request
      *
      * @param request the List Service Bindings request
@@ -92,7 +92,7 @@ public interface UserProvidedServiceInstances {
             ListUserProvidedServiceInstanceServiceBindingsRequest request);
 
     /**
-     * Makes the <a href="https://apidocs.cloudfoundry.org/latest-release/user_provided_service_instances/remove_route_from_the_user_provided_service_instance.html">Remove Route from the User Provided
+     * Makes the <a href="https://v2-apidocs.cloudfoundry.org/user_provided_service_instances/remove_route_from_the_user_provided_service_instance.html">Remove Route from the User Provided
      * Service Instance</a> request
      *
      * @param request the Remove Route from the User Provided Service Instance request
@@ -101,7 +101,7 @@ public interface UserProvidedServiceInstances {
     Mono<Void> removeRoute(RemoveUserProvidedServiceInstanceRouteRequest request);
 
     /**
-     * Makes the <a href="https://apidocs.cloudfoundry.org/latest-release/user_provided_service_instances/updating_a_user_provided_service_instance.html">Update User Provided Service Instance</a>
+     * Makes the <a href="https://v2-apidocs.cloudfoundry.org/user_provided_service_instances/updating_a_user_provided_service_instance.html">Update User Provided Service Instance</a>
      * request
      *
      * @param request the Update User Provided Service Instance request

--- a/cloudfoundry-client/src/main/java/org/cloudfoundry/client/v2/users/Users.java
+++ b/cloudfoundry-client/src/main/java/org/cloudfoundry/client/v2/users/Users.java
@@ -21,7 +21,7 @@ import reactor.core.publisher.Mono;
 public interface Users {
 
     /**
-     * Makes the <a href="https://apidocs.cloudfoundry.org/latest-release/users/associate_audited_organization_with_the_user.html">Associate Audited Organization with the User</a> request
+     * Makes the <a href="https://v2-apidocs.cloudfoundry.org/users/associate_audited_organization_with_the_user.html">Associate Audited Organization with the User</a> request
      *
      * @param request the Associate Audited Organization with the User request
      * @return the response from the Associate Audited Organization with the User request
@@ -30,7 +30,7 @@ public interface Users {
             AssociateUserAuditedOrganizationRequest request);
 
     /**
-     * Makes the <a href="https://apidocs.cloudfoundry.org/latest-release/users/associate_audited_space_with_the_user.html">Associate Audited Space with the User</a> request
+     * Makes the <a href="https://v2-apidocs.cloudfoundry.org/users/associate_audited_space_with_the_user.html">Associate Audited Space with the User</a> request
      *
      * @param request the Associate Audited Space with the User request
      * @return the response from the Associate Audited Space with the User request
@@ -39,7 +39,7 @@ public interface Users {
             AssociateUserAuditedSpaceRequest request);
 
     /**
-     * Makes the <a href="https://apidocs.cloudfoundry.org/latest-release/users/associate_billing_managed_organization_with_the_user.html">Associate Billing Managed Organization with the User</a>
+     * Makes the <a href="https://v2-apidocs.cloudfoundry.org/users/associate_billing_managed_organization_with_the_user.html">Associate Billing Managed Organization with the User</a>
      * request
      *
      * @param request the Associate Billing Managed Organization with the User request
@@ -49,7 +49,7 @@ public interface Users {
             AssociateUserBillingManagedOrganizationRequest request);
 
     /**
-     * Makes the <a href="https://apidocs.cloudfoundry.org/latest-release/users/associate_managed_organization_with_the_user.html">Associate Managed Organization with the User</a> request
+     * Makes the <a href="https://v2-apidocs.cloudfoundry.org/users/associate_managed_organization_with_the_user.html">Associate Managed Organization with the User</a> request
      *
      * @param request the Associate Managed Organization with the User request
      * @return the response from the Associate Managed Organization with the User request
@@ -58,7 +58,7 @@ public interface Users {
             AssociateUserManagedOrganizationRequest request);
 
     /**
-     * Makes the <a href="https://apidocs.cloudfoundry.org/latest-release/users/associate_managed_space_with_the_user.html">Associate Managed Space with the User</a> request
+     * Makes the <a href="https://v2-apidocs.cloudfoundry.org/users/associate_managed_space_with_the_user.html">Associate Managed Space with the User</a> request
      *
      * @param request the Associate Managed Space with the User request
      * @return the response from the Associate Managed Space with the User request
@@ -67,7 +67,7 @@ public interface Users {
             AssociateUserManagedSpaceRequest request);
 
     /**
-     * Makes the <a href="https://apidocs.cloudfoundry.org/latest-release/users/associate_organization_with_the_user.html">Associate Organization with the User</a> request
+     * Makes the <a href="https://v2-apidocs.cloudfoundry.org/users/associate_organization_with_the_user.html">Associate Organization with the User</a> request
      *
      * @param request the Associate Organization with the User request
      * @return the response from the Associate Organization with the User request
@@ -76,7 +76,7 @@ public interface Users {
             AssociateUserOrganizationRequest request);
 
     /**
-     * Makes the <a href="https://apidocs.cloudfoundry.org/latest-release/users/associate_space_with_the_user.html">Associate Space with the User</a> request
+     * Makes the <a href="https://v2-apidocs.cloudfoundry.org/users/associate_space_with_the_user.html">Associate Space with the User</a> request
      *
      * @param request the Associate Space with the User request
      * @return the response from the Associate Space with the User request
@@ -84,7 +84,7 @@ public interface Users {
     Mono<AssociateUserSpaceResponse> associateSpace(AssociateUserSpaceRequest request);
 
     /**
-     * Makes the <a href="https://apidocs.cloudfoundry.org/latest-release/users/creating_a_user.html">Creating a User</a> request
+     * Makes the <a href="https://v2-apidocs.cloudfoundry.org/users/creating_a_user.html">Creating a User</a> request
      *
      * @param request the Creating a User request
      * @return the response from the Creating a User request
@@ -92,7 +92,7 @@ public interface Users {
     Mono<CreateUserResponse> create(CreateUserRequest request);
 
     /**
-     * Makes the <a href="https://apidocs.cloudfoundry.org/latest-release/users/delete_a_particular_user.html">Delete a Particular User</a> request
+     * Makes the <a href="https://v2-apidocs.cloudfoundry.org/users/delete_a_particular_user.html">Delete a Particular User</a> request
      *
      * @param request the Delete a Particular User request
      * @return the response from the Delete a Particular User request
@@ -100,7 +100,7 @@ public interface Users {
     Mono<DeleteUserResponse> delete(DeleteUserRequest request);
 
     /**
-     * Makes the <a href="https://apidocs.cloudfoundry.org/latest-release/users/retrieve_a_particular_user.html">Retrieve a Particular User</a> request
+     * Makes the <a href="https://v2-apidocs.cloudfoundry.org/users/retrieve_a_particular_user.html">Retrieve a Particular User</a> request
      *
      * @param request the Retrieve a Particular User request
      * @return the response from the Retrieve a Particular User request
@@ -108,7 +108,7 @@ public interface Users {
     Mono<GetUserResponse> get(GetUserRequest request);
 
     /**
-     * Makes the <a href="https://apidocs.cloudfoundry.org/latest-release/users/list_all_users.html">List all Users</a> request
+     * Makes the <a href="https://v2-apidocs.cloudfoundry.org/users/list_all_users.html">List all Users</a> request
      *
      * @param request the List all Users request
      * @return the response from the List all Users request
@@ -116,7 +116,7 @@ public interface Users {
     Mono<ListUsersResponse> list(ListUsersRequest request);
 
     /**
-     * Makes the <a href="https://apidocs.cloudfoundry.org/latest-release/users/list_all_audited_organizations_for_the_user.html">List all Audited Organizations for the User</a> request
+     * Makes the <a href="https://v2-apidocs.cloudfoundry.org/users/list_all_audited_organizations_for_the_user.html">List all Audited Organizations for the User</a> request
      *
      * @param request the List all Audited Organizations for the User request
      * @return the response from the List all Audited Organizations for the User request
@@ -125,7 +125,7 @@ public interface Users {
             ListUserAuditedOrganizationsRequest request);
 
     /**
-     * Makes the <a href="https://apidocs.cloudfoundry.org/latest-release/users/list_all_audited_spaces_for_the_user.html">List all Audited Spaces for the User</a> request
+     * Makes the <a href="https://v2-apidocs.cloudfoundry.org/users/list_all_audited_spaces_for_the_user.html">List all Audited Spaces for the User</a> request
      *
      * @param request the List all Audited Spaces for the User request
      * @return the response from the List all Audited Spaces for the User request
@@ -133,7 +133,7 @@ public interface Users {
     Mono<ListUserAuditedSpacesResponse> listAuditedSpaces(ListUserAuditedSpacesRequest request);
 
     /**
-     * Makes the <a href="https://apidocs.cloudfoundry.org/latest-release/users/list_all_billing_managed_organizations_for_the_user.html">List all Billing Managed Organizations for the User</a> request
+     * Makes the <a href="https://v2-apidocs.cloudfoundry.org/users/list_all_billing_managed_organizations_for_the_user.html">List all Billing Managed Organizations for the User</a> request
      *
      * @param request the List all Billing Managed Organizations for the User request
      * @return the response from the List all Billing Managed Organizations for the User request
@@ -142,7 +142,7 @@ public interface Users {
             ListUserBillingManagedOrganizationsRequest request);
 
     /**
-     * Makes the <a href="https://apidocs.cloudfoundry.org/latest-release/users/list_all_managed_organizations_for_the_user.html">List all Managed Organizations for the User</a> request
+     * Makes the <a href="https://v2-apidocs.cloudfoundry.org/users/list_all_managed_organizations_for_the_user.html">List all Managed Organizations for the User</a> request
      *
      * @param request the List all Managed Organizations for the User request
      * @return the response from the List all Managed Organizations for the User request
@@ -151,7 +151,7 @@ public interface Users {
             ListUserManagedOrganizationsRequest request);
 
     /**
-     * Makes the <a href="https://apidocs.cloudfoundry.org/latest-release/users/list_all_managed_spaces_for_the_user.html">List all Managed Spaces for the User</a> request
+     * Makes the <a href="https://v2-apidocs.cloudfoundry.org/users/list_all_managed_spaces_for_the_user.html">List all Managed Spaces for the User</a> request
      *
      * @param request the List all Managed Spaces for the User request
      * @return the response from the List all Managed Spaces for the User request
@@ -159,7 +159,7 @@ public interface Users {
     Mono<ListUserManagedSpacesResponse> listManagedSpaces(ListUserManagedSpacesRequest request);
 
     /**
-     * Makes the <a href="https://apidocs.cloudfoundry.org/latest-release/users/list_all_organizations_for_the_user.html">List all Organizations for the User</a> request
+     * Makes the <a href="https://v2-apidocs.cloudfoundry.org/users/list_all_organizations_for_the_user.html">List all Organizations for the User</a> request
      *
      * @param request the List all Organizations for the User request
      * @return the response from the List all Organizations for the User request
@@ -167,7 +167,7 @@ public interface Users {
     Mono<ListUserOrganizationsResponse> listOrganizations(ListUserOrganizationsRequest request);
 
     /**
-     * Makes the <a href="https://apidocs.cloudfoundry.org/latest-release/users/list_all_spaces_for_the_user.html">List all Spaces for the User</a> request
+     * Makes the <a href="https://v2-apidocs.cloudfoundry.org/users/list_all_spaces_for_the_user.html">List all Spaces for the User</a> request
      *
      * @param request the List all Spaces for the User request
      * @return the response from the List all Spaces for the User request
@@ -175,7 +175,7 @@ public interface Users {
     Mono<ListUserSpacesResponse> listSpaces(ListUserSpacesRequest request);
 
     /**
-     * Makes the <a href="https://apidocs.cloudfoundry.org/latest-release/users/remove_audited_organization_from_the_user.html">Remove Audited Organization from the User</a> request
+     * Makes the <a href="https://v2-apidocs.cloudfoundry.org/users/remove_audited_organization_from_the_user.html">Remove Audited Organization from the User</a> request
      *
      * @param request the Remove Audited Organization from the User request
      * @return the response from the Remove Audited Organization from the User request
@@ -183,7 +183,7 @@ public interface Users {
     Mono<Void> removeAuditedOrganization(RemoveUserAuditedOrganizationRequest request);
 
     /**
-     * Makes the <a href="https://apidocs.cloudfoundry.org/latest-release/users/remove_managed_space_from_the_user.html">Remove Audited Space from the User</a> request
+     * Makes the <a href="https://v2-apidocs.cloudfoundry.org/users/remove_managed_space_from_the_user.html">Remove Audited Space from the User</a> request
      *
      * @param request the Remove Audited Space from the User request
      * @return the response from the Remove Audited Space from the User request
@@ -191,7 +191,7 @@ public interface Users {
     Mono<Void> removeAuditedSpace(RemoveUserAuditedSpaceRequest request);
 
     /**
-     * Makes the <a href="https://apidocs.cloudfoundry.org/latest-release/users/remove_billing_managed_organization_from_the_user.html">Remove Managed Billing Organization from the User</a> request
+     * Makes the <a href="https://v2-apidocs.cloudfoundry.org/users/remove_billing_managed_organization_from_the_user.html">Remove Managed Billing Organization from the User</a> request
      *
      * @param request the Remove Billing Managed Organization from the User request
      * @return the response from the Remove Billing Managed Organization from the User request
@@ -200,7 +200,7 @@ public interface Users {
             RemoveUserBillingManagedOrganizationRequest request);
 
     /**
-     * Makes the <a href="https://apidocs.cloudfoundry.org/latest-release/users/remove_managed_organization_from_the_user.html">Remove Managed Organization from the User</a> request
+     * Makes the <a href="https://v2-apidocs.cloudfoundry.org/users/remove_managed_organization_from_the_user.html">Remove Managed Organization from the User</a> request
      *
      * @param request the Remove Managed Organization from the User request
      * @return the response from the Remove Managed Organization from the User request
@@ -208,7 +208,7 @@ public interface Users {
     Mono<Void> removeManagedOrganization(RemoveUserManagedOrganizationRequest request);
 
     /**
-     * Makes the <a href="https://apidocs.cloudfoundry.org/latest-release/users/remove_managed_space_from_the_user.html">Remove Managed Space from the User</a> request
+     * Makes the <a href="https://v2-apidocs.cloudfoundry.org/users/remove_managed_space_from_the_user.html">Remove Managed Space from the User</a> request
      *
      * @param request the Remove Managed Space from the User request
      * @return the response from the Remove Managed Space from the User request
@@ -216,7 +216,7 @@ public interface Users {
     Mono<Void> removeManagedSpace(RemoveUserManagedSpaceRequest request);
 
     /**
-     * Makes the <a href="https://apidocs.cloudfoundry.org/latest-release/users/remove_organization_from_the_user.html">Remove Organization from the User</a> request
+     * Makes the <a href="https://v2-apidocs.cloudfoundry.org/users/remove_organization_from_the_user.html">Remove Organization from the User</a> request
      *
      * @param request the Remove Organization from the User request
      * @return the response from the Remove Organization from the User request
@@ -224,7 +224,7 @@ public interface Users {
     Mono<Void> removeOrganization(RemoveUserOrganizationRequest request);
 
     /**
-     * Makes the <a href="https://apidocs.cloudfoundry.org/latest-release/users/associate_space_with_the_user.html">Remove Space from the User</a> request
+     * Makes the <a href="https://v2-apidocs.cloudfoundry.org/users/associate_space_with_the_user.html">Remove Space from the User</a> request
      *
      * @param request the Remove Space from the User request
      * @return the response from the Remove Space from the User request
@@ -232,7 +232,7 @@ public interface Users {
     Mono<Void> removeSpace(RemoveUserSpaceRequest request);
 
     /**
-     * Makes the <a href="https://apidocs.cloudfoundry.org/latest-release/users/get_user_summary.html">Get User Summary</a> request
+     * Makes the <a href="https://v2-apidocs.cloudfoundry.org/users/get_user_summary.html">Get User Summary</a> request
      *
      * @param request the Get User summary request
      * @return the response from the Get User summary request
@@ -240,7 +240,7 @@ public interface Users {
     Mono<SummaryUserResponse> summary(SummaryUserRequest request);
 
     /**
-     * Makes the <a href="https://apidocs.cloudfoundry.org/latest-release/users/updating_a_user.html">Updating a User</a> request
+     * Makes the <a href="https://v2-apidocs.cloudfoundry.org/users/updating_a_user.html">Updating a User</a> request
      *
      * @param request the Updating a User request
      * @return the response from the Updating a User request

--- a/cloudfoundry-client/src/main/java/org/cloudfoundry/client/v3/securitygroups/SecurityGroupsV3.java
+++ b/cloudfoundry-client/src/main/java/org/cloudfoundry/client/v3/securitygroups/SecurityGroupsV3.java
@@ -22,7 +22,7 @@ public interface SecurityGroupsV3 {
 
     /**
      * Makes the <a href=
-     * "https://apidocs.cloudfoundry.org/latest-release/security_groups/creating_a_security_group.html">Creating
+     * "https://v3-apidocs.cloudfoundry.org/version/3.169.0/index.html#create-a-security-group">Creating
      * a Security Group</a> request.
      *
      * @param request the Create Security Group request


### PR DESCRIPTION
This PR updates CAPI v2 docs links from `apidocs.cloudfoundry.org` to `v2-apidocs.cloudfoundry.org`.
The goal is to signal that v3 is the primary API, also a necessary step in eventually sunsetting v2.

~~The infrastructure hosting the app serving docs at apidocs.cloudfoundry.org is expected to go down imminently, so this change is needed to avoid dead links.~~
`apidocs.cloudfoundry.org` has been converted to a redirect to `v3-apidocs.cloudfoundry.org`, so this change is needed to avoid incorrect links

See capi-release PRs [#440](https://github.com/cloudfoundry/capi-release/pull/440) and [#441](https://github.com/cloudfoundry/capi-release/pull/441)