### PR TITLE
DomainsV3: fix "router_group.id" type

### DIFF
--- a/cloudfoundry-client-reactor/src/test/java/org/cloudfoundry/reactor/client/v3/domains/ReactorDomainsV3Test.java
+++ b/cloudfoundry-client-reactor/src/test/java/org/cloudfoundry/reactor/client/v3/domains/ReactorDomainsV3Test.java
@@ -42,6 +42,7 @@ import org.cloudfoundry.client.v3.domains.GetDomainRequest;
 import org.cloudfoundry.client.v3.domains.GetDomainResponse;
 import org.cloudfoundry.client.v3.domains.ListDomainsRequest;
 import org.cloudfoundry.client.v3.domains.ListDomainsResponse;
+import org.cloudfoundry.client.v3.domains.RouterGroup;
 import org.cloudfoundry.client.v3.domains.ShareDomainRequest;
 import org.cloudfoundry.client.v3.domains.ShareDomainResponse;
 import org.cloudfoundry.client.v3.domains.UnshareDomainRequest;
@@ -279,6 +280,11 @@ final class ReactorDomainsV3Test extends AbstractClientApiTest {
                                                 .updatedAt("2019-03-08T01:06:19Z")
                                                 .name("test-domain.com")
                                                 .isInternal(false)
+                                                .routerGroup(
+                                                        RouterGroup.builder()
+                                                                .id(
+                                                                        "5806148f-cce6-4d86-7fbd-aa269e3f6f3f")
+                                                                .build())
                                                 .relationships(
                                                         DomainRelationships.builder()
                                                                 .organization(

--- a/cloudfoundry-client-reactor/src/test/resources/fixtures/client/v3/domains/GET_response.json
+++ b/cloudfoundry-client-reactor/src/test/resources/fixtures/client/v3/domains/GET_response.json
@@ -20,6 +20,7 @@
       "updated_at": "2019-03-08T01:06:19Z",
       "name": "test-domain.com",
       "internal": false,
+      "router_group": { "guid": "5806148f-cce6-4d86-7fbd-aa269e3f6f3f" },
       "metadata": {
         "labels": {},
         "annotations": {}

--- a/cloudfoundry-client/src/main/java/org/cloudfoundry/client/v3/domains/_RouterGroup.java
+++ b/cloudfoundry-client/src/main/java/org/cloudfoundry/client/v3/domains/_RouterGroup.java
@@ -30,6 +30,6 @@ public abstract class _RouterGroup {
      * The id of the desired router group to route tcp traffic through
      */
     @JsonProperty("guid")
-    public abstract List<String> getId();
+    public abstract String getId();
 
 }


### PR DESCRIPTION
Adding some more details in integration tests. This will grant more confidence migrating `operations.Domains` to the V3 API.