### PR TITLE
fix: Restore null-recent default to Doppler streaming

### DIFF
--- a/cloudfoundry-operations/src/main/java/org/cloudfoundry/operations/applications/DefaultApplications.java
+++ b/cloudfoundry-operations/src/main/java/org/cloudfoundry/operations/applications/DefaultApplications.java
@@ -559,7 +559,7 @@ public final class DefaultApplications implements Applications {
 
     @Override
     public Flux<ApplicationLog> logs(ApplicationLogsRequest request) {
-        if (request.getRecent() == null || request.getRecent()) {
+        if (request.getRecent() != null && request.getRecent()) {
             return Mono.zip(this.cloudFoundryClient, this.spaceId)
                     .flatMap(
                             function(

--- a/cloudfoundry-operations/src/test/java/org/cloudfoundry/operations/applications/DefaultApplicationsTest.java
+++ b/cloudfoundry-operations/src/test/java/org/cloudfoundry/operations/applications/DefaultApplicationsTest.java
@@ -1378,7 +1378,7 @@ final class DefaultApplicationsTest extends AbstractOperationsTest {
         requestLogsRecentLogCache(this.logCacheClient, "test-metadata-id");
 
         this.applications
-                .logs(ApplicationLogsRequest.builder().name("test-application-name").build())
+                .logs(ApplicationLogsRequest.builder().name("test-application-name").recent(true).build())
                 .as(StepVerifier::create)
                 .expectNextMatches(
                         log ->


### PR DESCRIPTION
PR #1348 changed the null-recent behavior from Doppler streaming to Log Cache. This restores the original default so null behaves like false (streaming), matching the prior logs(LogsRequest) contract.

---
AI Disclaimer: This change was authored with assistance from Claude (claude-opus-4-6) via Claude Code v2.1.92. I carefully reviewed it.