### PR TITLE
ci: Update APIHOST from CI testbed

### DIFF
--- a/ci/integration-test.sh
+++ b/ci/integration-test.sh
@@ -17,7 +17,7 @@ fi
 
 CF_CREDS=$(cat "${ROOT}"/environment/cf-creds.json)
 
-TEST_APIHOST=$(jq -n -r --argjson credentials "${CF_CREDS}" '"api.sys.\($credentials.name).cf-app.com"')
+TEST_APIHOST=$(jq -n -r --argjson credentials "${CF_CREDS}" '"$credentials.api_url"')
 export TEST_APIHOST
 
 TEST_ADMIN_USERNAME=$(jq -n -r --argjson credentials "${CF_CREDS}" '$credentials.username')


### PR DESCRIPTION
Internal CI has moved, and the contract for CI has changed. Update ci script accordingly.