### PR TITLE
Add env-var to ignore unknown properties. Fix #1341

### DIFF
--- a/README.md
+++ b/README.md
@@ -353,6 +353,7 @@ Name | Description
 `TEST_PROXY_PORT` | _(Optional)_ The port of a proxy to route all requests through. Defaults to `8080`.
 `TEST_PROXY_USERNAME` | _(Optional)_ The username for a proxy to route all requests through
 `TEST_SKIPSSLVALIDATION` | _(Optional)_ Whether to skip SSL validation when connecting to the Cloud Foundry instance.  Defaults to `false`.
+`TEST_FAIL_ON_UNKNOWN_PROPERTIES` | _(Optional)_ If "true", unknown values received from CF result in a parsing error. This usually happens when client and server versions do not match. When "false", unknown properties will be ignored allowing the execution of integration-tests. Use with care!  Defaults to `true`.
 `SKIP_BROWSER_AUTH_TESTS` | _(Optional)_ Set to `true` to skip integration tests that require browser-based authentication (e.g., SSO tests). Useful when the Cloud Foundry instance's UAA does not have browser-based authentication configured. Defaults to `false`.
 `SKIP_METRIC_REGISTRAR_TESTS` | _(Optional)_ Set to `true` to skip integration tests that require the Metric Registrar service (e.g., MetricRegistrarTest). Useful when the Cloud Foundry instance does not have the Metric Registrar service available. Defaults to `false`.
 `SKIP_TCP_ROUTING_TESTS` | _(Optional)_ Set to `true` to skip TCP routing integration tests (TcpRoutesTest, RouterGroupsTest). Useful when the Cloud Foundry instance does not have TCP routing configured (i.e., no `routing_endpoint` in the info payload). Defaults to `false`.

--- a/cloudfoundry-client-reactor/src/test/java/org/cloudfoundry/reactor/client/v3/serviceInstances/ReactorServiceInstancesV3Test.java
+++ b/cloudfoundry-client-reactor/src/test/java/org/cloudfoundry/reactor/client/v3/serviceInstances/ReactorServiceInstancesV3Test.java
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package org.cloudfoundry.reactor.client.v3.serviceinstances;
+package org.cloudfoundry.reactor.client.v3.serviceInstances;
 
 import static io.netty.handler.codec.http.HttpMethod.DELETE;
 import static io.netty.handler.codec.http.HttpMethod.GET;
@@ -62,6 +62,7 @@ import org.cloudfoundry.reactor.InteractionContext;
 import org.cloudfoundry.reactor.TestRequest;
 import org.cloudfoundry.reactor.TestResponse;
 import org.cloudfoundry.reactor.client.AbstractClientApiTest;
+import org.cloudfoundry.reactor.client.v3.serviceinstances.ReactorServiceInstancesV3;
 import org.junit.jupiter.api.Test;
 import reactor.test.StepVerifier;
 

--- a/integration-test/src/test/java/org/cloudfoundry/IntegrationTestConfiguration.java
+++ b/integration-test/src/test/java/org/cloudfoundry/IntegrationTestConfiguration.java
@@ -307,17 +307,18 @@ public class IntegrationTestConfiguration {
             @Value("${test.proxy.password:}") String proxyPassword,
             @Value("${test.proxy.port:8080}") Integer proxyPort,
             @Value("${test.proxy.username:}") String proxyUsername,
+            @Value("${test.fail.on.unknown.properties:true}") Boolean failOnUnknownProperties,
             @Value("${test.skipSslValidation:false}") Boolean skipSslValidation) {
 
         DefaultConnectionContext.Builder connectionContext =
                 DefaultConnectionContext.builder()
                         .apiHost(apiHost)
-                        .problemHandler(
-                                new FailingDeserializationProblemHandler()) // Test-only problem
-                        // handler
                         .skipSslValidation(skipSslValidation)
                         .sslHandshakeTimeout(Duration.ofSeconds(30));
-
+        if(failOnUnknownProperties) {
+            connectionContext.problemHandler(
+                    new FailingDeserializationProblemHandler()); // Test-only problem handler
+        }
         if (StringUtils.hasText(proxyHost)) {
             ProxyConfiguration.Builder proxyConfiguration =
                     ProxyConfiguration.builder().host(proxyHost).port(proxyPort);


### PR DESCRIPTION
Setting "TEST_FAIL_ON_UNKNOWN_PROPERTIES" to "false" will ignore unknown properties returned from the CF instance because of version mismatch. Default is "true", so we notice incompatibilities early. Developers can switch to "false" to continue working.
