### PR TITLE
Fix test-service-broker crash on JDK 17 by adding --add-opens flags

### DIFF
--- a/integration-test/src/test/java/org/cloudfoundry/ServiceBrokerUtils.java
+++ b/integration-test/src/test/java/org/cloudfoundry/ServiceBrokerUtils.java
@@ -145,6 +145,10 @@ public final class ServiceBrokerUtils {
         Map<String, Object> env = new HashMap<>();
         env.put("SERVICE_NAME", serviceName);
         env.put("PLAN_NAME", planName);
+        env.put(
+                "JAVA_OPTS",
+                "--add-opens java.base/java.lang=ALL-UNNAMED"
+                        + " --add-opens java.base/java.io=ALL-UNNAMED");
 
         return ApplicationUtils.pushApplication(
                 cloudFoundryClient,


### PR DESCRIPTION
Workaround for #1344 .

The test-service-broker.jar (Spring Boot 1.5.16 / Spring Framework 4.3.19) uses CGLIB proxying which requires reflective access to java.lang.ClassLoader.defineClass(). JDK 17's module system blocks this, causing the app to crash on startup with
InaccessibleObjectException and all ApplicationsTest methods to fail with DelayTimeoutException during serviceBrokerId bean creation.

Creating this as a draft as this is a workaround only to some parts of the integration tests work again.

AI tools used: Claude Code and GitHub Copilot (Opus 4.6) assisted me during development. I reviewed the result.