### PR TITLE
Fix v2.BuildpacksTest for CAPI < 2.209.x

### DIFF
--- a/integration-test/src/test/java/org/cloudfoundry/client/v2/BuildpacksTest.java
+++ b/integration-test/src/test/java/org/cloudfoundry/client/v2/BuildpacksTest.java
@@ -27,7 +27,6 @@ import org.cloudfoundry.client.v2.buildpacks.CreateBuildpackRequest;
 import org.cloudfoundry.client.v2.buildpacks.CreateBuildpackResponse;
 import org.cloudfoundry.client.v2.buildpacks.DeleteBuildpackRequest;
 import org.cloudfoundry.client.v2.buildpacks.GetBuildpackRequest;
-import org.cloudfoundry.client.v2.buildpacks.LifecycleType;
 import org.cloudfoundry.client.v2.buildpacks.ListBuildpacksRequest;
 import org.cloudfoundry.client.v2.buildpacks.UpdateBuildpackRequest;
 import org.cloudfoundry.client.v2.buildpacks.UploadBuildpackRequest;
@@ -58,16 +57,11 @@ public final class BuildpacksTest extends AbstractIntegrationTest {
                                 .name(buildpackName)
                                 .position(2)
                                 .build())
-                .map(ResourceUtils::getEntity)
+                .thenMany(requestListBuildpacks(this.cloudFoundryClient, buildpackName))
+                .map(BuildpackResource::getEntity)
+                .map(BuildpackEntity::getName)
                 .as(StepVerifier::create)
-                .expectNext(
-                        BuildpackEntity.builder()
-                                .enabled(false)
-                                .locked(true)
-                                .name(buildpackName)
-                                .position(2)
-                                .lifecycle(LifecycleType.BUILDPACK)
-                                .build())
+                .expectNext(buildpackName)
                 .expectComplete()
                 .verify(Duration.ofMinutes(5));
     }
@@ -130,15 +124,9 @@ public final class BuildpacksTest extends AbstractIntegrationTest {
                                                         .buildpackId(buildpackId)
                                                         .build()))
                 .map(ResourceUtils::getEntity)
+                .map(BuildpackEntity::getName)
                 .as(StepVerifier::create)
-                .expectNext(
-                        BuildpackEntity.builder()
-                                .enabled(false)
-                                .locked(false)
-                                .name(buildpackName)
-                                .position(3)
-                                .lifecycle(LifecycleType.BUILDPACK)
-                                .build())
+                .expectNext(buildpackName)
                 .expectComplete()
                 .verify(Duration.ofMinutes(5));
     }
@@ -160,15 +148,9 @@ public final class BuildpacksTest extends AbstractIntegrationTest {
                                                                                 .build()))
                                         .map(ResourceUtils::getEntity)
                                         .filter(entity -> buildpackName.equals(entity.getName())))
+                .map(BuildpackEntity::getName)
                 .as(StepVerifier::create)
-                .expectNext(
-                        BuildpackEntity.builder()
-                                .enabled(false)
-                                .locked(false)
-                                .name(buildpackName)
-                                .position(3)
-                                .lifecycle(LifecycleType.BUILDPACK)
-                                .build())
+                .expectNext(buildpackName)
                 .expectComplete()
                 .verify(Duration.ofMinutes(5));
     }
@@ -181,24 +163,17 @@ public final class BuildpacksTest extends AbstractIntegrationTest {
                 .flatMapMany(
                         buildpackId ->
                                 PaginationUtils.requestClientV2Resources(
-                                                page ->
-                                                        this.cloudFoundryClient
-                                                                .buildpacks()
-                                                                .list(
-                                                                        ListBuildpacksRequest
-                                                                                .builder()
-                                                                                .name(buildpackName)
-                                                                                .build()))
-                                        .map(ResourceUtils::getEntity))
+                                        page ->
+                                                this.cloudFoundryClient
+                                                        .buildpacks()
+                                                        .list(
+                                                                ListBuildpacksRequest.builder()
+                                                                        .name(buildpackName)
+                                                                        .build())))
+                .map(ResourceUtils::getEntity)
+                .map(BuildpackEntity::getName)
                 .as(StepVerifier::create)
-                .expectNext(
-                        BuildpackEntity.builder()
-                                .enabled(false)
-                                .locked(false)
-                                .name(buildpackName)
-                                .position(3)
-                                .lifecycle(LifecycleType.BUILDPACK)
-                                .build())
+                .expectNext(buildpackName)
                 .expectComplete()
                 .verify(Duration.ofMinutes(5));
     }
@@ -221,14 +196,8 @@ public final class BuildpacksTest extends AbstractIntegrationTest {
                                                         .build()))
                 .map(ResourceUtils::getEntity)
                 .as(StepVerifier::create)
-                .expectNext(
-                        BuildpackEntity.builder()
-                                .enabled(true)
-                                .locked(true)
-                                .name(buildpackName)
-                                .position(2)
-                                .lifecycle(LifecycleType.BUILDPACK)
-                                .build())
+                .expectNextMatches(
+                        b -> b.getEnabled() && b.getLocked() && b.getPosition().equals(2))
                 .expectComplete()
                 .verify(Duration.ofMinutes(5));
     }
@@ -251,16 +220,9 @@ public final class BuildpacksTest extends AbstractIntegrationTest {
                                                         .filename(filename)
                                                         .build()))
                 .map(ResourceUtils::getEntity)
+                .map(BuildpackEntity::getFilename)
                 .as(StepVerifier::create)
-                .expectNext(
-                        BuildpackEntity.builder()
-                                .enabled(false)
-                                .filename(filename)
-                                .locked(false)
-                                .name(buildpackName)
-                                .position(3)
-                                .lifecycle(LifecycleType.BUILDPACK)
-                                .build())
+                .expectNext(filename)
                 .expectComplete()
                 .verify(Duration.ofMinutes(5));
     }
@@ -283,16 +245,9 @@ public final class BuildpacksTest extends AbstractIntegrationTest {
                                                         .filename(filename)
                                                         .build()))
                 .map(ResourceUtils::getEntity)
+                .map(BuildpackEntity::getFilename)
                 .as(StepVerifier::create)
-                .expectNext(
-                        BuildpackEntity.builder()
-                                .enabled(false)
-                                .filename(filename + ".zip")
-                                .locked(false)
-                                .name(buildpackName)
-                                .position(3)
-                                .lifecycle(LifecycleType.BUILDPACK)
-                                .build())
+                .expectNext(filename + ".zip")
                 .expectComplete()
                 .verify(Duration.ofMinutes(5));
     }


### PR DESCRIPTION
- The tests were too precise in checking the results. Now that the `lifecycle` property has been introduced in newer CAPI versions, the results are different between CAPI versions.
- We now only check the basic information we care about in those tests (e.g. does the Buildpack exist given its name, or are the updated fields actually updated).