### PR TITLE
Support newer UAA response fields and grant types

### DIFF
--- a/cloudfoundry-client-reactor/src/test/java/org/cloudfoundry/reactor/uaa/clients/ReactorClientsTest.java
+++ b/cloudfoundry-client-reactor/src/test/java/org/cloudfoundry/reactor/uaa/clients/ReactorClientsTest.java
@@ -24,6 +24,7 @@ import static io.netty.handler.codec.http.HttpResponseStatus.CREATED;
 import static io.netty.handler.codec.http.HttpResponseStatus.OK;
 import static org.cloudfoundry.uaa.tokens.GrantType.AUTHORIZATION_CODE;
 import static org.cloudfoundry.uaa.tokens.GrantType.CLIENT_CREDENTIALS;
+import static org.cloudfoundry.uaa.tokens.GrantType.JWT_BEARER;
 import static org.cloudfoundry.uaa.tokens.GrantType.REFRESH_TOKEN;
 
 import java.time.Duration;
@@ -620,6 +621,7 @@ final class ReactorClientsTest extends AbstractUaaApiTest {
                                 .allowedProviders("uaa", "ldap", "my-saml-provider")
                                 .authorities("clients.read", "clients.write")
                                 .authorizedGrantType(CLIENT_CREDENTIALS)
+                                .authorizedGrantType(JWT_BEARER)
                                 .autoApprove("true")
                                 .clientId("4Z3t1r")
                                 .lastModified(1468364445592L)

--- a/cloudfoundry-client-reactor/src/test/java/org/cloudfoundry/reactor/uaa/identityzones/ReactorIdentityZonesTest.java
+++ b/cloudfoundry-client-reactor/src/test/java/org/cloudfoundry/reactor/uaa/identityzones/ReactorIdentityZonesTest.java
@@ -832,6 +832,8 @@ final class ReactorIdentityZonesTest extends AbstractUaaApiTest {
                                                                                             + " /passcode)")
                                                                                 .build())
                                                                 .ldapDiscoveryEnabled(false)
+                                                                .defaultIdentityProvider(
+                                                                        "test-identity-provider")
                                                                 .accountChooserEnabled(false)
                                                                 .build())
                                                 .name("The Twiglet Zone")

--- a/cloudfoundry-client-reactor/src/test/java/org/cloudfoundry/reactor/uaa/serverinformation/ReactorServerInformationTest.java
+++ b/cloudfoundry-client-reactor/src/test/java/org/cloudfoundry/reactor/uaa/serverinformation/ReactorServerInformationTest.java
@@ -151,6 +151,7 @@ final class ReactorServerInformationTest extends AbstractUaaApiTest {
                                 .showLoginLinks(true)
                                 .timestamp("2017-09-08T23:11:58+0000")
                                 .zoneName("uaa")
+                                .defaultIdpName("test-idp-name")
                                 .build())
                 .expectComplete()
                 .verify(Duration.ofSeconds(5));

--- a/cloudfoundry-client-reactor/src/test/resources/fixtures/uaa/clients/GET_{id}_response.json
+++ b/cloudfoundry-client-reactor/src/test/resources/fixtures/uaa/clients/GET_{id}_response.json
@@ -8,7 +8,8 @@
     "none"
   ],
   "authorized_grant_types": [
-    "client_credentials"
+    "client_credentials",
+    "urn:ietf:params:oauth:grant-type:jwt-bearer"
   ],
   "redirect_uri": [
     "http*://ant.path.wildcard/**/passback/*",

--- a/cloudfoundry-client-reactor/src/test/resources/fixtures/uaa/identity-zones/GET_response.json
+++ b/cloudfoundry-client-reactor/src/test/resources/fixtures/uaa/identity-zones/GET_response.json
@@ -97,6 +97,7 @@
           "text": "One Time Code (Get on at /passcode)"
         }
       ],
+      "defaultIdentityProvider": "test-identity-provider",
       "idpDiscoveryEnabled": false,
       "accountChooserEnabled": false
     },

--- a/cloudfoundry-client-reactor/src/test/resources/fixtures/uaa/info/GET_response.json
+++ b/cloudfoundry-client-reactor/src/test/resources/fixtures/uaa/info/GET_response.json
@@ -30,5 +30,6 @@
       "One Time Code ( Get one at http://localhost:8080/uaa/passcode )"
     ]
   },
-  "timestamp": "2017-09-08T23:11:58+0000"
+  "timestamp": "2017-09-08T23:11:58+0000",
+  "defaultIdpName": "test-idp-name"
 }

--- a/cloudfoundry-client/src/main/java/org/cloudfoundry/uaa/identityzones/_IdentityZoneConfiguration.java
+++ b/cloudfoundry-client/src/main/java/org/cloudfoundry/uaa/identityzones/_IdentityZoneConfiguration.java
@@ -66,6 +66,13 @@ abstract class _IdentityZoneConfiguration {
     abstract CorsPolicy getCorsPolicy();
 
     /**
+     * The default identity provider for this zone
+     */
+    @JsonProperty("defaultIdentityProvider")
+    @Nullable
+    abstract String getDefaultIdentityProvider();
+
+    /**
      * The issuer of this zone
      */
     @JsonProperty("issuer")

--- a/cloudfoundry-client/src/main/java/org/cloudfoundry/uaa/serverinformation/_GetInfoResponse.java
+++ b/cloudfoundry-client/src/main/java/org/cloudfoundry/uaa/serverinformation/_GetInfoResponse.java
@@ -93,4 +93,12 @@ abstract class _GetInfoResponse {
     @Nullable
     abstract String getZoneName();
 
+    /**
+     * The default identity provider name
+     */
+    @JsonProperty("defaultIdpName")
+    @Nullable
+    abstract String getDefaultIdpName();
+
+
 }

--- a/cloudfoundry-client/src/main/java/org/cloudfoundry/uaa/tokens/GrantType.java
+++ b/cloudfoundry-client/src/main/java/org/cloudfoundry/uaa/tokens/GrantType.java
@@ -40,6 +40,11 @@ public enum GrantType {
     IMPLICIT("implicit"),
 
     /**
+     * The JWT bearer grant type
+     */
+    JWT_BEARER("urn:ietf:params:oauth:grant-type:jwt-bearer"),
+
+    /**
      * The password grant type
      */
     PASSWORD("password"),
@@ -68,6 +73,8 @@ public enum GrantType {
                 return PASSWORD;
             case "refresh_token":
                 return REFRESH_TOKEN;
+            case "urn:ietf:params:oauth:grant-type:jwt-bearer":
+                return JWT_BEARER;
             default:
                 throw new IllegalArgumentException(String.format("Unknown grant type: %s", s));
         }

--- a/integration-test/src/test/java/org/cloudfoundry/uaa/ServerInformationTest.java
+++ b/integration-test/src/test/java/org/cloudfoundry/uaa/ServerInformationTest.java
@@ -95,11 +95,15 @@ public final class ServerInformationTest extends AbstractIntegrationTest {
         this.uaaClient
                 .serverInformation()
                 .getInfo(GetInfoRequest.builder().build())
-                .map(response -> response.getLinks().getPassword())
+                .map(response -> response.getLinks().getLogin())
                 .as(StepVerifier::create)
-                .consumeNextWith(endsWithExpectation("password"))
+                .consumeNextWith(containsExpectation("login"))
                 .expectComplete()
                 .verify(Duration.ofMinutes(5));
+    }
+
+    private static Consumer<String> containsExpectation(String substring) {
+        return actual -> assertThat(actual).contains(substring);
     }
 
     private static Consumer<String> endsWithExpectation(String suffix) {

--- a/integration-test/src/test/java/org/cloudfoundry/uaa/TokensTest.java
+++ b/integration-test/src/test/java/org/cloudfoundry/uaa/TokensTest.java
@@ -84,7 +84,7 @@ public final class TokensTest extends AbstractIntegrationTest {
                         t ->
                                 assertThat(t)
                                         .isInstanceOf(UaaException.class)
-                                        .hasMessage("access_denied: Access is denied"))
+                                        .hasMessageContainingAll("access_denied", "Access"))
                 .verify(Duration.ofMinutes(5));
     }
 


### PR DESCRIPTION
Different (likely newer?) versions of the open-source UAA (tested against v78.6.0) return fields and values that the client doesn't model, causing deserialization failures.

This PR adds support for:
  - `urn:ietf:params:oauth:grant-type:jwt-bearer` grant type (RFC 7523)
  - `defaultIdentityProvider` in identity zone configuration (added to [OSS UAA in 2018](https://github.com/cloudfoundry/uaa/commit/dac4722a51))
  - `defaultIdpName` in the /info endpoint response ([source](https://github.com/cloudfoundry/uaa/blob/284dd502db2316bfbdb05c47d9a6d23e3c82ba6a/server/src/main/java/org/cloudfoundry/identity/uaa/login/LoginInfoEndpoint.java#L277))
 
Integration test changes:

  - Relaxed assertion for UAA "access denied" error message wording
  - Check for login endpoint instead of password reset endpoint which might be disabled for some UAA

AI tools used: Claude Code and GitHub Copilot (Opus 4.6) assisted me during development. I reviewed the result.