### PR TITLE
integration-tests: compile with -parameters

### DIFF
--- a/integration-test/pom.xml
+++ b/integration-test/pom.xml
@@ -100,6 +100,9 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
+                <configuration>
+                    <parameters>true</parameters>
+                </configuration>
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>


### PR DESCRIPTION
- This is required to have integration tests passing on JDK 17+. This is because the IntegrationTestConfiguration relies on bean names for auto-wiring beans of the same type (mostly strings).

This supersedes #1247 