### PR TITLE
Add the AWAITING_UPLOAD and PROCESSING_UPLOAD state for the Droplet Resource.

### DIFF
--- a/cloudfoundry-client-reactor/src/test/java/org/cloudfoundry/reactor/client/v3/droplets/ReactorDropletsTest.java
+++ b/cloudfoundry-client-reactor/src/test/java/org/cloudfoundry/reactor/client/v3/droplets/ReactorDropletsTest.java
@@ -339,7 +339,53 @@ final class ReactorDropletsTest extends AbstractClientApiTest {
                                 .resource(
                                         DropletResource.builder()
                                                 .id("fdf3851c-def8-4de1-87f1-6d4543189e22")
-                                                .state(DropletState.STAGED)
+                                                .state(DropletState.PROCESSING_UPLOAD)
+                                                .error(null)
+                                                .lifecycle(
+                                                        Lifecycle.builder()
+                                                                .type(LifecycleType.DOCKER)
+                                                                .data(DockerData.builder().build())
+                                                                .build())
+                                                .executionMetadata("[PRIVATE DATA HIDDEN IN LISTS]")
+                                                .processType(
+                                                        "redacted_message",
+                                                        "[PRIVATE DATA HIDDEN IN LISTS]")
+                                                .image(
+                                                        "cloudfoundry/diego-docker-app-custom:latest")
+                                                .checksum(null)
+                                                .stack(null)
+                                                .createdAt("2016-03-17T00:00:01Z")
+                                                .updatedAt("2016-03-17T21:41:32Z")
+                                                .link(
+                                                        "self",
+                                                        Link.builder()
+                                                                .href(
+                                                                        "https://api.example.org/v3/droplets/fdf3851c-def8-4de1-87f1-6d4543189e22")
+                                                                .build())
+                                                .link(
+                                                        "package",
+                                                        Link.builder()
+                                                                .href(
+                                                                        "https://api.example.org/v3/packages/c5725684-a02f-4e59-bc67-8f36ae944688")
+                                                                .build())
+                                                .link(
+                                                        "app",
+                                                        Link.builder()
+                                                                .href(
+                                                                        "https://api.example.org/v3/apps/7b34f1cf-7e73-428a-bb5a-8a17a8058396")
+                                                                .build())
+                                                .link(
+                                                        "assign_current_droplet",
+                                                        Link.builder()
+                                                                .href(
+                                                                        "https://api.example.org/v3/apps/7b34f1cf-7e73-428a-bb5a-8a17a8058396/relationships/current_droplet")
+                                                                .method("PATCH")
+                                                                .build())
+                                                .build())
+                                .resource(
+                                        DropletResource.builder()
+                                                .id("fdf3851c-def8-4de1-87f1-6d4543189e23")
+                                                .state(DropletState.AWAITING_UPLOAD)
                                                 .error(null)
                                                 .lifecycle(
                                                         Lifecycle.builder()
@@ -383,6 +429,7 @@ final class ReactorDropletsTest extends AbstractClientApiTest {
                                                                 .build())
                                                 .build())
                                 .build())
+
                 .expectComplete()
                 .verify(Duration.ofSeconds(5));
     }

--- a/cloudfoundry-client-reactor/src/test/java/org/cloudfoundry/reactor/client/v3/droplets/ReactorDropletsTest.java
+++ b/cloudfoundry-client-reactor/src/test/java/org/cloudfoundry/reactor/client/v3/droplets/ReactorDropletsTest.java
@@ -429,7 +429,6 @@ final class ReactorDropletsTest extends AbstractClientApiTest {
                                                                 .build())
                                                 .build())
                                 .build())
-
                 .expectComplete()
                 .verify(Duration.ofSeconds(5));
     }

--- a/cloudfoundry-client-reactor/src/test/resources/fixtures/client/v3/droplets/GET_response.json
+++ b/cloudfoundry-client-reactor/src/test/resources/fixtures/client/v3/droplets/GET_response.json
@@ -56,7 +56,41 @@
     },
     {
       "guid": "fdf3851c-def8-4de1-87f1-6d4543189e22",
-      "state": "STAGED",
+      "state": "PROCESSING_UPLOAD",
+      "error": null,
+      "lifecycle": {
+        "type": "docker",
+        "data": {}
+      },
+      "execution_metadata": "[PRIVATE DATA HIDDEN IN LISTS]",
+      "process_types": {
+        "redacted_message": "[PRIVATE DATA HIDDEN IN LISTS]"
+      },
+      "image": "cloudfoundry/diego-docker-app-custom:latest",
+      "checksum": null,
+      "buildpacks": null,
+      "stack": null,
+      "created_at": "2016-03-17T00:00:01Z",
+      "updated_at": "2016-03-17T21:41:32Z",
+      "links": {
+        "self": {
+          "href": "https://api.example.org/v3/droplets/fdf3851c-def8-4de1-87f1-6d4543189e22"
+        },
+        "package": {
+          "href": "https://api.example.org/v3/packages/c5725684-a02f-4e59-bc67-8f36ae944688"
+        },
+        "app": {
+          "href": "https://api.example.org/v3/apps/7b34f1cf-7e73-428a-bb5a-8a17a8058396"
+        },
+        "assign_current_droplet": {
+          "href": "https://api.example.org/v3/apps/7b34f1cf-7e73-428a-bb5a-8a17a8058396/relationships/current_droplet",
+          "method": "PATCH"
+        }
+      }
+    },
+    {
+      "guid": "fdf3851c-def8-4de1-87f1-6d4543189e23",
+      "state": "AWAITING_UPLOAD",
       "error": null,
       "lifecycle": {
         "type": "docker",

--- a/cloudfoundry-client/src/main/java/org/cloudfoundry/client/v3/droplets/DropletState.java
+++ b/cloudfoundry-client/src/main/java/org/cloudfoundry/client/v3/droplets/DropletState.java
@@ -43,7 +43,17 @@ public enum DropletState {
     /**
      * The staged state
      */
-    STAGED("STAGED");
+    STAGED("STAGED"),
+
+    /**
+     * The awaiting upload state
+     */
+    AWAITING_UPLOAD("AWAITING_UPLOAD"),
+
+    /**
+     * The processing upload state
+     */
+    PROCESSING_UPLOAD("PROCESSING_UPLOAD");
 
     private final String value;
 
@@ -62,6 +72,10 @@ public enum DropletState {
                 return FAILED;
             case "staged":
                 return STAGED;
+            case "awaiting_upload":
+                return AWAITING_UPLOAD;
+            case "processing_upload":
+                return PROCESSING_UPLOAD;
             default:
                 throw new IllegalArgumentException(String.format("Unknown droplet state: %s", s));
         }


### PR DESCRIPTION
Add the AWAITING_UPLOAD and PROCESSING_UPLOAD state for the Droplet resource, as stated in the CF API (https://v3-apidocs.cloudfoundry.org/version/3.192.0/#droplets).

Extend the ReactorDropletsTests to test those two new states.