### PR TITLE
Feature: handle rate limiting of UAA server. Fix #1307

### DIFF
--- a/README.md
+++ b/README.md
@@ -253,7 +253,7 @@ Beyond that, it is helpful to capture the following information:
 If you open a Github issue with a request for help, please include as much of the information above as possible and do not forget to sanitize any request/response data posted.
 
 ## Development
-The project depends on Java 8. To build from source and install to your local Maven cache, run the following:
+The project depends on Java 8 to 21. To build from source and install to your local Maven cache, run the following:
 
 ```shell
 $ git submodule update --init --recursive
@@ -297,6 +297,7 @@ Name | Description
 `TEST_PROXY_PORT` | _(Optional)_ The port of a proxy to route all requests through. Defaults to `8080`.
 `TEST_PROXY_USERNAME` | _(Optional)_ The username for a proxy to route all requests through
 `TEST_SKIPSSLVALIDATION` | _(Optional)_ Whether to skip SSL validation when connecting to the Cloud Foundry instance.  Defaults to `false`.
+`UAA_API_REQUEST_LIMIT` | _(Optional)_ If your UAA server does rate limiting and returns 429 errors, set this variable to a value smaller than the limit. Defaults to `0` (no limit)
 
 If you do not have access to a CloudFoundry instance with admin access, you can run one locally using [bosh-deployment](https://github.com/cloudfoundry/bosh-deployment) & [cf-deployment](https://github.com/cloudfoundry/cf-deployment/) and Virtualbox.
 

--- a/cloudfoundry-client-reactor/src/main/java/org/cloudfoundry/reactor/uaa/AbstractUaaOperations.java
+++ b/cloudfoundry-client-reactor/src/main/java/org/cloudfoundry/reactor/uaa/AbstractUaaOperations.java
@@ -24,6 +24,7 @@ import java.util.stream.Stream;
 import org.cloudfoundry.reactor.ConnectionContext;
 import org.cloudfoundry.reactor.TokenProvider;
 import org.cloudfoundry.reactor.client.QueryBuilder;
+import org.cloudfoundry.reactor.uaa.UaaThrottler.ResourceToken;
 import org.cloudfoundry.reactor.util.AbstractReactorOperations;
 import org.cloudfoundry.reactor.util.ErrorPayloadMappers;
 import org.cloudfoundry.reactor.util.Operator;
@@ -43,62 +44,114 @@ public abstract class AbstractUaaOperations extends AbstractReactorOperations {
         super(connectionContext, root, tokenProvider, requestTags);
     }
 
-    @Override
-    protected Mono<Operator> createOperator() {
-        return super.createOperator().map(this::attachErrorPayloadMapper);
+    private Mono<UaaOperator> createOperator(ResourceToken token) {
+        return this.root
+                .map(super::buildOperatorContext)
+                .flatMap(
+                        context ->
+                                Mono.just(
+                                                new UaaOperator(
+                                                        context,
+                                                        this.connectionContext.getHttpClient(),
+                                                        token,
+                                                        ""))
+                                        .map(op -> op.headers(super::addHeaders))
+                                        .map(op -> op.headersWhen(super::addHeadersWhen)))
+                .map(this::attachErrorPayloadMapper);
     }
 
     protected final <T> Mono<T> delete(
             Object requestPayload,
             Class<T> responseType,
             Function<UriComponentsBuilder, UriComponentsBuilder> uriTransformer) {
-        return createOperator()
+        return UaaThrottler.getInstance()
+                .acquire(
+                        queryTransformer(requestPayload)
+                                .andThen(uriTransformer)
+                                .apply(UriComponentsBuilder.fromPath(""))
+                                .build()
+                                .toUriString())
+                .flatMap(token -> delete(requestPayload, responseType, uriTransformer, token));
+    }
+
+    private <T> Mono<T> delete(
+            Object requestPayload,
+            Class<T> responseType,
+            Function<UriComponentsBuilder, UriComponentsBuilder> uriTransformer,
+            ResourceToken token) {
+        return createOperator(token)
                 .flatMap(
-                        operator ->
-                                operator.headers(headers -> addHeaders(headers, requestPayload))
-                                        .delete()
-                                        .uri(
-                                                queryTransformer(requestPayload)
-                                                        .andThen(uriTransformer))
-                                        .send(requestPayload)
-                                        .response()
-                                        .parseBody(responseType));
+                        operator -> {
+                            return operator.headers(headers -> addHeaders(headers, requestPayload))
+                                    .delete()
+                                    .uri(queryTransformer(requestPayload).andThen(uriTransformer))
+                                    .send(requestPayload)
+                                    .response()
+                                    .parseBody(responseType);
+                        });
     }
 
     protected final Mono<HttpClientResponse> get(
             Object requestPayload,
             Function<UriComponentsBuilder, UriComponentsBuilder> uriTransformer) {
-        return createOperator()
+        return UaaThrottler.getInstance()
+                .acquire(
+                        queryTransformer(requestPayload)
+                                .andThen(uriTransformer)
+                                .apply(UriComponentsBuilder.fromPath(""))
+                                .build()
+                                .toUriString())
+                .flatMap(token -> get(requestPayload, uriTransformer, token));
+    }
+
+    private Mono<HttpClientResponse> get(
+            Object requestPayload,
+            Function<UriComponentsBuilder, UriComponentsBuilder> uriTransformer,
+            ResourceToken token) {
+        return createOperator(token)
                 .flatMap(
-                        operator ->
-                                operator.headers(headers -> addHeaders(headers, requestPayload))
-                                        .get()
-                                        .uri(
-                                                queryTransformer(requestPayload)
-                                                        .andThen(uriTransformer))
-                                        .response()
-                                        .get());
+                        operator -> {
+                            return operator.headers(headers -> addHeaders(headers, requestPayload))
+                                    .get()
+                                    .uri(queryTransformer(requestPayload).andThen(uriTransformer))
+                                    .response()
+                                    .get();
+                        });
     }
 
     protected final Mono<HttpClientResponse> get(
             Object requestPayload,
             Function<UriComponentsBuilder, UriComponentsBuilder> uriTransformer,
             Consumer<HttpHeaders> headersTransformer) {
-        return createOperator()
+        return UaaThrottler.getInstance()
+                .acquire(
+                        queryTransformer(requestPayload)
+                                .andThen(uriTransformer)
+                                .apply(UriComponentsBuilder.fromPath(""))
+                                .build()
+                                .toUriString())
+                .flatMap(token -> get(requestPayload, uriTransformer, headersTransformer, token));
+    }
+
+    private Mono<HttpClientResponse> get(
+            Object requestPayload,
+            Function<UriComponentsBuilder, UriComponentsBuilder> uriTransformer,
+            Consumer<HttpHeaders> headersTransformer,
+            ResourceToken token) {
+        return createOperator(token)
                 .flatMap(
-                        operator ->
-                                operator.headers(
-                                                headers ->
-                                                        addHeaders(
-                                                                headers,
-                                                                requestPayload,
-                                                                headersTransformer))
-                                        .get()
-                                        .uri(
-                                                queryTransformer(requestPayload)
-                                                        .andThen(uriTransformer))
-                                        .response()
-                                        .get());
+                        operator -> {
+                            return operator.headers(
+                                            headers ->
+                                                    addHeaders(
+                                                            headers,
+                                                            requestPayload,
+                                                            headersTransformer))
+                                    .get()
+                                    .uri(queryTransformer(requestPayload).andThen(uriTransformer))
+                                    .response()
+                                    .get();
+                        });
     }
 
     protected final Mono<HttpClientResponse> get(
@@ -106,38 +159,74 @@ public abstract class AbstractUaaOperations extends AbstractReactorOperations {
             Function<UriComponentsBuilder, UriComponentsBuilder> uriTransformer,
             Consumer<HttpHeaders> headersTransformer,
             Function<HttpHeaders, Mono<? extends HttpHeaders>> headersWhenTransformer) {
-        return createOperator()
+        return UaaThrottler.getInstance()
+                .acquire(
+                        queryTransformer(requestPayload)
+                                .andThen(uriTransformer)
+                                .apply(UriComponentsBuilder.fromPath(""))
+                                .build()
+                                .toUriString())
                 .flatMap(
-                        operator ->
-                                operator.headers(
-                                                headers ->
-                                                        addHeaders(
-                                                                headers,
-                                                                requestPayload,
-                                                                headersTransformer))
-                                        .headersWhen(headersWhenTransformer)
-                                        .get()
-                                        .uri(
-                                                queryTransformer(requestPayload)
-                                                        .andThen(uriTransformer))
-                                        .response()
-                                        .get());
+                        token ->
+                                get(
+                                        requestPayload,
+                                        uriTransformer,
+                                        headersTransformer,
+                                        headersWhenTransformer,
+                                        token));
+    }
+
+    private Mono<HttpClientResponse> get(
+            Object requestPayload,
+            Function<UriComponentsBuilder, UriComponentsBuilder> uriTransformer,
+            Consumer<HttpHeaders> headersTransformer,
+            Function<HttpHeaders, Mono<? extends HttpHeaders>> headersWhenTransformer,
+            ResourceToken token) {
+        return createOperator(token)
+                .flatMap(
+                        operator -> {
+                            return operator.headers(
+                                            headers ->
+                                                    addHeaders(
+                                                            headers,
+                                                            requestPayload,
+                                                            headersTransformer))
+                                    .headersWhen(headersWhenTransformer)
+                                    .get()
+                                    .uri(queryTransformer(requestPayload).andThen(uriTransformer))
+                                    .response()
+                                    .get();
+                        });
     }
 
     protected final <T> Mono<T> get(
             Object requestPayload,
             Class<T> responseType,
             Function<UriComponentsBuilder, UriComponentsBuilder> uriTransformer) {
-        return createOperator()
+        return UaaThrottler.getInstance()
+                .acquire(
+                        queryTransformer(requestPayload)
+                                .andThen(uriTransformer)
+                                .apply(UriComponentsBuilder.fromPath(""))
+                                .build()
+                                .toUriString())
+                .flatMap(token -> get(requestPayload, responseType, uriTransformer, token));
+    }
+
+    private <T> Mono<T> get(
+            Object requestPayload,
+            Class<T> responseType,
+            Function<UriComponentsBuilder, UriComponentsBuilder> uriTransformer,
+            ResourceToken token) {
+        return createOperator(token)
                 .flatMap(
-                        operator ->
-                                operator.headers(headers -> addHeaders(headers, requestPayload))
-                                        .get()
-                                        .uri(
-                                                queryTransformer(requestPayload)
-                                                        .andThen(uriTransformer))
-                                        .response()
-                                        .parseBody(responseType));
+                        operator -> {
+                            return operator.headers(headers -> addHeaders(headers, requestPayload))
+                                    .get()
+                                    .uri(queryTransformer(requestPayload).andThen(uriTransformer))
+                                    .response()
+                                    .parseBody(responseType);
+                        });
     }
 
     protected final <T> Mono<T> get(
@@ -145,38 +234,74 @@ public abstract class AbstractUaaOperations extends AbstractReactorOperations {
             Class<T> responseType,
             Function<UriComponentsBuilder, UriComponentsBuilder> uriTransformer,
             Consumer<HttpHeaders> headersTransformer) {
-        return createOperator()
+        return UaaThrottler.getInstance()
+                .acquire(
+                        queryTransformer(requestPayload)
+                                .andThen(uriTransformer)
+                                .apply(UriComponentsBuilder.fromPath(""))
+                                .build()
+                                .toUriString())
                 .flatMap(
-                        operator ->
-                                operator.headers(
-                                                headers ->
-                                                        addHeaders(
-                                                                headers,
-                                                                requestPayload,
-                                                                headersTransformer))
-                                        .get()
-                                        .uri(
-                                                queryTransformer(requestPayload)
-                                                        .andThen(uriTransformer))
-                                        .response()
-                                        .parseBody(responseType));
+                        token ->
+                                get(
+                                        requestPayload,
+                                        responseType,
+                                        uriTransformer,
+                                        headersTransformer,
+                                        token));
+    }
+
+    private <T> Mono<T> get(
+            Object requestPayload,
+            Class<T> responseType,
+            Function<UriComponentsBuilder, UriComponentsBuilder> uriTransformer,
+            Consumer<HttpHeaders> headersTransformer,
+            ResourceToken token) {
+        return createOperator(token)
+                .flatMap(
+                        operator -> {
+                            return operator.headers(
+                                            headers ->
+                                                    addHeaders(
+                                                            headers,
+                                                            requestPayload,
+                                                            headersTransformer))
+                                    .get()
+                                    .uri(queryTransformer(requestPayload).andThen(uriTransformer))
+                                    .response()
+                                    .parseBody(responseType);
+                        });
     }
 
     protected final <T> Mono<T> patch(
             Object requestPayload,
             Class<T> responseType,
             Function<UriComponentsBuilder, UriComponentsBuilder> uriTransformer) {
-        return createOperator()
+        return UaaThrottler.getInstance()
+                .acquire(
+                        queryTransformer(requestPayload)
+                                .andThen(uriTransformer)
+                                .apply(UriComponentsBuilder.fromPath(""))
+                                .build()
+                                .toUriString())
+                .flatMap(token -> patch(requestPayload, responseType, uriTransformer, token));
+    }
+
+    private <T> Mono<T> patch(
+            Object requestPayload,
+            Class<T> responseType,
+            Function<UriComponentsBuilder, UriComponentsBuilder> uriTransformer,
+            ResourceToken token) {
+        return createOperator(token)
                 .flatMap(
-                        operator ->
-                                operator.headers(headers -> addHeaders(headers, requestPayload))
-                                        .patch()
-                                        .uri(
-                                                queryTransformer(requestPayload)
-                                                        .andThen(uriTransformer))
-                                        .send(requestPayload)
-                                        .response()
-                                        .parseBody(responseType));
+                        operator -> {
+                            return operator.headers(headers -> addHeaders(headers, requestPayload))
+                                    .patch()
+                                    .uri(queryTransformer(requestPayload).andThen(uriTransformer))
+                                    .send(requestPayload)
+                                    .response()
+                                    .parseBody(responseType);
+                        });
     }
 
     protected final <T> Mono<T> post(
@@ -184,22 +309,44 @@ public abstract class AbstractUaaOperations extends AbstractReactorOperations {
             Class<T> responseType,
             Function<UriComponentsBuilder, UriComponentsBuilder> uriTransformer,
             Consumer<HttpHeaders> headersTransformer) {
-        return createOperator()
+        return UaaThrottler.getInstance()
+                .acquire(
+                        queryTransformer(requestPayload)
+                                .andThen(uriTransformer)
+                                .apply(UriComponentsBuilder.fromPath(""))
+                                .build()
+                                .toUriString())
                 .flatMap(
-                        operator ->
-                                operator.headers(
-                                                headers ->
-                                                        addHeaders(
-                                                                headers,
-                                                                requestPayload,
-                                                                headersTransformer))
-                                        .post()
-                                        .uri(
-                                                queryTransformer(requestPayload)
-                                                        .andThen(uriTransformer))
-                                        .send(requestPayload)
-                                        .response()
-                                        .parseBody(responseType));
+                        token ->
+                                post(
+                                        requestPayload,
+                                        responseType,
+                                        uriTransformer,
+                                        headersTransformer,
+                                        token));
+    }
+
+    private <T> Mono<T> post(
+            Object requestPayload,
+            Class<T> responseType,
+            Function<UriComponentsBuilder, UriComponentsBuilder> uriTransformer,
+            Consumer<HttpHeaders> headersTransformer,
+            ResourceToken token) {
+        return createOperator(token)
+                .flatMap(
+                        operator -> {
+                            return operator.headers(
+                                            headers ->
+                                                    addHeaders(
+                                                            headers,
+                                                            requestPayload,
+                                                            headersTransformer))
+                                    .post()
+                                    .uri(queryTransformer(requestPayload).andThen(uriTransformer))
+                                    .send(requestPayload)
+                                    .response()
+                                    .parseBody(responseType);
+                        });
     }
 
     protected final <T> Mono<T> post(
@@ -208,57 +355,109 @@ public abstract class AbstractUaaOperations extends AbstractReactorOperations {
             Function<UriComponentsBuilder, UriComponentsBuilder> uriTransformer,
             Consumer<HttpHeaders> headersTransformer,
             Function<HttpHeaders, Mono<? extends HttpHeaders>> headersWhenTransformer) {
-        return createOperator()
+        return UaaThrottler.getInstance()
+                .acquire(
+                        queryTransformer(requestPayload)
+                                .andThen(uriTransformer)
+                                .apply(UriComponentsBuilder.fromPath(""))
+                                .build()
+                                .toUriString())
                 .flatMap(
-                        operator ->
-                                operator.headers(
-                                                headers ->
-                                                        addHeaders(
-                                                                headers,
-                                                                requestPayload,
-                                                                headersTransformer))
-                                        .headersWhen(headersWhenTransformer)
-                                        .post()
-                                        .uri(
-                                                queryTransformer(requestPayload)
-                                                        .andThen(uriTransformer))
-                                        .send(requestPayload)
-                                        .response()
-                                        .parseBody(responseType));
+                        token ->
+                                post(
+                                        requestPayload,
+                                        responseType,
+                                        uriTransformer,
+                                        headersTransformer,
+                                        headersWhenTransformer,
+                                        token));
+    }
+
+    private <T> Mono<T> post(
+            Object requestPayload,
+            Class<T> responseType,
+            Function<UriComponentsBuilder, UriComponentsBuilder> uriTransformer,
+            Consumer<HttpHeaders> headersTransformer,
+            Function<HttpHeaders, Mono<? extends HttpHeaders>> headersWhenTransformer,
+            ResourceToken token) {
+        return createOperator(token)
+                .flatMap(
+                        operator -> {
+                            return operator.headers(
+                                            headers ->
+                                                    addHeaders(
+                                                            headers,
+                                                            requestPayload,
+                                                            headersTransformer))
+                                    .headersWhen(headersWhenTransformer)
+                                    .post()
+                                    .uri(queryTransformer(requestPayload).andThen(uriTransformer))
+                                    .send(requestPayload)
+                                    .response()
+                                    .parseBody(responseType);
+                        });
     }
 
     protected final <T> Mono<T> post(
             Object requestPayload,
             Class<T> responseType,
             Function<UriComponentsBuilder, UriComponentsBuilder> uriTransformer) {
-        return createOperator()
+        return UaaThrottler.getInstance()
+                .acquire(
+                        queryTransformer(requestPayload)
+                                .andThen(uriTransformer)
+                                .apply(UriComponentsBuilder.fromPath(""))
+                                .build()
+                                .toUriString())
+                .flatMap(token -> post(requestPayload, responseType, uriTransformer, token));
+    }
+
+    private <T> Mono<T> post(
+            Object requestPayload,
+            Class<T> responseType,
+            Function<UriComponentsBuilder, UriComponentsBuilder> uriTransformer,
+            ResourceToken token) {
+        return createOperator(token)
                 .flatMap(
-                        operator ->
-                                operator.headers(headers -> addHeaders(headers, requestPayload))
-                                        .post()
-                                        .uri(
-                                                queryTransformer(requestPayload)
-                                                        .andThen(uriTransformer))
-                                        .send(requestPayload)
-                                        .response()
-                                        .parseBody(responseType));
+                        operator -> {
+                            return operator.headers(headers -> addHeaders(headers, requestPayload))
+                                    .post()
+                                    .uri(queryTransformer(requestPayload).andThen(uriTransformer))
+                                    .send(requestPayload)
+                                    .response()
+                                    .parseBody(responseType);
+                        });
     }
 
     protected final <T> Mono<T> put(
             Object requestPayload,
             Class<T> responseType,
             Function<UriComponentsBuilder, UriComponentsBuilder> uriTransformer) {
-        return createOperator()
+        return UaaThrottler.getInstance()
+                .acquire(
+                        queryTransformer(requestPayload)
+                                .andThen(uriTransformer)
+                                .apply(UriComponentsBuilder.fromPath(""))
+                                .build()
+                                .toUriString())
+                .flatMap(token -> put(requestPayload, responseType, uriTransformer, token));
+    }
+
+    private <T> Mono<T> put(
+            Object requestPayload,
+            Class<T> responseType,
+            Function<UriComponentsBuilder, UriComponentsBuilder> uriTransformer,
+            ResourceToken token) {
+        return createOperator(token)
                 .flatMap(
-                        operator ->
-                                operator.headers(headers -> addHeaders(headers, requestPayload))
-                                        .put()
-                                        .uri(
-                                                queryTransformer(requestPayload)
-                                                        .andThen(uriTransformer))
-                                        .send(requestPayload)
-                                        .response()
-                                        .parseBody(responseType));
+                        operator -> {
+                            return operator.headers(headers -> addHeaders(headers, requestPayload))
+                                    .put()
+                                    .uri(queryTransformer(requestPayload).andThen(uriTransformer))
+                                    .send(requestPayload)
+                                    .response()
+                                    .parseBody(responseType);
+                        });
     }
 
     private static void addHeaders(
@@ -274,9 +473,14 @@ public abstract class AbstractUaaOperations extends AbstractReactorOperations {
         VersionBuilder.augment(httpHeaders, requestPayload);
     }
 
-    private Operator attachErrorPayloadMapper(Operator operator) {
-        return operator.withErrorPayloadMapper(
-                ErrorPayloadMappers.uaa(this.connectionContext.getObjectMapper()));
+    private UaaOperator attachErrorPayloadMapper(Operator operator) {
+        if (operator instanceof UaaOperator) {
+            UaaOperator op = (UaaOperator) operator;
+            return op.withErrorPayloadMapper(
+                    ErrorPayloadMappers.uaa(this.connectionContext.getObjectMapper()));
+        } else {
+            throw new RuntimeException("Wrong class of operator " + operator.getClass().toString());
+        }
     }
 
     private Function<UriComponentsBuilder, UriComponentsBuilder> queryTransformer(

--- a/cloudfoundry-client-reactor/src/main/java/org/cloudfoundry/reactor/uaa/ReactorRatelimit.java
+++ b/cloudfoundry-client-reactor/src/main/java/org/cloudfoundry/reactor/uaa/ReactorRatelimit.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright 2013-2025 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.cloudfoundry.reactor.uaa;
+
+import java.util.Map;
+import org.cloudfoundry.reactor.ConnectionContext;
+import org.cloudfoundry.reactor.TokenProvider;
+import org.cloudfoundry.uaa.ratelimit.Ratelimit;
+import org.cloudfoundry.uaa.ratelimit.RatelimitRequest;
+import org.cloudfoundry.uaa.ratelimit.RatelimitResponse;
+import reactor.core.publisher.Mono;
+
+public final class ReactorRatelimit extends AbstractUaaOperations implements Ratelimit {
+
+    /**
+     * Creates an instance
+     *
+     * @param connectionContext the {@link ConnectionContext} to use when communicating with the server
+     * @param root              the root URI of the server. Typically something like {@code https://uaa.run.pivotal.io}.
+     * @param tokenProvider     the {@link TokenProvider} to use when communicating with the server
+     * @param requestTags       map with custom http headers which will be added to web request
+     */
+    public ReactorRatelimit(
+            ConnectionContext connectionContext,
+            Mono<String> root,
+            TokenProvider tokenProvider,
+            Map<String, String> requestTags) {
+        super(connectionContext, root, tokenProvider, requestTags);
+    }
+
+    @Override
+    public Mono<RatelimitResponse> getRatelimit(RatelimitRequest request) {
+        return get(
+                        request,
+                        RatelimitResponse.class,
+                        builder -> builder.pathSegment("RateLimitingStatus"))
+                .checkpoint();
+    }
+}

--- a/cloudfoundry-client-reactor/src/main/java/org/cloudfoundry/reactor/uaa/UaaOperator.java
+++ b/cloudfoundry-client-reactor/src/main/java/org/cloudfoundry/reactor/uaa/UaaOperator.java
@@ -1,0 +1,130 @@
+/*
+ * Copyright 2013-2025 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.cloudfoundry.reactor.uaa;
+
+import io.netty.handler.codec.http.HttpHeaders;
+import java.util.function.Consumer;
+import java.util.function.Function;
+import org.cloudfoundry.reactor.uaa.UaaThrottler.ResourceToken;
+import org.cloudfoundry.reactor.util.ErrorPayloadMapper;
+import org.cloudfoundry.reactor.util.Operator;
+import org.cloudfoundry.reactor.util.OperatorContext;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import reactor.core.publisher.Mono;
+import reactor.netty.http.client.HttpClient;
+
+public class UaaOperator extends Operator {
+
+    private ResourceToken token = null;
+    private static final Logger LOGGER = LoggerFactory.getLogger("cloudfoundry-client.test");
+
+    public UaaOperator(
+            OperatorContext context, HttpClient httpClient, ResourceToken value, String caller) {
+        super(context, httpClient);
+        token = value;
+        if (token != UaaThrottler.NON_UAA_TOKEN) {
+            LOGGER.debug("UaaOperator creating instance for " + value.id());
+        }
+    }
+
+    @Override
+    public UaaOperator followRedirects() {
+        UaaOperator result =
+                new UaaOperator(
+                        this.context,
+                        super.getHttpClient().followRedirect(true),
+                        this.token,
+                        "follow");
+        if (this.token != null) {
+            result.setToken(token);
+        }
+        return result;
+    }
+
+    @Override
+    public UaaOperator headers(Consumer<HttpHeaders> headersTransformer) {
+        UaaOperator result =
+                new UaaOperator(
+                        this.context,
+                        super.getHttpClient().headers(headersTransformer),
+                        this.token,
+                        "headers");
+        if (this.token != null) {
+            result.setToken(token);
+        }
+        return result;
+    }
+
+    @Override
+    public UaaOperator headersWhen(
+            Function<HttpHeaders, Mono<? extends HttpHeaders>> headersWhenTransformer) {
+        UaaOperator result =
+                new UaaOperator(
+                        this.context,
+                        super.getHttpClient().headersWhen(headersWhenTransformer),
+                        this.token,
+                        "headersWhen");
+        if (this.token != null) {
+            result.setToken(token);
+        }
+        return result;
+    }
+
+    @Override
+    public UaaOperator withErrorPayloadMapper(ErrorPayloadMapper errorPayloadMapper) {
+        UaaOperator result =
+                new UaaOperator(
+                        this.context.withErrorPayloadMapper(errorPayloadMapper),
+                        super.getHttpClient(),
+                        this.token,
+                        "errorPayload");
+        if (this.token != null) {
+            result.setToken(token);
+        }
+        return result;
+    }
+
+    @Override
+    protected HttpClient attachRequestLogger(HttpClient httpClient) {
+        return super.attachRequestLogger(httpClient)
+                .doAfterResponseSuccess((response, connection) -> releaseToken())
+                .doOnResponseError((response, connection) -> releaseToken());
+    }
+
+    public UaaOperator setToken(ResourceToken value) {
+        if (this.token != null) {
+            if (this.token == value) {
+                // not needed, no harm is done.
+            } else {
+                LOGGER.error(
+                        "UaaOperator replacing token with different value. Old: "
+                                + this.token
+                                + " new: "
+                                + value);
+            }
+        }
+        this.token = value;
+        return this;
+    }
+
+    private void releaseToken() {
+        if (this.token != null) {
+            token.release();
+        }
+    }
+}

--- a/cloudfoundry-client-reactor/src/main/java/org/cloudfoundry/reactor/uaa/UaaThrottler.java
+++ b/cloudfoundry-client-reactor/src/main/java/org/cloudfoundry/reactor/uaa/UaaThrottler.java
@@ -1,0 +1,261 @@
+package org.cloudfoundry.reactor.uaa;
+
+import java.time.Duration;
+import java.util.Objects;
+import java.util.Queue;
+import java.util.concurrent.ConcurrentLinkedQueue;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledFuture;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.function.Consumer;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import reactor.core.publisher.Mono;
+import reactor.core.publisher.Sinks;
+
+/**
+ * Throttle calls to uaa in order to avoid running into a rate limit.
+ * If your UAA server is configured with a rate limit, the number of allowed parallel requests
+ * must be set here in order to slow down the client and avoid http 429-responses.
+ *
+ * @author D034003
+ *
+ */
+public class UaaThrottler {
+    public static final ResourceToken NON_UAA_TOKEN = ResourceToken.empty();
+    private static UaaThrottler instance = null;
+    private static int maxDelay = 8;
+    private static int maxResources = 0;
+    private AtomicInteger inUse;
+    private Queue<SinkWithId> waitingQueue;
+
+    private static final Logger LOGGER = LoggerFactory.getLogger("cloudfoundry-client.test");
+
+    private static Consumer<TimeoutException> timeoutHandler = ex -> ex.printStackTrace();
+
+    public static UaaThrottler getInstance() {
+        if (instance == null) {
+            instance = new UaaThrottler();
+        }
+        return instance;
+    }
+
+    private UaaThrottler() {
+        inUse = new AtomicInteger(0);
+        waitingQueue = new ConcurrentLinkedQueue<>();
+    }
+
+    /**
+     * This method should only be used to get a defined state in test coding.
+     */
+    public static void reset() {
+        instance = null;
+    }
+
+    private String logString() {
+        return "maxResources "
+                + maxResources
+                + " inUse "
+                + inUse.get()
+                + " queue "
+                + waitingQueue.size();
+    }
+
+    /**
+     * Here the number of parallel requests can be configured. Must be less than the value returned by
+     * the `RateLimitingStatus` endpoint of your UAA.
+     * Default is `0`, meaning no limit.
+     * @param rateLimit
+     */
+    public static void setUaaRateLimit(int rateLimit) {
+        maxResources = rateLimit;
+    }
+
+    /**
+     * Configure the time in seconds until a request is regarded to be lost. After this time, requests will not be canceled or aborted, but they will not count to the limit and new requests may start.
+     *
+     * @param max time in seconds. Default is 8 seconds.
+     */
+    public static void setMaxDelay(int max) {
+        maxDelay = max;
+    }
+
+    public Mono<ResourceToken> acquire(String url) {
+        if ((maxResources > 0)) {
+            LOGGER.debug(
+                    "UaaThrottler about to acquire one token "
+                            + this.logString()
+                            + " for url "
+                            + url);
+            return Mono.defer(
+                            () -> {
+                                if (inUse.incrementAndGet() < maxResources) {
+                                    // Slot available
+                                    ResourceToken token =
+                                            new ResourceToken(
+                                                    url,
+                                                    timeoutHandler,
+                                                    new TimeoutException(
+                                                            "Requests block each other and time"
+                                                                    + " out"));
+                                    LOGGER.debug(
+                                            "UaaThrottler created one token "
+                                                    + this.logString()
+                                                    + " for url "
+                                                    + url
+                                                    + " token "
+                                                    + token);
+                                    return Mono.just(token);
+                                } else {
+                                    Sinks.One<ResourceToken> sink = Sinks.one();
+                                    waitingQueue.offer(new SinkWithId(url, sink));
+                                    LOGGER.debug(
+                                            "UaaThrottler created sink "
+                                                    + this.logString()
+                                                    + " for url "
+                                                    + url);
+                                    return sink.asMono();
+                                }
+                            })
+                    .cache();
+        } else {
+            return Mono.just(NON_UAA_TOKEN);
+        }
+    }
+
+    private void release(ResourceToken token) {
+        String url = token.id;
+        if ((maxResources > 0)) {
+            LOGGER.debug(
+                    "UaaThrottler about to release token "
+                            + this.logString()
+                            + " released "
+                            + token.released.get()
+                            + " for url "
+                            + url
+                            + " token "
+                            + token);
+            SinkWithId urlSink = waitingQueue.poll();
+            if (urlSink != null) {
+                Mono.delay(Duration.ofMillis(1))
+                        .subscribe(
+                                __ -> {
+                                    ResourceToken newToken =
+                                            new ResourceToken(
+                                                    urlSink.id,
+                                                    timeoutHandler,
+                                                    new TimeoutException(
+                                                            "Requests block each other and time"
+                                                                    + " out"));
+                                    LOGGER.debug(
+                                            "UaaThrottler releasing sink and creating token "
+                                                    + this.logString()
+                                                    + " released "
+                                                    + token.released.get()
+                                                    + " oldUrl "
+                                                    + token.id
+                                                    + " newUrl "
+                                                    + newToken.id
+                                                    + " oldToken "
+                                                    + token
+                                                    + " newToken "
+                                                    + newToken);
+                                    inUse.decrementAndGet();
+                                    urlSink.sink.tryEmitValue(newToken);
+                                });
+            } else {
+                inUse.decrementAndGet();
+                LOGGER.debug(
+                        "UaThrottler completed release. "
+                                + this.logString()
+                                + " for url "
+                                + url
+                                + " token"
+                                + token);
+            }
+        }
+    }
+
+    /**
+     * By default, a message and callstack is written to stderr in case a request does not return within maxDelay seconds.
+     * Here different behavior can be configured.
+     *
+     * @param timeoutHandler
+     */
+    public static void setTimeoutHandler(Consumer<TimeoutException> timeoutHandler) {
+        UaaThrottler.timeoutHandler = Objects.requireNonNull(timeoutHandler);
+    }
+
+    public static class ResourceToken {
+        private final String id;
+        private final ScheduledFuture<?> leakTask;
+        private final AtomicBoolean released = new AtomicBoolean(false);
+        private UaaThrottler instance;
+
+        private ResourceToken(
+                String id,
+                Consumer<TimeoutException> timeoutHandler,
+                TimeoutException tokenAquiredAt) {
+            this.id = id;
+            this.instance = UaaThrottler.instance;
+            if (timeoutHandler == null) { // this is the null-object
+                this.leakTask = null;
+            } else {
+                this.leakTask =
+                        Executors.newSingleThreadScheduledExecutor()
+                                .schedule(
+                                        () -> {
+                                            if (!released.get()) {
+                                                LOGGER.error(
+                                                        "[LEAK DETECTED] UaaThrottler.ResourceToken"
+                                                                + " was not released within "
+                                                                + maxDelay
+                                                                + " seconds "
+                                                                + this.id
+                                                                + " token "
+                                                                + this);
+                                                this.release();
+                                                timeoutHandler.accept(tokenAquiredAt);
+                                            }
+                                        },
+                                        maxDelay,
+                                        TimeUnit.SECONDS);
+            }
+        }
+
+        private static ResourceToken empty() {
+            return new ResourceToken(null, null, null);
+        }
+
+        public void release() {
+            if (this != NON_UAA_TOKEN) {
+                if (released.compareAndSet(false, true)) {
+                    leakTask.cancel(true);
+                    Mono.delay(Duration.ofMillis(1))
+                            .doOnNext(__ -> this.instance.release(this))
+                            .subscribe();
+                } else {
+                    // If a request times out, the token gets released. When the response comes
+                    // later, the token is already released and must not be released a second time.
+                }
+            }
+        }
+
+        public String id() {
+            return id;
+        }
+    }
+
+    private class SinkWithId {
+        final String id;
+        final Sinks.One<ResourceToken> sink;
+
+        private SinkWithId(String idForLogmessages, Sinks.One<ResourceToken> sink) {
+            this.id = idForLogmessages;
+            this.sink = sink;
+        }
+    }
+}

--- a/cloudfoundry-client-reactor/src/main/java/org/cloudfoundry/reactor/uaa/_ReactorUaaClient.java
+++ b/cloudfoundry-client-reactor/src/main/java/org/cloudfoundry/reactor/uaa/_ReactorUaaClient.java
@@ -33,6 +33,7 @@ import org.cloudfoundry.uaa.clients.Clients;
 import org.cloudfoundry.uaa.groups.Groups;
 import org.cloudfoundry.uaa.identityproviders.IdentityProviders;
 import org.cloudfoundry.uaa.identityzones.IdentityZones;
+import org.cloudfoundry.uaa.ratelimit.Ratelimit;
 import org.cloudfoundry.uaa.serverinformation.ServerInformation;
 import org.cloudfoundry.uaa.tokens.Tokens;
 import org.cloudfoundry.uaa.users.Users;
@@ -102,6 +103,12 @@ abstract class _ReactorUaaClient implements UaaClient {
     @Value.Derived
     public Users users() {
         return new ReactorUsers(getConnectionContext(), getRoot(), getTokenProvider(), getRequestTags());
+    }
+
+    @Override
+    @Value.Derived
+    public Ratelimit rateLimit() {
+        return new ReactorRatelimit(getConnectionContext(), getRoot(), getTokenProvider(), getRequestTags());
     }
 
     /**

--- a/cloudfoundry-client-reactor/src/main/java/org/cloudfoundry/reactor/uaa/_UaaRatelimit.java
+++ b/cloudfoundry-client-reactor/src/main/java/org/cloudfoundry/reactor/uaa/_UaaRatelimit.java
@@ -1,0 +1,17 @@
+package org.cloudfoundry.reactor.uaa;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+
+import org.cloudfoundry.Nullable;
+import org.immutables.value.Value;
+
+@JsonDeserialize
+@Value.Immutable
+abstract class _UaaRatelimit {
+
+    @JsonProperty("limiterMappings")
+    @Nullable
+    public abstract Integer getRatelimit();
+
+
+}

--- a/cloudfoundry-client-reactor/src/main/java/org/cloudfoundry/reactor/util/AbstractReactorOperations.java
+++ b/cloudfoundry-client-reactor/src/main/java/org/cloudfoundry/reactor/util/AbstractReactorOperations.java
@@ -58,19 +58,19 @@ public abstract class AbstractReactorOperations {
                 .map(operator -> operator.headersWhen(this::addHeadersWhen));
     }
 
-    private void addHeaders(HttpHeaders httpHeaders) {
+    public void addHeaders(HttpHeaders httpHeaders) {
         UserAgent.setUserAgent(httpHeaders);
         JsonCodec.setDecodeHeaders(httpHeaders);
         this.requestTags.forEach(httpHeaders::set);
     }
 
-    private Mono<? extends HttpHeaders> addHeadersWhen(HttpHeaders httpHeaders) {
+    public Mono<? extends HttpHeaders> addHeadersWhen(HttpHeaders httpHeaders) {
         return this.tokenProvider
                 .getToken(this.connectionContext)
                 .map(token -> httpHeaders.set(AUTHORIZATION, token));
     }
 
-    private OperatorContext buildOperatorContext(String root) {
+    public OperatorContext buildOperatorContext(String root) {
         return OperatorContext.builder()
                 .connectionContext(this.connectionContext)
                 .root(root)

--- a/cloudfoundry-client-reactor/src/main/java/org/cloudfoundry/reactor/util/RequestLogger.java
+++ b/cloudfoundry-client-reactor/src/main/java/org/cloudfoundry/reactor/util/RequestLogger.java
@@ -34,7 +34,7 @@ public class RequestLogger {
     private long requestSentTime;
 
     public void request(HttpClientRequest request) {
-        request(String.format("%-6s {}", request.method()), request.uri());
+        request(String.format("%-6s {}", request.method()), request.resourceUrl());
     }
 
     public void response(HttpClientResponse response) {
@@ -50,19 +50,19 @@ public class RequestLogger {
                 RESPONSE_LOGGER.debug(
                         "{}    {} ({}, {})",
                         response.status().code(),
-                        response.uri(),
+                        response.resourceUrl(),
                         elapsed,
                         response.responseHeaders().get("X-Vcap-Request-Id"));
             } else {
                 RESPONSE_LOGGER.debug(
-                        "{}    {} ({})", response.status().code(), response.uri(), elapsed);
+                        "{}    {} ({})", response.status().code(), response.resourceUrl(), elapsed);
             }
         } else {
             if (RESPONSE_LOGGER.isTraceEnabled()) {
                 RESPONSE_LOGGER.warn(
                         "{}    {} ({}, {}) [{}]",
                         response.status().code(),
-                        response.uri(),
+                        response.resourceUrl(),
                         elapsed,
                         response.responseHeaders().get("X-Vcap-Request-Id"),
                         String.join(", ", warnings));
@@ -70,7 +70,7 @@ public class RequestLogger {
                 RESPONSE_LOGGER.warn(
                         "{}    {} ({}) [{}]",
                         response.status().code(),
-                        response.uri(),
+                        response.resourceUrl(),
                         elapsed,
                         String.join(", ", warnings));
             }

--- a/cloudfoundry-client-reactor/src/test/java/org/cloudfoundry/reactor/AbstractRestTest.java
+++ b/cloudfoundry-client-reactor/src/test/java/org/cloudfoundry/reactor/AbstractRestTest.java
@@ -53,7 +53,7 @@ public abstract class AbstractRestTest {
 
     protected final Mono<String> root;
 
-    final MockWebServer mockWebServer;
+    protected final MockWebServer mockWebServer;
 
     private MultipleRequestDispatcher multipleRequestDispatcher = new MultipleRequestDispatcher();
 
@@ -78,7 +78,7 @@ public abstract class AbstractRestTest {
         this.multipleRequestDispatcher.add(interactionContext);
     }
 
-    private static final class FailingDeserializationProblemHandler
+    public static final class FailingDeserializationProblemHandler
             extends DeserializationProblemHandler {
 
         @Override

--- a/cloudfoundry-client-reactor/src/test/resources/fixtures/uaa/groups/GET_429_response.json
+++ b/cloudfoundry-client-reactor/src/test/resources/fixtures/uaa/groups/GET_429_response.json
@@ -1,0 +1,3 @@
+{
+  "error":"429 - Too Many Request - Request limited by Rate Limiter configuration: Name: SCIM Type: CredentialsID"
+}

--- a/cloudfoundry-client/src/main/java/org/cloudfoundry/uaa/UaaClient.java
+++ b/cloudfoundry-client/src/main/java/org/cloudfoundry/uaa/UaaClient.java
@@ -21,6 +21,7 @@ import org.cloudfoundry.uaa.clients.Clients;
 import org.cloudfoundry.uaa.groups.Groups;
 import org.cloudfoundry.uaa.identityproviders.IdentityProviders;
 import org.cloudfoundry.uaa.identityzones.IdentityZones;
+import org.cloudfoundry.uaa.ratelimit.Ratelimit;
 import org.cloudfoundry.uaa.serverinformation.ServerInformation;
 import org.cloudfoundry.uaa.tokens.Tokens;
 import org.cloudfoundry.uaa.users.Users;
@@ -80,4 +81,9 @@ public interface UaaClient {
      * Main entry point to the UAA User Client API
      */
     Users users();
+
+    /**
+     * Main entry point to the UAA Ratelimit API
+     */
+    Ratelimit rateLimit();
 }

--- a/cloudfoundry-client/src/main/java/org/cloudfoundry/uaa/ratelimit/Ratelimit.java
+++ b/cloudfoundry-client/src/main/java/org/cloudfoundry/uaa/ratelimit/Ratelimit.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright 2013-2025 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.cloudfoundry.uaa.ratelimit;
+
+import reactor.core.publisher.Mono;
+
+/**
+ * Main entry point to the UAA Ratelimit Client API
+ */
+public interface Ratelimit {
+
+    Mono<RatelimitResponse> getRatelimit(RatelimitRequest request);
+}

--- a/cloudfoundry-client/src/main/java/org/cloudfoundry/uaa/ratelimit/_Current.java
+++ b/cloudfoundry-client/src/main/java/org/cloudfoundry/uaa/ratelimit/_Current.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright 2013-2025 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.cloudfoundry.uaa.ratelimit;
+
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+
+import java.util.Date;
+
+import org.immutables.value.Value;
+
+/**
+ * The payload for the uaa ratelimiting
+ */
+@JsonDeserialize
+@Value.Immutable
+abstract class _Current {
+
+    /**
+     * The limit value
+     */
+    @JsonProperty("limiterMappings")
+    abstract Integer getLimit();
+
+    /**
+     * Is ratelimit "ACTIVE" or not? Possible values are DISABLED, PENDING, ACTIVE
+     */
+    @JsonProperty("status")
+    abstract String getStatus();
+
+    /**
+     * Timestamp, when this Current was created.
+     */
+    @JsonProperty("asOf")
+    abstract Date getTimeOfCurrent();
+
+    /**
+     * The credentialIdExtractor
+     */
+    @JsonProperty("credentialIdExtractor")
+    abstract String getCredentialIdExtractor();
+
+    /**
+     * The loggingLevel. Valid values include: "OnlyLimited", "AllCalls" and "AllCallsWithDetails"
+     */
+    @JsonProperty("loggingLevel")
+    abstract String getLoggingLevel();
+}

--- a/cloudfoundry-client/src/main/java/org/cloudfoundry/uaa/ratelimit/_RatelimitRequest.java
+++ b/cloudfoundry-client/src/main/java/org/cloudfoundry/uaa/ratelimit/_RatelimitRequest.java
@@ -1,0 +1,24 @@
+/*
+ * Copyright 2013-2025 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.cloudfoundry.uaa.ratelimit;
+
+import org.immutables.value.Value;
+
+@Value.Immutable
+abstract class _RatelimitRequest {
+
+}

--- a/cloudfoundry-client/src/main/java/org/cloudfoundry/uaa/ratelimit/_RatelimitResponse.java
+++ b/cloudfoundry-client/src/main/java/org/cloudfoundry/uaa/ratelimit/_RatelimitResponse.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2013-2025 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.cloudfoundry.uaa.ratelimit;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import org.cloudfoundry.Nullable;
+import org.immutables.value.Value;
+
+@JsonDeserialize
+@Value.Immutable
+abstract class _RatelimitResponse {
+
+    @JsonProperty("current")
+    @Nullable
+    abstract Current getCurrentData();
+
+    @JsonProperty("fromSource")
+    @Nullable
+    abstract String getFromSource();
+
+}

--- a/integration-test/src/test/java/org/cloudfoundry/uaa/UaaRatelimitInitializer.java
+++ b/integration-test/src/test/java/org/cloudfoundry/uaa/UaaRatelimitInitializer.java
@@ -1,0 +1,79 @@
+package org.cloudfoundry.uaa;
+
+import java.time.Duration;
+import org.cloudfoundry.reactor.uaa.UaaThrottler;
+import org.cloudfoundry.uaa.ratelimit.Current;
+import org.cloudfoundry.uaa.ratelimit.Ratelimit;
+import org.cloudfoundry.uaa.ratelimit.RatelimitRequest;
+import org.cloudfoundry.uaa.ratelimit.RatelimitResponse;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.InitializingBean;
+import org.springframework.stereotype.Component;
+import reactor.core.publisher.Mono;
+
+@Component
+public class UaaRatelimitInitializer implements InitializingBean {
+    private final Logger logger = LoggerFactory.getLogger("cloudfoundry-client.test");
+
+    private final Ratelimit ratelimitService;
+    private Integer commandlineRequestlimit;
+
+    public UaaRatelimitInitializer(Ratelimit ratelimitService, Integer commandlineRequestLimit) {
+        this.ratelimitService = ratelimitService;
+        this.commandlineRequestlimit = commandlineRequestLimit;
+    }
+
+    private void init() {
+        int limit = 0;
+
+        Integer serverRatelimit =
+                ratelimitService
+                        .getRatelimit(RatelimitRequest.builder().build())
+                        .map(response -> getServerRatelimit(response))
+                        .timeout(Duration.ofSeconds(5))
+                        .onErrorResume(
+                                ex -> {
+                                    logger.error(
+                                            "Warning: could not fetch UAA rate limit, using default"
+                                                    + " "
+                                                    + 0
+                                                    + ". Cause: "
+                                                    + ex);
+                                    return Mono.just(0);
+                                })
+                        .block();
+
+        if (serverRatelimit != null) {
+            limit = serverRatelimit.intValue();
+        }
+        if (commandlineRequestlimit != null) {
+            limit = commandlineRequestlimit.intValue();
+            logger.debug("UaaRatelimitInitializer using configured value " + limit);
+        }
+
+        UaaThrottler.setUaaRateLimit(limit);
+    }
+
+    private Integer getServerRatelimit(RatelimitResponse response) {
+        Current curr = response.getCurrentData();
+        if (!"ACTIVE".equals(curr.getStatus())) {
+            logger.debug(
+                    "UaaRatelimitInitializer server ratelimit is not 'ACTIVE', but "
+                            + curr.getStatus()
+                            + ". Ignoring server value for ratelimit.");
+            return null;
+        }
+        Integer result = curr.getLimit() - 1; // using the value returned from server
+        // will not stop the 429-Errors. Decreased value is safe.
+        logger.debug(
+                "UaaRatelimitInitializer using server value for ratelimit -1, resulting in "
+                        + result);
+        return result;
+    }
+
+    @Override
+    public void afterPropertiesSet() throws Exception {
+        this.init();
+    }
+}


### PR DESCRIPTION
If the UAA server is configured with rate limiting, too many parallel requests result in http-429 results. This will block integration tests, as they create a lot of groups in parallel during initialization.
With this pull request, first the rate limit value is requested from UAA. If ratelimiting is inactive, everything works as normal.
If there is a ratelimit, requests to UAA are limited to the allowed number of parallel requests. Excess requests are queued until a slot becomes free.
For testing purposes, the limit can be provided with the new environment variable `UAA_API_REQUEST_LIMIT`. Value "0" means no rate limit, any other value gives the maximum number of parallel calls.
In class integration-test/src/test/java/org/cloudfoundry/IntegrationTestConfiguration.java, some changes from a different pull request are copied to allow integration-test execution.