### PR TITLE
issue 1299 abstract authentication configuration get link text should be a string

### DIFF
--- a/cloudfoundry-client/src/main/java/org/cloudfoundry/uaa/identityproviders/AbstractAuthenticationConfiguration.java
+++ b/cloudfoundry-client/src/main/java/org/cloudfoundry/uaa/identityproviders/AbstractAuthenticationConfiguration.java
@@ -44,7 +44,7 @@ abstract class AbstractAuthenticationConfiguration
      */
     @JsonProperty("linkText")
     @Nullable
-    abstract Boolean getLinkText();
+    abstract String getLinkText();
 
     /**
      * The client ID which is registered with the external OAuth provider for use by the UAA

--- a/integration-test/pom.xml
+++ b/integration-test/pom.xml
@@ -76,7 +76,7 @@
             <version>${project.version}</version>
             <scope>test</scope>
         </dependency>
-  <dependency>
+        <dependency>
             <groupId>org.hamcrest</groupId>
             <artifactId>hamcrest-junit</artifactId>
             <version>2.0.0.0</version>
@@ -96,11 +96,6 @@
         <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter</artifactId>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.springframework.boot</groupId>
-            <artifactId>spring-boot-starter-test</artifactId>
             <scope>test</scope>
         </dependency>
     </dependencies>


### PR DESCRIPTION
The PR sorts an issues where the getLinkText should have been a String instead of a Boolean. In addition it remove a duplicate entry in the POM file to remove warning "duplicate declaration of version"