### PR TITLE
Deprecate doppler-based ApplicationsTests#logs, restrict tests to to CF 2.x line

### DIFF
--- a/cloudfoundry-operations/src/main/java/org/cloudfoundry/operations/applications/ApplicationLogType.java
+++ b/cloudfoundry-operations/src/main/java/org/cloudfoundry/operations/applications/ApplicationLogType.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright 2013-2025 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.cloudfoundry.operations.applications;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonValue;
+
+public enum ApplicationLogType {
+    /**
+     * {@code STDERR}
+     */
+    ERR("ERR"),
+
+    /**
+     * {@code STDOUT}
+     */
+    OUT("OUT");
+
+    private final String value;
+
+    ApplicationLogType(String value) {
+        this.value = value;
+    }
+
+    @JsonCreator
+    public static ApplicationLogType from(String s) {
+        switch (s.toLowerCase()) {
+            case "err":
+                return ERR;
+            case "out":
+                return OUT;
+            default:
+                throw new IllegalArgumentException(String.format("Unknown log type: %s", s));
+        }
+    }
+
+    @JsonValue
+    public String getValue() {
+        return this.value;
+    }
+
+    @Override
+    public String toString() {
+        return getValue();
+    }
+}

--- a/cloudfoundry-operations/src/main/java/org/cloudfoundry/operations/applications/Applications.java
+++ b/cloudfoundry-operations/src/main/java/org/cloudfoundry/operations/applications/Applications.java
@@ -115,12 +115,26 @@ public interface Applications {
     Flux<Task> listTasks(ListApplicationTasksRequest request);
 
     /**
-     * List the applications logs
+     * List the applications logs. Uses Doppler under the hood.
+     * Only works with {@code Loggregator < 107.0}, shipped in {@code CFD < 24.3}
+     * and {@code TAS < 4.0}.
+     *
+     * @param request the application logs request
+     * @return the applications logs
+     * @deprecated Use {@link #logs(ApplicationLogsRequest)} instead.
+     */
+    @Deprecated
+    Flux<LogMessage> logs(LogsRequest request);
+
+    /**
+     * List the applications logs.
+     * Only works with {@code Loggregator < 107.0}, shipped in {@code CFD < 24.3}
+     * and {@code TAS < 4.0}.
      *
      * @param request the application logs request
      * @return the applications logs
      */
-    Flux<LogMessage> logs(LogsRequest request);
+    Flux<ApplicationLog> logs(ApplicationLogsRequest request);
 
     /**
      * Push a specific application

--- a/cloudfoundry-operations/src/main/java/org/cloudfoundry/operations/applications/DefaultApplications.java
+++ b/cloudfoundry-operations/src/main/java/org/cloudfoundry/operations/applications/DefaultApplications.java
@@ -543,6 +543,26 @@ public final class DefaultApplications implements Applications {
     }
 
     @Override
+    public Flux<ApplicationLog> logs(ApplicationLogsRequest request) {
+        return logs(LogsRequest.builder()
+                        .name(request.getName())
+                        .recent(request.getRecent())
+                        .build())
+                .map(
+                        logMessage ->
+                                ApplicationLog.builder()
+                                        .sourceId(logMessage.getApplicationId())
+                                        .sourceType(logMessage.getSourceType())
+                                        .instanceId(logMessage.getSourceInstance())
+                                        .message(logMessage.getMessage())
+                                        .timestamp(logMessage.getTimestamp())
+                                        .logType(
+                                                ApplicationLogType.from(
+                                                        logMessage.getMessageType().name()))
+                                        .build());
+    }
+
+    @Override
     @SuppressWarnings("deprecation")
     public Mono<Void> push(PushApplicationRequest request) {
         ApplicationManifest.Builder builder =

--- a/cloudfoundry-operations/src/main/java/org/cloudfoundry/operations/applications/_ApplicationLog.java
+++ b/cloudfoundry-operations/src/main/java/org/cloudfoundry/operations/applications/_ApplicationLog.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2013-2025 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.cloudfoundry.operations.applications;
+
+import org.immutables.value.Value;
+
+/**
+ * Represents an application log.
+ */
+@Value.Immutable
+abstract class _ApplicationLog {
+    abstract String getSourceId();
+
+    abstract String getInstanceId();
+
+    abstract String getSourceType();
+
+    abstract String getMessage();
+
+    abstract ApplicationLogType getLogType();
+
+    abstract Long getTimestamp();
+}

--- a/cloudfoundry-operations/src/main/java/org/cloudfoundry/operations/applications/_ApplicationLogsRequest.java
+++ b/cloudfoundry-operations/src/main/java/org/cloudfoundry/operations/applications/_ApplicationLogsRequest.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2013-2025 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.cloudfoundry.operations.applications;
+
+import org.cloudfoundry.Nullable;
+import org.immutables.value.Value;
+
+/**
+ * Represents a request for logs.
+ */
+@Value.Immutable
+abstract class _ApplicationLogsRequest {
+
+    /**
+     * The name of the application
+     */
+    abstract String getName();
+
+    /**
+     * Whether only recent logs should be retrieved
+     */
+    @Nullable
+    abstract Boolean getRecent();
+}

--- a/integration-test/src/test/java/org/cloudfoundry/operations/ApplicationsTest.java
+++ b/integration-test/src/test/java/org/cloudfoundry/operations/ApplicationsTest.java
@@ -487,6 +487,7 @@ public final class ApplicationsTest extends AbstractIntegrationTest {
     }
 
     @Test
+    @IfCloudFoundryVersion(lessThan = CloudFoundryVersion.PCF_4_v2)
     public void logs() throws IOException {
         String applicationName = this.nameFactory.getApplicationName();
 


### PR DESCRIPTION
We should cut a release with what we have now. Once it is out, we can work on merging "recent logs" support for TAS 4.x

This PR paves the way for the work on logcache-based logging.

## Context

The DopplerClient does not work with Loggregator >= 107.0.0, and we cannot obtain "recent" logs. Until this is fixed, we cannot cut a release. That is the only blocking test.
- See :
  - gh-1181
  - gh-1230 
  - gh-1237


## Plan

- Prepare for supporting log-cache in place of the doppler client with the correct deprecation markers.
- Publish `5.13` with what's in main.
- Replace the `Applications#logs` implementation using the logcache client, both `--recent` and streaming logs.
- Publish `6.0` with the new logs implementation, deleting the old doppler-based `#logs` method.