### PR TITLE
issue-1242 Fixing version of PaginatedRequest implemented by v3._ListSecurityGroupsRequest

### DIFF
--- a/cloudfoundry-client/src/main/java/org/cloudfoundry/client/v3/securitygroups/_ListSecurityGroupsRequest.java
+++ b/cloudfoundry-client/src/main/java/org/cloudfoundry/client/v3/securitygroups/_ListSecurityGroupsRequest.java
@@ -14,7 +14,7 @@
 
 package org.cloudfoundry.client.v3.securitygroups;
 
-import org.cloudfoundry.client.v2.PaginatedRequest;
+import org.cloudfoundry.client.v3.PaginatedRequest;
 import org.immutables.value.Value;
 import org.cloudfoundry.client.v3.FilterParameter;
 import org.cloudfoundry.Nullable;

--- a/integration-test/src/test/java/org/cloudfoundry/client/v3/SecurityGroupsTest.java
+++ b/integration-test/src/test/java/org/cloudfoundry/client/v3/SecurityGroupsTest.java
@@ -18,6 +18,8 @@ import static org.cloudfoundry.client.v3.securitygroups.Protocol.TCP;
 
 import java.time.Duration;
 import java.util.Arrays;
+import java.util.Collections;
+
 import org.cloudfoundry.AbstractIntegrationTest;
 import org.cloudfoundry.client.CloudFoundryClient;
 import org.cloudfoundry.client.v3.securitygroups.BindRunningSecurityGroupRequest;
@@ -34,6 +36,7 @@ import org.cloudfoundry.client.v3.securitygroups.Rule;
 import org.cloudfoundry.client.v3.securitygroups.UnbindRunningSecurityGroupRequest;
 import org.cloudfoundry.client.v3.securitygroups.UnbindStagingSecurityGroupRequest;
 import org.cloudfoundry.client.v3.securitygroups.UpdateSecurityGroupRequest;
+import org.cloudfoundry.util.PaginationUtils;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -190,6 +193,27 @@ public final class SecurityGroupsTest extends AbstractIntegrationTest {
                                                         .spaceId(v.getT2())
                                                         .names(Arrays.asList(v.getT1().getName()))
                                                         .build()))
+                .as(StepVerifier::create)
+                .expectNextCount(1)
+                .expectComplete()
+                .verify(Duration.ofMinutes(5));
+    }
+
+    @Test
+    public void listWithPagination() {
+        this.securityGroup
+                .map(
+                        securityGroup ->
+                                PaginationUtils.requestClientV3Resources(
+                                        page ->
+                                                cloudFoundryClient
+                                                        .securityGroupsV3()
+                                                        .list(
+                                                                ListSecurityGroupsRequest.builder()
+                                                                        .page(page)
+                                                                        .perPage(1)
+                                                                        .names(Collections.singletonList(securityGroup.getName()))
+                                                                        .build())))
                 .as(StepVerifier::create)
                 .expectNextCount(1)
                 .expectComplete()


### PR DESCRIPTION
v3._ListSecurityGroupsRequest extends the v2.PaginatedRequest which is incorrect. It needs to extend the v3.PaginatedRequest. The code fixes the incorrect package referenced in v3._ListSecurityGroupsRequest and adds a integration test case